### PR TITLE
Add hearing personalisation pipeline (TASK-116)

### DIFF
--- a/docs/designs/hearing-personalization.md
+++ b/docs/designs/hearing-personalization.md
@@ -1,0 +1,345 @@
+# Hearing Personalisation — Architecture and Scientific Basis
+
+## 1. Overview
+
+HeadMatch can personalise the EQ preset to a listener's individual hearing thresholds.
+Two usage paths are supported:
+
+| Path | Equipment required | Accuracy |
+|------|--------------------|----------|
+| **Hearing-only** (`headmatch hearing-fit`) | Headphones under test + quiet room | Moderate — assumes flat headphone FR |
+| **Measurement + compensation** (`headmatch fit --with-hearing-compensation`) | Headphones + measurement microphone | High — real headphone FR plus personalisation |
+
+The hearing test itself is identical in both paths.
+
+---
+
+## 2. Measurement Procedure
+
+### 2.1 Modified Hughson-Westlake Pure-Tone Audiometry
+
+The threshold engine in `headmatch/hearing_test.py` implements the
+**Modified Hughson-Westlake procedure** (Carhart & Jerger, 1959 — public domain).
+
+**Algorithm ("up-5 down-10"):**
+1. Start at a comfortable listening level (−20 dBFS peak).
+2. After a *heard* response: decrease level by 10 dB.
+3. After a *missed* response: increase level by 5 dB (ascending run begins).
+4. An ascending run closes when the listener responds while the level is ascending.
+5. **Threshold declaration**: lowest level heard on ≥ 2 of the most recent 3 ascending runs.
+6. **Minimum 3 ascending runs** required before a threshold can be declared.
+7. **Maximum 8 ascending runs** (constant `MAX_ASCENDING_RUNS`): if exceeded, the most-frequently-heard level is used as a best estimate.
+
+This procedure is a standard clinical method published in the public domain;
+no proprietary algorithm is used.
+
+**Reference:**
+> Carhart, R., & Jerger, J. (1959). Preferred method for clinical determination of
+> pure-tone thresholds. *Journal of Speech and Hearing Disorders*, 24(4), 330–345.
+
+### 2.2 Frequency Set and Test Order
+
+Frequencies follow **ISO 8253-1** (Pure tone audiometry — basic pure-tone
+air and bone conduction threshold audiometry; public international standard):
+
+- **Test frequencies**: 500, 1000, 2000, 3000, 4000, 6000, 8000 Hz
+- **Test order**: 1000 → 2000 → 3000 → 4000 → 6000 → 8000 → 1000 → 500 Hz
+
+The 1 kHz frequency is visited twice to provide an inter-run reliability check.
+Both measurements are reconciled by using only the first visit in the threshold
+table (the duplicate entry is skipped by the `processed_freqs` set in the runner).
+
+### 2.3 Relative dBFS Levels (No RETSPL Calibration)
+
+Clinical audiometry uses **dB HL** (Hearing Level), a calibrated absolute scale
+referenced to the Reference Equivalent Threshold Sound Pressure Level (RETSPL),
+which is transducer-specific. HeadMatch operates entirely in relative **dBFS**
+(digital full-scale), which avoids device-specific calibration but requires that
+the listener first sets a **consistent comfortable listening volume** before the test.
+
+This volume setting anchors the whole test: a tone at −20 dBFS will be
+approximately 30 dB above a normal-hearing listener's threshold at 1 kHz,
+so the starting level (−20 dBFS) is perceptually familiar as "comfortable music."
+
+The `NORMAL_HEARING_REFERENCE` dictionary records the expected threshold level
+for a young adult (18–25 yrs) with normal hearing at a comfortable listening
+volume. Values are derived from **ISO 7029:2017** median data (age-related
+hearing threshold statistics for otologically normal persons) mapped to the
+project's relative dBFS scale.
+
+```python
+NORMAL_HEARING_REFERENCE = {
+    500:  -48.0,   # dBFS — expected threshold at 500 Hz
+    1000: -50.0,
+    2000: -50.0,
+    3000: -49.0,
+    4000: -47.0,
+    6000: -44.0,
+    8000: -42.0,
+}
+```
+
+**Reference:**
+> ISO 7029:2017. *Acoustics — Statistical distribution of hearing thresholds
+> related to age and gender.* International Organization for Standardization.
+
+---
+
+## 3. Compensation Curve
+
+### 3.1 Half-Gain Rule
+
+The per-frequency EQ compensation gain is computed using the **half-gain rule**
+(Lybarger, 1944 — public domain, predating all modern patents):
+
+```
+loss(f)  = measured_threshold(f)  −  NORMAL_HEARING_REFERENCE(f)
+              [positive when threshold is worse than reference]
+
+gain(f)  = clamp( loss(f) × 0.50,  0 dB,  12 dB )
+```
+
+The half-gain fraction (0.50) is the most widely cited rule-of-thumb for
+initial hearing aid gain prescription. It produces a modest boost that
+compensates for reduced sensitivity without over-amplifying in quiet
+environments. The 12 dB maximum cap (`MAX_COMPENSATION_DB`) prevents
+extreme boosts from unstable or outlying threshold estimates.
+
+**References:**
+> Lybarger, S. F. (1944). *Method of fitting hearing aids*. US Patent 2,360,181
+> (now expired; the half-gain rule itself is in the public domain).
+>
+> Killion, M. C., & Fikret-Pasa, S. (1993). The 3 types of sensorineural hearing
+> loss: loudness and intelligibility considerations. *The Hearing Journal*, 46(11),
+> 31–36.
+
+### 3.2 Bilateral Averaging
+
+Left and right threshold measurements are averaged at each frequency before
+computing the compensation gain:
+
+```python
+avg_threshold(f) = mean(left_threshold(f), right_threshold(f))
+```
+
+If one ear is undetermined, only the other ear's threshold is used.
+This produces a single symmetric compensation curve applied equally to
+both EQ channels. Listeners with very large L/R asymmetry (> 15 dB at
+any frequency) receive a warning; their compensation may not be optimal
+and an audiologist consultation is recommended.
+
+### 3.3 Interpolation and Smoothing
+
+Only 7 test frequencies are available. To produce a continuous compensation
+curve on the analysis frequency grid:
+
+1. **Cubic spline interpolation** on the log-frequency axis (`scipy.interpolate.CubicSpline`,
+   not-a-knot boundary condition). Log-frequency spacing respects the logarithmic
+   nature of auditory perception.
+2. **1-octave Gaussian smoothing** via the existing `fractional_octave_smoothing()`
+   function. This eliminates sharp EQ peaks that could arise from noisy threshold
+   estimates at individual frequencies.
+3. Gain values are clamped to [0, MAX_COMPENSATION_DB] after smoothing.
+
+---
+
+## 4. Pipeline Architecture
+
+### 4.1 Measurement + Compensation (Full Path)
+
+```
+┌─────────────────────┐     ┌──────────────────┐
+│  Headphone sweep    │     │  Hearing test     │
+│  (microphone req.)  │     │  (ears only)      │
+└─────────┬───────────┘     └────────┬──────────┘
+          │ MeasurementResult        │ HearingProfile
+          │ freqs_hz, L/R dB         │ thresholds per freq
+          └───────────┬──────────────┘
+                      │
+              fit_from_measurement()
+                      │
+              resolved_target  =  base_target(f) + compensation(f)
+              eq_target(f)     =  resolved_target(f) − measured_FR(f)
+                      │
+                  fit_peq()
+                      │
+              PEQ bands  →  EQ preset files
+```
+
+Key call site in `pipeline.py:fit_from_measurement()`:
+```python
+compensation = compute_compensation_curve(hearing_profile, result.freqs_hz)
+left_eq_target = (resolved_target.left_values_db + compensation) - result.left_db
+```
+
+The compensation is folded into the target *before* the PEQ fitter runs.
+This means the existing pipeline, analysis, confidence scoring, and artifact
+writing are completely unchanged.
+
+### 4.2 Hearing-Only Path (No Measurement Equipment)
+
+```
+┌─────────────┐
+│  Hearing    │
+│  test       │
+└──────┬──────┘
+       │ HearingProfile
+       │
+fit_from_hearing_profile()
+       │
+  freqs    = geometric_log_grid(20 Hz, 20 kHz, 512 points)
+  flat     = 0 dB  (assumed headphone FR)
+  target   = flat or user-supplied target CSV
+  eq_target = target(f) + compensation(f)
+       │
+   fit_peq()
+       │
+run_hearing_fit()
+       │
+  equalizer_apo.txt
+  camilladsp_full.yaml
+  camilladsp_filters_only.yaml
+  equalizer_apo_graphiceq.txt
+  hearing_fit_report.json
+  README.txt
+```
+
+Key function: `pipeline.py:fit_from_hearing_profile()` and `run_hearing_fit()`.
+
+The flat headphone assumption means the EQ bands encode *only* the
+compensation curve (plus any target deviation). This is suitable as a
+starting point; it can be iteratively refined by re-running with a
+real headphone measurement using `--with-hearing-compensation`.
+
+---
+
+## 5. Tone Playback
+
+Test tones are pure sine waves with 30 ms raised-cosine onset and offset
+ramps to eliminate clicks. Generated by `generate_tone()` in `hearing_test.py`:
+
+```python
+mono = np.sin(2.0 * np.pi * freq_hz * t)
+ramp = 0.5 * (1.0 - np.cos(np.pi * np.arange(n_ramp) / n_ramp))
+mono[:n_ramp] *= ramp
+mono[-n_ramp:] *= ramp[::-1]
+mono *= 10.0 ** (level_dbfs / 20.0)
+```
+
+Tones are played via `backend.play_tone(samples, sample_rate, device)` —
+a thin method on both the PipeWire and PortAudio backends that plays
+audio without any recording, leaving the existing `play_and_record` path
+completely unaffected.
+
+**Tone stimulus parameters (from CTA-2118 2023 guidance on minimum audible threshold testing):**
+- Duration: 1.0 s
+- Ramp: 30 ms raised cosine (onset + offset)
+- Response window: 3.0 s from tone start
+- Inter-tone interval: 0.8 s silence between responses
+
+---
+
+## 6. Data Model
+
+```python
+@dataclass
+class FrequencyThreshold:
+    freq_hz: int
+    level_dbfs: float | None   # None when undetermined
+    ascending_runs: int
+    determined: bool
+
+@dataclass
+class HearingProfile:
+    left: dict[int, FrequencyThreshold]
+    right: dict[int, FrequencyThreshold]
+    tested_at: str              # ISO 8601 timestamp
+    asymmetric_freqs: list[int] # freqs where |L − R| > 15 dB
+```
+
+Profiles are serialised as JSON to `$XDG_CONFIG_HOME/headmatch/hearing_profile.json`
+via `save_hearing_profile()` / `load_hearing_profile()`.
+
+---
+
+## 7. CLI Reference
+
+```bash
+# Run the hearing test interactively
+headmatch hearing-test [--output-target DEVICE] [--sample-rate 48000] [--json]
+
+# Run the hearing test and immediately generate an EQ preset (no microphone needed)
+headmatch hearing-test --fit --out-dir ./hearing_eq
+
+# Generate an EQ preset from a previously saved hearing profile
+headmatch hearing-fit --out-dir ./hearing_eq [--target-csv harman.csv] [--max-filters 8]
+
+# Apply hearing compensation during a headphone measurement fit
+headmatch fit --recording recording.wav --out-dir ./fit --with-hearing-compensation
+```
+
+---
+
+## 8. GUI Integration
+
+**Hearing Test** appears in the advanced navigation sidebar.
+
+After the test completes, the shell offers two choices:
+1. **Generate EQ Preset Now** — calls `run_hearing_fit()` as a background task,
+   assumes flat headphone FR, writes preset to `…/hearing_fit/`.
+2. **Run a Measurement** — navigates to the Measure workflow. The saved
+   `self.hearing_profile` is automatically passed to the online pipeline so
+   compensation is applied during the next measurement fit.
+
+---
+
+## 9. Acceptance Criteria
+
+| Test | Covered by |
+|------|-----------|
+| Threshold engine converges on simulated listener | `test_hearing_test.py::TestThresholdEngine` |
+| Half-gain rule produces correct gain | `test_hearing_test.py::TestComputeCompensationCurve` |
+| Gain capped at MAX_COMPENSATION_DB | `test_hearing_test.py::test_gain_capped_at_max` |
+| No negative compensation | `test_hearing_test.py::test_no_negative_gain` |
+| Profile round-trip serialisation | `test_hearing_test.py::TestHearingProfileSerialisation` |
+| Compensation applied in pipeline | `test_hearing_compensation.py::TestHearingCompensationInPipeline` |
+| Equipment-free fit writes all artifacts | `test_hearing_fit.py::TestRunHearingFit` |
+| Normal hearing → near-flat EQ | `test_hearing_fit.py::test_normal_hearing_gives_small_boost` |
+| 20 dB loss → positive boost | `test_hearing_fit.py::test_20dB_loss_produces_boost` |
+
+---
+
+## 10. Limitations and Future Extensions
+
+| Limitation | Future work |
+|------------|-------------|
+| Flat headphone assumption in hearing-only path | Couple with a published HRTF/average-headphone FR |
+| No RETSPL calibration | Per-transducer calibration table (device-specific dB HL offset) |
+| Symmetric compensation applied to both channels | Per-ear PEQ bands when the pipeline supports per-channel fitting |
+| Single comfort-volume anchor | Automated comfort calibration tone at session start |
+| Half-gain rule is a rough heuristic | NAL-NL2 prescription (Dillon, 2012) when clinical data available |
+
+---
+
+## 11. References
+
+1. Carhart, R., & Jerger, J. (1959). Preferred method for clinical determination of
+   pure-tone thresholds. *Journal of Speech and Hearing Disorders*, 24(4), 330–345.
+
+2. ISO 8253-1:2010. *Acoustics — Audiometric test methods — Part 1: Pure-tone air
+   and bone conduction audiometry.* International Organization for Standardization.
+
+3. Lybarger, S. F. (1944). *Method of fitting hearing aids.* US Patent 2,360,181
+   (expired; half-gain rule in the public domain).
+
+4. ISO 7029:2017. *Acoustics — Statistical distribution of hearing thresholds
+   related to age and gender.* International Organization for Standardization.
+
+5. Consumer Technology Association (2023). *CTA-2118: Method of Measurement for
+   Minimum Audible Threshold of Personal Listening Devices.* CTA Standard.
+
+6. Killion, M. C., & Fikret-Pasa, S. (1993). The 3 types of sensorineural hearing
+   loss: loudness and intelligibility considerations. *The Hearing Journal*, 46(11), 31–36.
+
+7. Dillon, H. (2012). *Hearing Aids* (2nd ed.). Boomerang Press / Thieme.
+   [NAL-NL2 prescription background — not implemented; cited for future-work reference only.]

--- a/docs/tasks/TASK-116.md
+++ b/docs/tasks/TASK-116.md
@@ -1,0 +1,433 @@
+# TASK-116 — Hearing measurement & personalised EQ compensation
+
+## Summary
+
+Add a self-administered pure-tone hearing measurement workflow that
+sweeps a set of test frequencies, estimates the user's hearing thresholds
+via the Modified Hughson-Westlake procedure (Carhart & Jerger 1959,
+public domain), and converts the result to an EQ compensation curve
+using the half-gain rule (Lybarger 1944, public domain).  The
+compensation curve is folded into the target before the existing PEQ
+fitter runs — so the final preset corrects both the headphone's acoustic
+response and the user's hearing profile simultaneously.
+
+---
+
+## Background & methodology
+
+All procedures reference published, public-domain audiological science.
+No proprietary algorithm or patented DSP method is used.
+
+### Frequency set
+
+Seven test bands in decade-logarithmic spacing, covering the
+perceptually important 500 Hz – 8 kHz range where age- and noise-related
+threshold shifts are most pronounced (ISO 8253-1 §5.2):
+
+```
+500 Hz, 1 000 Hz, 2 000 Hz, 3 000 Hz, 4 000 Hz, 6 000 Hz, 8 000 Hz
+```
+
+Testing order follows ISO 8253-1: start at 1 000 Hz (most reliable
+reference), ascend to 2 000 → 3 000 → 4 000 → 6 000 → 8 000 Hz,
+re-verify 1 000 Hz (must agree ± 5 dB), then descend to 500 Hz.  This
+order minimises adaptation effects.
+
+### Threshold detection — Modified Hughson-Westlake ("up-5 down-10")
+
+Classic procedure from Carhart & Jerger (1959), still the ISO 8253-1
+reference method.  For each frequency:
+
+1. Present a familiarisation tone at `start_level_dB` (see below) — a
+   level comfortably above threshold.
+2. After each *heard* response: decrease level 10 dB.
+3. After each *not-heard* silence: increase level 5 dB.
+4. An **ascending run** is completed when the user responds after one or
+   more silent (not-heard) presentations.
+5. **Threshold** = lowest level that produced a response on ≥ 2 of the
+   last 3 ascending runs.
+6. Minimum 3 ascending runs required before declaring threshold.
+7. Maximum 8 ascending runs; if no stable threshold after 8 runs, the
+   frequency is marked as `UNDETERMINED` and skipped in compensation.
+
+### Starting level
+
+Because HeadMatch has no RETSPL calibration table (device-specific
+dB HL conversion offsets), the test operates in **relative dB units**:
+level 0 = nominal digital silence, level 100 = full-scale headphone
+output.  An empirically reasonable starting point is level **60** (≈
+comfortable listening for normal hearing at most headphone models at
+typical playback volumes).  The user is told to set their system volume
+to a comfortable music-listening level before starting; the test is
+calibrated against that anchor.
+
+### Ambient noise gate
+
+Record 1.5 s of silence via the active `AudioBackend` before the first
+tone.  Compute RMS of the captured buffer.  If the ambient noise floor
+exceeds `NOISE_GATE_THRESHOLD` (default: –30 dBFS), display a warning
+and allow the user to retry.  Do not abort silently.
+
+### Tone stimulus
+
+- Pure sine wave, duration **1 000 ms**
+- 30 ms raised-cosine (Hann) onset and offset ramps (eliminates
+  spectral splatter and audible clicks)
+- 800 ms inter-stimulus interval of silence between tones
+- No pulsed pattern (single continuous burst keeps UI response mapping
+  simple)
+
+### Compensation curve — half-gain rule (Lybarger 1944)
+
+For each tested frequency `f`:
+
+```
+ref_level(f)    = median level across all users who responded at f
+                  (seeded from a built-in normal-hearing baseline table;
+                   see hearing_test.py NORMAL_HEARING_REFERENCE)
+loss(f)         = measured_threshold(f) - ref_level(f)
+gain(f)         = max(0, loss(f)) * GAIN_FRACTION
+                  where GAIN_FRACTION = 0.50  (half-gain rule)
+gain(f)         = clamp(gain(f), 0.0, MAX_COMPENSATION_DB)
+                  where MAX_COMPENSATION_DB = 12.0
+```
+
+The resulting 7-point `(log_freq, gain_dB)` curve is interpolated to
+the existing HeadMatch frequency grid using **cubic spline interpolation
+on a log-frequency axis** (scipy.interpolate.CubicSpline), then
+smoothed with a 1-octave Gaussian kernel to prevent sharp filter
+transitions.
+
+The compensation curve is then **added to the active target curve**
+before the PEQ fitter runs:
+
+```
+effective_target(f) = base_target(f) + hearing_compensation(f)
+```
+
+This reuses the entire existing pipeline unchanged.  The fitter sees a
+target that already encodes both the desired headphone response and the
+hearing profile correction.
+
+### Per-ear measurement
+
+Both ears are tested independently.  L/R compensation curves are
+averaged before being applied to the mono target (headphone measurements
+in HeadMatch are per-channel but the target curve is mono).  If the
+L/R asymmetry at any frequency exceeds 15 dB, a warning is shown
+("consider consulting an audiologist") but processing continues.
+
+---
+
+## New modules
+
+### `headmatch/hearing_test.py`
+
+Core test engine.  No GUI or I/O dependencies.
+
+```
+NORMAL_HEARING_REFERENCE: dict[int, float]
+    Built-in baseline table (freq_hz → relative_level).
+    Derived from ISO 7029:2017 median thresholds for 18-year-olds,
+    mapped to HeadMatch's relative dB scale.
+
+TEST_FREQUENCIES: tuple[int, ...]   = (500, 1000, 2000, 3000, 4000, 6000, 8000)
+TEST_ORDER: tuple[int, ...]         = (1000, 2000, 3000, 4000, 6000, 8000, 1000, 500)
+MAX_ASCENDING_RUNS: int             = 8
+THRESHOLD_RESPONSES_NEEDED: int     = 2
+THRESHOLD_WINDOW: int               = 3
+GAIN_FRACTION: float                = 0.50
+MAX_COMPENSATION_DB: float          = 12.0
+NOISE_GATE_THRESHOLD_DBFS: float    = -30.0
+
+@dataclass
+class FrequencyThreshold:
+    freq_hz: int
+    level: float          # relative dB; None if UNDETERMINED
+    ascending_runs: int
+    determined: bool
+
+@dataclass
+class HearingProfile:
+    left: dict[int, FrequencyThreshold]
+    right: dict[int, FrequencyThreshold]
+    tested_at: str        # ISO 8601 timestamp
+    asymmetric_freqs: list[int]   # freqs where L/R gap > 15 dB
+
+class ThresholdEngine:
+    """State machine for a single-ear, single-frequency threshold search."""
+    def __init__(self, start_level: float, freq_hz: int) -> None: ...
+    def next_level(self) -> float: ...
+    def record_response(self, heard: bool) -> None: ...
+    @property
+    def threshold(self) -> float | None: ...
+    @property
+    def done(self) -> bool: ...
+
+def generate_tone(freq_hz: int, level_db: float,
+                  sample_rate: int = 48000) -> np.ndarray:
+    """Pure sine with 30 ms Hann ramps at normalised level."""
+
+def measure_noise_floor(backend: AudioBackend,
+                        device_config: DeviceConfig,
+                        duration_s: float = 1.5) -> float:
+    """Returns RMS in dBFS from a short silence recording."""
+
+def compute_compensation_curve(
+    profile: HearingProfile,
+    freq_grid: np.ndarray,          # HeadMatch log frequency grid
+) -> np.ndarray:
+    """
+    Returns gain_db per freq_grid point.
+    Averages L/R thresholds, applies half-gain rule, cubic-spline
+    interpolates, then 1-octave Gaussian smooth.
+    """
+
+def save_hearing_profile(profile: HearingProfile, paths: AppPaths) -> Path:
+    """Writes ~/.config/headmatch/hearing_profile.json."""
+
+def load_hearing_profile(paths: AppPaths) -> HearingProfile | None:
+    """Returns None if no saved profile exists."""
+```
+
+### `headmatch/pipeline.py` (modification)
+
+Add optional parameter to `run_pipeline()`:
+
+```python
+hearing_profile: HearingProfile | None = None
+```
+
+When present, `compute_compensation_curve()` is called and the result
+added to the target array before PEQ fitting.  No other pipeline logic
+changes.
+
+### `headmatch/contracts.py` (modification)
+
+Add `WorkflowName` literal: `"hearing_test"`.
+
+Add dataclass:
+
+```python
+@dataclass
+class HearingTestResult:
+    profile: HearingProfile
+    compensation_curve_path: Path   # saved SVG preview
+    applied_to_run: str | None      # run_id if immediately applied
+```
+
+### `headmatch/gui/views/hearing_test.py`
+
+New GUI view module.  Follows the existing view pattern (returns a
+rendered Tkinter frame; all state flows through callbacks to the
+controller).
+
+States (rendered as distinct sub-frames within the view):
+
+```
+INTRO        → NOISE_CHECK  → TESTING_EAR_L  → TESTING_EAR_R
+           → RESULTS → APPLY_CONFIRM
+```
+
+Key UI elements per state:
+
+**INTRO**
+- Brief plain-language explanation of the test
+- "Make sure you're in a quiet room and set volume to a comfortable
+  music level"
+- `[Start Test]` button
+
+**NOISE_CHECK**
+- Progress spinner while ambient noise is sampled
+- Pass: transitions automatically to TESTING_EAR_L
+- Fail: red warning + `[Retry]` + `[Skip check and continue]`
+
+**TESTING_EAR_L / TESTING_EAR_R**
+- Header: "Testing left ear — cover your right ear" (or vice versa)
+- Frequency progress: `"Frequency 3 / 7 — 2 000 Hz"`
+- Large `[I hear it]` button (primary action)
+- Tone is played automatically on entry to each level step; a small
+  animated speaker icon shows when the tone is active
+- No "I don't hear it" button — silence = no response (simpler UX,
+  avoids false negatives from slow button press)
+- Response window: 3 000 ms from tone onset; if no tap within window,
+  records "not heard" and plays next step
+- `[Stop test]` link in corner (discards result)
+
+**RESULTS**
+- Simple bar chart (canvas-drawn, matches existing SVG style) showing
+  estimated threshold by frequency for each ear
+- Asymmetry warnings shown inline if L/R differ > 15 dB
+- `[Apply to next EQ run]` button (saves profile + sets
+  `pending_hearing_compensation = True` in GUI state)
+- `[Save without applying]` button
+- `[Discard]` link
+
+**APPLY_CONFIRM**
+- One-line summary: "Your hearing compensation (+X dB average) will be
+  added to the target curve in the next measurement run."
+- `[OK]` → returns to main shell
+
+### `headmatch/gui/controllers.py` (modification)
+
+Add `HearingTestController`:
+
+```python
+class HearingTestController:
+    def __init__(self, backend: AudioBackend, paths: AppPaths,
+                 on_complete: Callable[[HearingTestResult], None]) -> None: ...
+
+    def start(self, device_config: DeviceConfig) -> None:
+        # 1. noise floor check
+        # 2. iterate through TEST_ORDER for left ear
+        #    - play tone via backend (direct output, no recording)
+        #    - wait for GUI response or timeout
+        #    - feed to ThresholdEngine
+        # 3. repeat for right ear
+        # 4. compute profile, save, call on_complete
+
+    def _play_tone(self, freq_hz: int, level_db: float) -> None:
+        # Generates tone buffer via generate_tone()
+        # Plays via backend.play() (new thin play-only method; see below)
+```
+
+### `headmatch/audio_backend.py` (modification)
+
+Add `play_tone()` to the `AudioBackend` protocol:
+
+```python
+def play_tone(self, samples: np.ndarray, sample_rate: int,
+              device: str | None = None) -> None:
+    """Play a short buffer to the output device without recording."""
+```
+
+Implement in both `PipeWireBackend` (write samples to a temp WAV, call
+`pw-play`) and `PortAudioBackend` (call `sd.play(samples, sample_rate,
+blocking=True)`).
+
+---
+
+## CLI surface
+
+```
+headmatch hearing-test
+    Run the hearing test (TUI / headless mode, left ear then right ear).
+    Plays tone, waits for Enter key = heard, silence timeout = not heard.
+    Saves profile to config dir.
+    --device <name|id>          output device override
+    --no-noise-check            skip ambient noise gate
+    --json                      emit HearingTestResult JSON to stdout
+
+headmatch fit --with-hearing-compensation
+    Load saved hearing profile and fold into target before fitting.
+    Errors with clear message if no saved profile found.
+```
+
+---
+
+## Persistence
+
+Profile saved as human-readable JSON at:
+- Linux: `~/.config/headmatch/hearing_profile.json`
+- macOS: `~/Library/Application Support/headmatch/hearing_profile.json`
+- Windows: `%APPDATA%/headmatch/hearing_profile.json`
+
+Schema (matches `HearingProfile` dataclass, serialised via `dataclasses.asdict`):
+
+```json
+{
+  "tested_at": "2026-06-13T22:00:00Z",
+  "asymmetric_freqs": [],
+  "left": {
+    "500":  { "freq_hz": 500,  "level": 58.0, "ascending_runs": 3, "determined": true },
+    "1000": { "freq_hz": 1000, "level": 60.0, "ascending_runs": 3, "determined": true },
+    ...
+  },
+  "right": { ... }
+}
+```
+
+---
+
+## Integration points with existing pipeline
+
+```
+gui/shell.py
+  └─ HearingTestController
+       └─ ThresholdEngine × 14 (7 freq × 2 ears)
+       └─ AudioBackend.play_tone()
+       └─ save_hearing_profile()
+  └─ HearingTestView (gui/views/hearing_test.py)
+
+pipeline.py  run_pipeline(hearing_profile=...)
+  └─ compute_compensation_curve(profile, freq_grid)  → gain array
+  └─ effective_target = base_target + compensation
+  └─ [existing peq.py fit — unchanged]
+  └─ [existing exporters.py — unchanged]
+
+run_summary.json (no schema change)
+  hearing_compensation_applied: bool   ← new field, optional
+```
+
+---
+
+## Design decisions & constraints
+
+| Decision | Rationale |
+|---|---|
+| Relative dB scale, not dB HL | No RETSPL calibration data per headphone model; avoids false clinical claims |
+| Half-gain rule (0.5×) | Public domain (Lybarger 1944); conservative; appropriate for music listening, not speech intelligibility |
+| Cap at +12 dB | Prevents runaway boost on frequencies where driver distortion is high |
+| Fold into target, not separate EQ layer | Reuses existing pipeline; single artefact per run; no architectural new EQ stage |
+| Per-ear then averaged to mono | Matches existing mono-target pipeline; asymmetry warning surfaced but not fatal |
+| 7 test frequencies | Balances resolution (better than 4-point PTA minimum) with test time (~4 min total) |
+| No "I don't hear it" button | Reduces false positives from hesitation; silent timeout is the standard response |
+| 3 s response window | Longer than clinical (1 s) to accommodate consumer UX latency |
+| Built-in normal-hearing reference | Enables compensation without needing a prior calibration run |
+
+---
+
+## Acceptance criteria
+
+- [ ] Tone playback works on PipeWire (Linux) and PortAudio (macOS/Windows) via the existing backend
+- [ ] ThresholdEngine produces stable threshold within 3–8 ascending runs for a simulated perfect listener
+- [ ] Compensation curve: 0 dB at all frequencies for a "flat" (at-reference) hearing profile
+- [ ] Compensation curve: +10 dB at 4 kHz for a profile with 20 dB of loss at 4 kHz (half-gain = 10)
+- [ ] `pipeline.py` with `hearing_profile` produces a different (boosted) effective target than without
+- [ ] GUI flow completes end-to-end without crashing on Linux desktop
+- [ ] Saved profile round-trips through JSON serialisation
+- [ ] `headmatch hearing-test --json` emits valid JSON
+- [ ] `headmatch fit --with-hearing-compensation` loads saved profile and runs
+- [ ] L/R asymmetry warning shown correctly when gap > 15 dB
+- [ ] Noise gate warning shown and non-blocking
+
+---
+
+## Suggested files / components
+
+**New files:**
+- `headmatch/hearing_test.py`
+- `headmatch/gui/views/hearing_test.py`
+- `tests/test_hearing_test.py`
+- `tests/test_hearing_compensation.py`
+
+**Modified files:**
+- `headmatch/audio_backend.py` — add `play_tone()` to protocol
+- `headmatch/backend_pipewire.py` — implement `play_tone()`
+- `headmatch/backend_portaudio.py` — implement `play_tone()`
+- `headmatch/contracts.py` — add `WorkflowName` literal + `HearingTestResult`
+- `headmatch/pipeline.py` — add `hearing_profile` parameter
+- `headmatch/gui/controllers.py` — add `HearingTestController`
+- `headmatch/gui/shell.py` — wire new view + controller, add hearing test entry point
+- `headmatch/cli.py` — add `hearing-test` and `fit --with-hearing-compensation`
+
+---
+
+## Out of scope for this task
+
+- Dynamic compression / WDRC (requires per-band compressor in the DSP chain; separate task)
+- RETSPL calibration per headphone model (requires a calibration database; separate task)
+- Bone-conduction testing
+- Speech-in-noise testing
+- Clinical audiogram import (can be added later by mapping dB HL → relative dB via a stored RETSPL table)
+- Extended high-frequency testing above 8 kHz

--- a/headmatch/audio_backend.py
+++ b/headmatch/audio_backend.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
 
 from .signals import SweepSpec
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @dataclass(frozen=True)
@@ -76,6 +79,15 @@ class AudioBackend(Protocol):
         device: DeviceConfig,
     ) -> Path:
         """Play sweep and record simultaneously. Returns path to recording WAV."""
+        ...
+
+    def play_tone(
+        self,
+        samples: "np.ndarray",
+        sample_rate: int,
+        device: Optional[str] = None,
+    ) -> None:
+        """Play a short audio buffer to the output device without recording."""
         ...
 
     def format_device_list(self, devices: list[AudioDevice]) -> str:

--- a/headmatch/backend_pipewire.py
+++ b/headmatch/backend_pipewire.py
@@ -243,6 +243,23 @@ class PipeWireBackend:
             )
         return paths.recording_wav
 
+    def play_tone(self, samples, sample_rate: int, device: Optional[str] = None) -> None:
+        import tempfile
+        from .measure import require_executable
+        from .io_utils import write_wav
+
+        require_executable("pw-play")
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            tmp_path = Path(f.name)
+        try:
+            write_wav(tmp_path, samples, sample_rate)
+            cmd = ["pw-play", "--rate", str(sample_rate), "--channels", "2", str(tmp_path)]
+            if device:
+                cmd.extend(["--target", device])
+            subprocess.run(cmd, capture_output=True, check=False)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
     def format_device_list(self, devices: list[AudioDevice]) -> str:
         lines = [
             'Audio targets you can pass to --output-target / --input-target',

--- a/headmatch/backend_portaudio.py
+++ b/headmatch/backend_portaudio.py
@@ -250,6 +250,17 @@ class PortAudioBackend:
             )
         return paths.recording_wav
 
+    def play_tone(self, samples, sample_rate: int, device: Optional[str] = None) -> None:
+        sd = _import_sd()
+        output_device = None
+        if device:
+            try:
+                output_device = int(device)
+            except ValueError:
+                output_device = device  # type: ignore[assignment]
+        sd.play(samples, samplerate=sample_rate, device=output_device, blocking=True)
+        sd.wait()
+
     def format_device_list(self, devices: list[AudioDevice]) -> str:
         lines = [
             "Audio targets you can pass to --output-target / --input-target",

--- a/headmatch/cli.py
+++ b/headmatch/cli.py
@@ -163,6 +163,37 @@ def build_parser(config) -> argparse.ArgumentParser:
     add_filter_budget_args(p, config)
     p.add_argument("--json", action="store_true", help="Print the run summary as JSON instead of the human-readable terminal summary.")
     p.add_argument("--show-clipping", action="store_true", help="Show detailed clipping assessment information in the terminal output.")
+    p.add_argument("--with-hearing-compensation", action="store_true", help="Load the saved hearing profile and add compensation to the target curve before fitting.")
+
+    p = sub.add_parser(
+        "hearing-test",
+        help="Run a pure-tone hearing threshold test and save a personalised hearing profile.",
+        description=(
+            "Sweeps 7 frequencies per ear using the Modified Hughson-Westlake procedure "
+            "(Carhart & Jerger 1959). Saves a hearing profile to the config directory. "
+            "Use 'headmatch fit --with-hearing-compensation' to apply the profile to a fit."
+        ),
+    )
+    p.add_argument("--output-target", default=config.pipewire_output_target, help="Playback device to use for test tones. Run 'headmatch list-targets' to discover values.")
+    p.add_argument("--sample-rate", type=int, default=config.sample_rate)
+    p.add_argument("--json", action="store_true", help="Print the resulting hearing profile as JSON.")
+    p.add_argument("--fit", action="store_true", help="Generate an EQ preset immediately after the hearing test completes.")
+    p.add_argument("--out-dir", default=None, help="Output folder for EQ files when --fit is used. Defaults to ~/Documents/HeadMatch/hearing_fit.")
+
+    p = sub.add_parser(
+        "hearing-fit",
+        help="Generate an EQ preset from a saved hearing profile — no headphone measurement needed.",
+        description=(
+            "Load the saved hearing profile and fit PEQ bands that combine the target curve "
+            "with your personal hearing compensation (half-gain rule, Lybarger 1944). "
+            "Assumes a flat headphone response. For best results, run a headphone measurement "
+            "and use 'headmatch fit --with-hearing-compensation' instead."
+        ),
+    )
+    p.add_argument("--out-dir", required=True, help="Folder to write the EQ preset files.")
+    p.add_argument("--target-csv", default=config.preferred_target_csv, help="Optional target curve CSV. If omitted, fit toward flat.")
+    add_filter_budget_args(p, config)
+    p.add_argument("--json", action="store_true", help="Print the fit report as JSON.")
 
     p = sub.add_parser("search-headphone", help="Search community headphone databases for a model name.")
     p.add_argument("query", help="Headphone model name to search for.")
@@ -431,6 +462,11 @@ def print_next_steps(cmd: str, args) -> None:
         print()
         print(f"Done. Review outputs in {out_dir}.")
         print("Start with run_summary.json, then use equalizer_apo.txt or camilladsp_full.yaml.")
+    elif cmd == "hearing-fit":
+        print()
+        print(f"Hearing fit complete. Review outputs in {args.out_dir}.")
+        print("Load equalizer_apo.txt in Equalizer APO or camilladsp_full.yaml in CamillaDSP.")
+        print("For better accuracy, measure your headphones and use 'headmatch fit --with-hearing-compensation'.")
     elif cmd == "clone-target":
         print()
         print(f"Clone target written to {args.out}.")
@@ -561,8 +597,62 @@ def main(argv: list[str] | None = None) -> None:
             )
         elif args.cmd == "analyze":
             analyze_measurement(args.recording, spec_from_args(args), out_dir=args.out_dir)
+        elif args.cmd == "hearing-test":
+            from .hearing_test import (
+                load_hearing_profile,
+                run_cli_hearing_test,
+                save_hearing_profile,
+                hearing_profile_path,
+            )
+            from .audio_backend import get_audio_backend
+            backend = get_audio_backend()
+            output_device = getattr(args, "output_target", None) or None
+            profile = run_cli_hearing_test(backend, output_device, sample_rate=args.sample_rate)
+            path = save_hearing_profile(profile)
+            if getattr(args, "json", False):
+                print(json.dumps(profile.to_dict(), indent=2))
+            else:
+                print(f"\nHearing profile saved to {path}")
+                if profile.asymmetric_freqs:
+                    freq_strs = ", ".join(str(f) for f in profile.asymmetric_freqs)
+                    print(f"Warning: large L/R difference at {freq_strs} Hz — consider consulting an audiologist.")
+                print("Run 'headmatch fit --with-hearing-compensation' to apply this profile to a fit.")
+            if getattr(args, "fit", False):
+                from .pipeline import run_hearing_fit
+                from pathlib import Path as _Path
+                out_dir = getattr(args, "out_dir", None) or str(_Path.home() / "Documents" / "HeadMatch" / "hearing_fit")
+                print(f"\nGenerating EQ preset in {out_dir} ...")
+                run_hearing_fit(profile, out_dir, sample_rate=args.sample_rate)
+                print(f"Done. EQ files written to {out_dir}.")
+        elif args.cmd == "hearing-fit":
+            from .hearing_test import load_hearing_profile, hearing_profile_path
+            from .pipeline import run_hearing_fit
+            profile = load_hearing_profile()
+            if profile is None:
+                parser.exit(2, f"Error: no hearing profile found at {hearing_profile_path()}.\nRun 'headmatch hearing-test' first.\n")
+            run_hearing_fit(
+                profile,
+                args.out_dir,
+                sample_rate=config.sample_rate,
+                target_path=getattr(args, "target_csv", None) or None,
+                max_filters=args.max_filters,
+                filter_budget=filter_budget_from_args(args),
+            )
+            if getattr(args, "json", False):
+                import json as _json
+                report_path = Path(args.out_dir) / "hearing_fit_report.json"
+                try:
+                    print(_json.dumps(_json.loads(report_path.read_text(encoding="utf-8")), indent=2, sort_keys=True))
+                except Exception:
+                    pass
         elif args.cmd == "fit":
-            process_single_measurement(args.recording, args.out_dir, spec_from_args(args), target_path=args.target_csv, max_filters=args.max_filters, filter_budget=filter_budget_from_args(args))
+            hearing_profile = None
+            if getattr(args, "with_hearing_compensation", False):
+                from .hearing_test import load_hearing_profile, hearing_profile_path
+                hearing_profile = load_hearing_profile()
+                if hearing_profile is None:
+                    parser.exit(2, f"Error: no hearing profile found at {hearing_profile_path()}.\nRun 'headmatch hearing-test' first.\n")
+            process_single_measurement(args.recording, args.out_dir, spec_from_args(args), target_path=args.target_csv, max_filters=args.max_filters, filter_budget=filter_budget_from_args(args), hearing_profile=hearing_profile)
             if getattr(args, "json", False):
                 summary_path = Path(args.out_dir) / "run_summary.json"
                 try:
@@ -695,7 +785,7 @@ def main(argv: list[str] | None = None) -> None:
     except ValueError as exc:
         parser.exit(2, f"Error: {format_user_error(args.cmd, exc)}\n")
 
-    if args.cmd not in {'doctor', 'tui', 'list-targets'} and not (args.cmd == "fit" and getattr(args, "json", False)):
+    if args.cmd not in {'doctor', 'tui', 'list-targets', 'hearing-test', 'hearing-fit'} and not (args.cmd == "fit" and getattr(args, "json", False)):
         try:
             save_config(update_config_from_args(args, existing=config), config_path)
         except OSError:

--- a/headmatch/cli.py
+++ b/headmatch/cli.py
@@ -620,18 +620,19 @@ def main(argv: list[str] | None = None) -> None:
             if getattr(args, "fit", False):
                 from .pipeline import run_hearing_fit
                 from pathlib import Path as _Path
-                out_dir = getattr(args, "out_dir", None) or str(_Path.home() / "Documents" / "HeadMatch" / "hearing_fit")
-                print(f"\nGenerating EQ preset in {out_dir} ...")
-                run_hearing_fit(profile, out_dir, sample_rate=args.sample_rate)
-                print(f"Done. EQ files written to {out_dir}.")
+                fit_out_dir: str = getattr(args, "out_dir", None) or str(_Path.home() / "Documents" / "HeadMatch" / "hearing_fit")
+                print(f"\nGenerating EQ preset in {fit_out_dir} ...")
+                run_hearing_fit(profile, fit_out_dir, sample_rate=args.sample_rate)
+                print(f"Done. EQ files written to {fit_out_dir}.")
         elif args.cmd == "hearing-fit":
             from .hearing_test import load_hearing_profile, hearing_profile_path
             from .pipeline import run_hearing_fit
-            profile = load_hearing_profile()
-            if profile is None:
+            hf_profile = load_hearing_profile()
+            if hf_profile is None:
                 parser.exit(2, f"Error: no hearing profile found at {hearing_profile_path()}.\nRun 'headmatch hearing-test' first.\n")
+                raise SystemExit(2)
             run_hearing_fit(
-                profile,
+                hf_profile,
                 args.out_dir,
                 sample_rate=config.sample_rate,
                 target_path=getattr(args, "target_csv", None) or None,

--- a/headmatch/contracts.py
+++ b/headmatch/contracts.py
@@ -20,6 +20,8 @@ WorkflowName = Literal[
     "fit",
     "iterate",
     "clone-target",
+    "hearing-test",
+    "hearing-fit",
 ]
 
 RunMode = Literal["online", "offline", "analysis-only", "clone-target"]

--- a/headmatch/gui/shell.py
+++ b/headmatch/gui/shell.py
@@ -31,6 +31,7 @@ from .views import (
     render_clone_target_workflow,
     render_completion,
     render_fetch_curve,
+    render_hearing_test,
     render_history_page,
     render_import_apo,
     render_offline_wizard,
@@ -86,8 +87,8 @@ BASIC_NAV_ITEMS: tuple[NavigationItem, ...] = (
 )
 
 NAV_ITEMS: tuple[NavigationItem, ...] = (
-
     NavigationItem("measure-online", "Measure"),
+    NavigationItem("hearing-test", "Hearing Test"),
     NavigationItem("setup-check", "Setup Check"),
     NavigationItem("prepare-offline", "Prepare Offline"),
     NavigationItem("target-editor", "Target Editor"),
@@ -210,6 +211,7 @@ class HeadMatchGuiApp:
         self.basic_clone_source_var = tk.StringVar(master=root, value="")
         self.basic_clone_target_var = tk.StringVar(master=root, value="")
         self.basic_clone_output_var = tk.StringVar(master=root, value="")
+        self.hearing_profile = None  # HearingProfile | None; set after a successful test
         self.basic_progress_var = tk.StringVar(master=root, value="")
         self.progress_title_var = tk.StringVar(master=root, value="")
         self.progress_body_var = tk.StringVar(master=root, value="")
@@ -333,6 +335,9 @@ class HeadMatchGuiApp:
             return
         if key == "fetch-curve":
             self._render_fetch_curve()
+            return
+        if key == "hearing-test":
+            self._render_hearing_test()
             return
         if key == "history":
             self._render_history()
@@ -571,6 +576,86 @@ class HeadMatchGuiApp:
         status = self._ttk.Label(self.content, text=message, wraplength=560, justify="left")
         status.grid(row=99, column=0, sticky="w", pady=(12, 0))
         self.root.after(8000, status.destroy)
+
+    def _render_hearing_test(self) -> None:
+        from ..audio_backend import get_audio_backend
+        try:
+            backend = get_audio_backend()
+        except RuntimeError as exc:
+            self._show_status(f"Audio backend unavailable: {exc}")
+            return
+
+        output_device = self._strip_device_label(self.output_target_var.get()) or None
+
+        def _on_complete(profile) -> None:
+            self.hearing_profile = profile
+            self._show_hearing_followup(profile)
+
+        def _on_cancel() -> None:
+            self.show_view("measure-online")
+
+        render_hearing_test(
+            self._ttk,
+            self.content,
+            backend=backend,
+            output_device=output_device,
+            sample_rate=self.state.sample_rate,
+            on_complete=_on_complete,
+            on_cancel=_on_cancel,
+        )
+
+    def _show_hearing_followup(self, profile) -> None:
+        for child in self.content.winfo_children():  # type: ignore[attr-defined]
+            child.destroy()
+        ttk = self._ttk
+        self.content.columnconfigure(0, weight=1)  # type: ignore[attr-defined]
+        ttk.Label(self.content, text="Hearing Test Complete", style="Title.TLabel").grid(
+            row=0, column=0, sticky="w", pady=(0, 8)
+        )
+        ttk.Label(
+            self.content,
+            text=(
+                "Your hearing profile has been saved. "
+                "Choose how to apply it: generate a standalone EQ preset now "
+                "(assumes a flat headphone response), or run a headphone measurement "
+                "first for a more accurate personalised fit."
+            ),
+            wraplength=560,
+            justify="left",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 16))
+
+        def _generate_now():
+            from pathlib import Path as _Path
+            out_dir = str(_Path(self.state.default_output_dir).expanduser().parent / "hearing_fit")
+            self._start_hearing_fit(profile, out_dir)
+
+        btn_frame = ttk.Frame(self.content)
+        btn_frame.grid(row=2, column=0, sticky="w")
+        ttk.Button(btn_frame, text="Generate EQ Preset Now", command=_generate_now).grid(
+            row=0, column=0, padx=(0, 8)
+        )
+        ttk.Button(
+            btn_frame, text="Run a Measurement",
+            command=lambda: self.show_view("measure-online"),
+        ).grid(row=0, column=1)
+
+    def _start_hearing_fit(self, profile, out_dir: str) -> None:
+        from ..pipeline import run_hearing_fit
+        self._run_background_task(
+            task_name="hearing-fit",
+            progress_title="Generating EQ preset from hearing profile",
+            progress_body=f"Fitting EQ bands to your hearing compensation curve. Writing output to {out_dir}.",
+            worker=lambda: run_hearing_fit(profile, out_dir, sample_rate=self.state.sample_rate),
+            on_success=lambda _result: self._set_completion(
+                title="Hearing EQ preset ready",
+                summary=f"EQ preset written to {out_dir}.",
+                steps=(
+                    f"Load equalizer_apo.txt from {out_dir} in Equalizer APO.",
+                    "This preset corrects for your personal hearing thresholds (flat headphone assumed).",
+                    "For a more accurate fit, run a headphone measurement with Hearing Test compensation enabled.",
+                ),
+            ),
+        )
 
     def _render_history(self) -> None:
         def _browse_history():
@@ -821,6 +906,7 @@ class HeadMatchGuiApp:
         output_target = self._strip_device_label(self.output_target_var.get()) or None
         input_target = self._strip_device_label(self.input_target_var.get()) or None
 
+        hearing_profile = getattr(self, "hearing_profile", None)
         self._run_background_task(
             task_name="measure-online",
             progress_title="Running online measurement",
@@ -834,6 +920,7 @@ class HeadMatchGuiApp:
                 iterations=iterations,
                 max_filters=max_filters,
                 iteration_mode=self.iteration_mode_var.get().strip() or 'independent',
+                hearing_profile=hearing_profile,
             ),
             on_success=lambda result: self._set_completion(
                 title="Online measurement complete",

--- a/headmatch/gui/views/__init__.py
+++ b/headmatch/gui/views/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .basic import render_basic_mode, render_clone_target_workflow
 from .completion import render_completion, render_progress
 from .fetch_curve import render_fetch_curve
+from .hearing_test import render_hearing_test
 from .history import render_history_page, render_history_results
 from .import_apo import render_import_apo
 from .offline import render_offline_wizard
@@ -15,6 +16,7 @@ __all__ = [
     'render_clone_target_workflow',
     'render_completion',
     'render_fetch_curve',
+    'render_hearing_test',
     'render_history_page',
     'render_history_results',
     'render_import_apo',

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -437,7 +437,7 @@ def _draw_threshold_chart(ttk, frame, *, left, right, width=500, height=160):
 
     def _y(level_dbfs: float) -> float:
         frac = (level_dbfs - y_min) / y_range
-        return margin_t + plot_h * (1.0 - frac)
+        return float(margin_t + plot_h * (1.0 - frac))
 
     # Axes
     canvas.create_line(margin_l, margin_t, margin_l, margin_t + plot_h, fill="#888888")

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -1,0 +1,485 @@
+"""GUI view for the hearing threshold test workflow."""
+from __future__ import annotations
+
+import threading
+from typing import Callable, Optional
+
+from ...hearing_test import (
+    ASYMMETRY_WARNING_DB,
+    GAIN_FRACTION,
+    MAX_COMPENSATION_DB,
+    NORMAL_HEARING_REFERENCE,
+    RESPONSE_WINDOW_S,
+    START_LEVEL_DBFS,
+    TEST_FREQUENCIES,
+    TEST_ORDER,
+    FrequencyThreshold,
+    HearingProfile,
+    ThresholdEngine,
+    detect_asymmetric_frequencies,
+    generate_tone,
+    save_hearing_profile,
+)
+
+from datetime import datetime, timezone
+
+
+_FREQ_LABELS = {
+    500: "500 Hz",
+    1000: "1 kHz",
+    2000: "2 kHz",
+    3000: "3 kHz",
+    4000: "4 kHz",
+    6000: "6 kHz",
+    8000: "8 kHz",
+}
+
+
+def render_hearing_test(
+    ttk,
+    frame,
+    *,
+    backend,
+    output_device: Optional[str],
+    sample_rate: int,
+    on_complete: Callable[[HearingProfile], None],
+    on_cancel: Callable[[], None],
+) -> None:
+    """
+    Render the hearing test into frame.
+
+    Manages the full INTRO → TEST_L → TEST_R → RESULTS flow inside frame.
+    Calls on_complete(profile) when the user accepts results, or on_cancel()
+    if they stop the test early.
+    """
+    import tkinter as tk
+
+    _state: dict = {
+        "ear": "left",
+        "engine": None,
+        "freq_index": 0,
+        "processed_freqs": set(),
+        "left": {},
+        "right": {},
+        "response_timer": None,
+        "tone_thread": None,
+        "responded": False,
+    }
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _clear():
+        for child in frame.winfo_children():
+            child.destroy()
+
+    def _cancel_timer():
+        timer_id = _state.get("response_timer")
+        if timer_id is not None:
+            try:
+                frame.after_cancel(timer_id)
+            except Exception:
+                pass
+            _state["response_timer"] = None
+
+    def _play_tone_async(freq_hz: int, level_dbfs: float):
+        """Play tone in a background thread so Tkinter stays responsive."""
+        def _worker():
+            try:
+                samples = generate_tone(freq_hz, level_dbfs, sample_rate)
+                backend.play_tone(samples, sample_rate, output_device)
+            except Exception:
+                pass
+        t = threading.Thread(target=_worker, daemon=True)
+        t.start()
+        _state["tone_thread"] = t
+
+    # ── view transitions ─────────────────────────────────────────────────────
+
+    def _show_intro():
+        _clear()
+        frame.columnconfigure(0, weight=1)
+
+        ttk.Label(frame, text="Hearing Test", style="Title.TLabel").grid(
+            row=0, column=0, sticky="w", pady=(0, 8)
+        )
+        ttk.Label(
+            frame,
+            text=(
+                "This test sweeps pure tones across 7 frequencies in each ear "
+                "and estimates where your hearing thresholds are. "
+                "The result is used to personalise the EQ compensation applied "
+                "to your headphone fit."
+            ),
+            wraplength=560,
+            justify="left",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 12))
+
+        instructions = (
+            "Before you start:",
+            "  • Set your headphone volume to a comfortable music-listening level.",
+            "  • Go to a quiet room.",
+            "  • The test takes about 5 minutes total.",
+            "",
+            "During the test:",
+            "  • Click 'I hear it' each time you hear a tone.",
+            "  • If you don't hear the tone, do nothing — the test advances automatically.",
+            "  • Test your LEFT ear first, then your RIGHT ear.",
+        )
+        info_text = tk.Text(
+            frame, height=10, width=62, state="normal",
+            relief="flat", background=frame.cget("background") if hasattr(frame, "cget") else "#f0f0f0",
+            wrap="word",
+        )
+        info_text.insert("1.0", "\n".join(instructions))
+        info_text.configure(state="disabled")
+        info_text.grid(row=2, column=0, sticky="ew", pady=(0, 16))
+
+        btn_frame = ttk.Frame(frame)
+        btn_frame.grid(row=3, column=0, sticky="w")
+        ttk.Button(btn_frame, text="Start Test", command=_begin_left).grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btn_frame, text="Cancel", command=on_cancel).grid(row=0, column=1)
+
+    def _begin_left():
+        _state["ear"] = "left"
+        _state["processed_freqs"] = set()
+        _state["freq_index"] = 0
+        _show_ear_intro("left", callback=_start_test_loop)
+
+    def _begin_right():
+        _state["ear"] = "right"
+        _state["processed_freqs"] = set()
+        _state["freq_index"] = 0
+        _show_ear_intro("right", callback=_start_test_loop)
+
+    def _show_ear_intro(ear: str, callback: Callable):
+        _clear()
+        frame.columnconfigure(0, weight=1)
+        cover = "right" if ear == "left" else "left"
+        ttk.Label(frame, text=f"Testing {ear.capitalize()} Ear", style="Title.TLabel").grid(
+            row=0, column=0, sticky="w", pady=(0, 8)
+        )
+        ttk.Label(
+            frame,
+            text=f"Cover or plug your {cover} ear. Click Ready when set.",
+            wraplength=560,
+        ).grid(row=1, column=0, sticky="w", pady=(0, 16))
+        ttk.Button(frame, text="Ready — Start", command=callback).grid(row=2, column=0, sticky="w")
+        ttk.Button(frame, text="Stop Test", command=_stop_test).grid(row=3, column=0, sticky="w", pady=(8, 0))
+
+    # ── test loop ─────────────────────────────────────────────────────────────
+
+    def _start_test_loop():
+        _state["freq_index"] = 0
+        _state["processed_freqs"] = set()
+        _advance_to_next_freq()
+
+    def _advance_to_next_freq():
+        idx = _state["freq_index"]
+        order = TEST_ORDER
+
+        # Skip already-processed frequencies
+        while idx < len(order) and order[idx] in _state["processed_freqs"]:
+            idx += 1
+        _state["freq_index"] = idx
+
+        if idx >= len(order):
+            _finish_ear()
+            return
+
+        freq_hz = order[idx]
+        _state["processed_freqs"].add(freq_hz)
+        _state["engine"] = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
+        _show_test_screen(freq_hz, idx)
+        _next_tone()
+
+    def _show_test_screen(freq_hz: int, order_idx: int):
+        _clear()
+        frame.columnconfigure(0, weight=1)
+
+        ear = _state["ear"]
+        # Count unique frequencies done so far
+        done_count = len(_state["processed_freqs"])
+        total = len(TEST_FREQUENCIES)
+
+        ttk.Label(frame, text=f"Testing {ear.capitalize()} Ear", style="Title.TLabel").grid(
+            row=0, column=0, sticky="w", pady=(0, 4)
+        )
+        ttk.Label(
+            frame,
+            text=f"Frequency {done_count} / {total} — {_FREQ_LABELS.get(freq_hz, f'{freq_hz} Hz')}",
+            style="Heading.TLabel",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 12))
+
+        # Speaker indicator
+        _state["speaker_label_var"] = tk.StringVar(value="♪ Playing tone …")
+        ttk.Label(frame, textvariable=_state["speaker_label_var"]).grid(
+            row=2, column=0, sticky="w", pady=(0, 12)
+        )
+
+        # "I hear it" button — the only interaction
+        hear_btn = ttk.Button(
+            frame,
+            text="I hear it",
+            command=_on_heard,
+        )
+        hear_btn.grid(row=3, column=0, sticky="w", pady=(0, 8))
+        _state["hear_btn"] = hear_btn
+
+        ttk.Button(frame, text="Stop Test", command=_stop_test).grid(row=4, column=0, sticky="w", pady=(4, 0))
+
+    def _next_tone():
+        """Play the current tone and start the response window timer."""
+        _cancel_timer()
+        _state["responded"] = False
+
+        engine: ThresholdEngine = _state["engine"]
+        if engine.done:
+            _on_freq_done()
+            return
+
+        freq_hz = engine.freq_hz
+        level = engine.current_level_dbfs
+
+        # Update speaker indicator
+        speaker_var = _state.get("speaker_label_var")
+        if speaker_var:
+            speaker_var.set("♪ Playing tone …")
+
+        _play_tone_async(freq_hz, level)
+
+        # Response window: RESPONSE_WINDOW_S seconds from tone start
+        timer_id = frame.after(
+            int(RESPONSE_WINDOW_S * 1000),
+            _on_timeout,
+        )
+        _state["response_timer"] = timer_id
+
+    def _on_heard():
+        if _state.get("responded"):
+            return
+        _state["responded"] = True
+        _cancel_timer()
+        engine: ThresholdEngine = _state["engine"]
+        engine.record_response(True)
+        speaker_var = _state.get("speaker_label_var")
+        if speaker_var:
+            speaker_var.set("✓ Heard")
+        if engine.done:
+            frame.after(300, _on_freq_done)
+        else:
+            frame.after(300, _next_tone)
+
+    def _on_timeout():
+        if _state.get("responded"):
+            return
+        _state["responded"] = True
+        _state["response_timer"] = None
+        engine: ThresholdEngine = _state["engine"]
+        engine.record_response(False)
+        speaker_var = _state.get("speaker_label_var")
+        if speaker_var:
+            speaker_var.set("— Not heard")
+        if engine.done:
+            frame.after(300, _on_freq_done)
+        else:
+            frame.after(300, _next_tone)
+
+    def _on_freq_done():
+        engine: ThresholdEngine = _state["engine"]
+        freq_hz = engine.freq_hz
+        threshold = engine.threshold
+        determined = threshold is not None
+
+        result = FrequencyThreshold(
+            freq_hz=freq_hz,
+            level_dbfs=threshold,
+            ascending_runs=engine.ascending_run_count,
+            determined=determined,
+        )
+        _state[_state["ear"]][freq_hz] = result
+
+        # Advance freq_index past the current entry
+        _state["freq_index"] += 1
+        _advance_to_next_freq()
+
+    def _finish_ear():
+        ear = _state["ear"]
+        if ear == "left":
+            _begin_right()
+        else:
+            _show_results()
+
+    def _stop_test():
+        _cancel_timer()
+        on_cancel()
+
+    # ── results ───────────────────────────────────────────────────────────────
+
+    def _show_results():
+        _clear()
+        frame.columnconfigure(0, weight=1)
+
+        left_thresholds: dict[int, FrequencyThreshold] = _state["left"]
+        right_thresholds: dict[int, FrequencyThreshold] = _state["right"]
+        asymmetric = detect_asymmetric_frequencies(left_thresholds, right_thresholds)
+
+        ttk.Label(frame, text="Hearing Test Results", style="Title.TLabel").grid(
+            row=0, column=0, sticky="w", pady=(0, 8)
+        )
+
+        # ── canvas bar chart ──
+        canvas_w, canvas_h = 500, 160
+        canvas = _draw_threshold_chart(
+            ttk, frame,
+            left=left_thresholds,
+            right=right_thresholds,
+            width=canvas_w,
+            height=canvas_h,
+        )
+        canvas.grid(row=1, column=0, sticky="w", pady=(0, 12))
+
+        # ── summary text ──
+        n_determined = sum(
+            1 for t in {**left_thresholds, **right_thresholds}.values() if t.determined
+        )
+        n_total = len(left_thresholds) + len(right_thresholds)
+        summary_parts = [f"Thresholds determined: {n_determined} / {n_total}"]
+
+        if asymmetric:
+            freq_labels = ", ".join(_FREQ_LABELS.get(f, str(f)) for f in asymmetric)
+            summary_parts.append(
+                f"Large L/R difference (>{ASYMMETRY_WARNING_DB:.0f} dB) at: {freq_labels}. "
+                "Consider consulting an audiologist."
+            )
+
+        # Estimate average compensation
+        from ...hearing_test import compute_compensation_curve
+        import numpy as np
+        from ...signals import geometric_log_grid
+
+        profile_for_preview = HearingProfile(
+            left=left_thresholds,
+            right=right_thresholds,
+            tested_at=datetime.now(timezone.utc).isoformat(),
+            asymmetric_freqs=asymmetric,
+        )
+        grid = geometric_log_grid(500.0, 8000.0, 48)
+        comp = compute_compensation_curve(profile_for_preview, grid)
+        avg_boost = float(np.mean(comp[comp > 0])) if np.any(comp > 0) else 0.0
+        max_boost = float(np.max(comp))
+        if max_boost > 0:
+            summary_parts.append(
+                f"EQ compensation: avg +{avg_boost:.1f} dB, max +{max_boost:.1f} dB "
+                f"(half-gain rule, capped at {MAX_COMPENSATION_DB:.0f} dB)."
+            )
+        else:
+            summary_parts.append("No EQ compensation needed — thresholds are at or below the normal reference.")
+
+        for i, txt in enumerate(summary_parts):
+            ttk.Label(frame, text=txt, wraplength=560, justify="left").grid(
+                row=2 + i, column=0, sticky="w", pady=2
+            )
+
+        row_offset = 2 + len(summary_parts) + 1
+
+        btn_frame = ttk.Frame(frame)
+        btn_frame.grid(row=row_offset, column=0, sticky="w", pady=(8, 0))
+
+        def _save_and_apply():
+            profile = HearingProfile(
+                left=left_thresholds,
+                right=right_thresholds,
+                tested_at=datetime.now(timezone.utc).isoformat(),
+                asymmetric_freqs=asymmetric,
+            )
+            save_hearing_profile(profile)
+            on_complete(profile)
+
+        def _save_only():
+            profile = HearingProfile(
+                left=left_thresholds,
+                right=right_thresholds,
+                tested_at=datetime.now(timezone.utc).isoformat(),
+                asymmetric_freqs=asymmetric,
+            )
+            save_hearing_profile(profile)
+            on_cancel()
+
+        ttk.Button(btn_frame, text="Save & Use for EQ", command=_save_and_apply).grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btn_frame, text="Save Without Applying", command=_save_only).grid(row=0, column=1, padx=(0, 8))
+        ttk.Button(btn_frame, text="Discard", command=on_cancel).grid(row=0, column=2)
+
+    # ── kick off ──────────────────────────────────────────────────────────────
+    _show_intro()
+
+
+def _draw_threshold_chart(ttk, frame, *, left, right, width=500, height=160):
+    """
+    Draw a simple canvas bar chart of L/R thresholds per frequency.
+    Returns the Canvas widget.
+    """
+    import tkinter as tk
+
+    canvas = tk.Canvas(frame, width=width, height=height, bg="#f8f8f8", highlightthickness=1, highlightbackground="#cccccc")
+
+    margin_l, margin_r, margin_t, margin_b = 44, 12, 16, 28
+    plot_w = width - margin_l - margin_r
+    plot_h = height - margin_t - margin_b
+
+    freqs = TEST_FREQUENCIES
+    n = len(freqs)
+    bar_group_w = plot_w / n
+    bar_w = bar_group_w * 0.3
+
+    # dBFS range for display
+    y_min, y_max = -70.0, -5.0
+    y_range = y_max - y_min
+
+    def _y(level_dbfs: float) -> float:
+        frac = (level_dbfs - y_min) / y_range
+        return margin_t + plot_h * (1.0 - frac)
+
+    # Axes
+    canvas.create_line(margin_l, margin_t, margin_l, margin_t + plot_h, fill="#888888")
+    canvas.create_line(margin_l, margin_t + plot_h, margin_l + plot_w, margin_t + plot_h, fill="#888888")
+
+    # Y gridlines and labels at -70, -55, -40, -25, -10 dBFS
+    for db in (-70, -55, -40, -25, -10):
+        y = _y(float(db))
+        canvas.create_line(margin_l, y, margin_l + plot_w, y, fill="#dddddd", dash=(2, 3))
+        canvas.create_text(margin_l - 3, y, text=str(db), anchor="e", font=("TkDefaultFont", 7), fill="#666666")
+
+    normal_ref_avg = sum(NORMAL_HEARING_REFERENCE.get(f, -50.0) for f in freqs) / len(freqs)
+    ref_y = _y(normal_ref_avg)
+    canvas.create_line(margin_l, ref_y, margin_l + plot_w, ref_y, fill="#4488cc", dash=(4, 3), width=1)
+    canvas.create_text(margin_l + plot_w, ref_y - 3, text="ref", anchor="e", font=("TkDefaultFont", 7), fill="#4488cc")
+
+    for i, freq_hz in enumerate(freqs):
+        x_center = margin_l + (i + 0.5) * bar_group_w
+
+        # Frequency label
+        canvas.create_text(
+            x_center, margin_t + plot_h + 10,
+            text=_FREQ_LABELS.get(freq_hz, str(freq_hz)).replace(" Hz", "").replace(" kHz", "k"),
+            font=("TkDefaultFont", 7), fill="#444444"
+        )
+
+        for side, color, offset in (("left", "#2266cc", -bar_w * 0.55), ("right", "#cc4422", bar_w * 0.55)):
+            data = left if side == "left" else right
+            t = data.get(freq_hz)
+            if t is None or not t.determined or t.level_dbfs is None:
+                continue
+            level = float(t.level_dbfs)
+            y_bar = _y(level)
+            y_bottom = _y(y_min)
+            x0 = x_center + offset - bar_w / 2
+            x1 = x_center + offset + bar_w / 2
+            canvas.create_rectangle(x0, y_bar, x1, y_bottom, fill=color, outline="")
+
+    # Legend
+    canvas.create_rectangle(margin_l, height - 10, margin_l + 8, height - 4, fill="#2266cc", outline="")
+    canvas.create_text(margin_l + 11, height - 7, text="L", anchor="w", font=("TkDefaultFont", 7), fill="#2266cc")
+    canvas.create_rectangle(margin_l + 22, height - 10, margin_l + 30, height - 4, fill="#cc4422", outline="")
+    canvas.create_text(margin_l + 33, height - 7, text="R", anchor="w", font=("TkDefaultFont", 7), fill="#cc4422")
+
+    return canvas

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -1,0 +1,419 @@
+"""Hearing threshold measurement and EQ compensation.
+
+Implements the Modified Hughson-Westlake pure-tone threshold procedure
+(Carhart & Jerger 1959, public domain) and the half-gain EQ compensation
+rule (Lybarger 1944, public domain).
+
+No proprietary algorithm or patented DSP method is used.
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from scipy.interpolate import CubicSpline
+
+from .paths import config_dir
+from .signals import fractional_octave_smoothing
+
+
+# ── Frequency protocol ────────────────────────────────────────────────────────
+
+TEST_FREQUENCIES: tuple[int, ...] = (500, 1000, 2000, 3000, 4000, 6000, 8000)
+
+# ISO 8253-1 test order: start at 1 kHz, ascend, re-verify 1 kHz, descend.
+# The duplicate 1000 Hz entry allows reliability verification.
+TEST_ORDER: tuple[int, ...] = (1000, 2000, 3000, 4000, 6000, 8000, 1000, 500)
+
+# ── Tone stimulus parameters ──────────────────────────────────────────────────
+
+TONE_DURATION_S: float = 1.0
+INTER_TONE_SILENCE_S: float = 0.8
+RAMP_DURATION_S: float = 0.03       # 30 ms raised-cosine onset/offset
+
+# ── Threshold engine parameters ───────────────────────────────────────────────
+
+START_LEVEL_DBFS: float = -20.0     # first tone at comfortable level
+MIN_LEVEL_DBFS: float = -70.0
+MAX_LEVEL_DBFS: float = -5.0
+STEP_DOWN_DB: float = 10.0          # decrease after heard response (Hughson-Westlake)
+STEP_UP_DB: float = 5.0             # increase after no response
+MAX_ASCENDING_RUNS: int = 8
+THRESHOLD_RESPONSES_NEEDED: int = 2
+THRESHOLD_WINDOW: int = 3
+RESPONSE_WINDOW_S: float = 3.0
+
+# ── Compensation parameters ───────────────────────────────────────────────────
+
+GAIN_FRACTION: float = 0.50         # half-gain rule (Lybarger 1944)
+MAX_COMPENSATION_DB: float = 12.0
+ASYMMETRY_WARNING_DB: float = 15.0
+NOISE_GATE_THRESHOLD_DBFS: float = -30.0
+
+# ── Normal hearing reference ──────────────────────────────────────────────────
+#
+# Expected threshold level (dBFS) for a young adult with normal hearing at a
+# comfortable music-listening volume. These values are used to convert a
+# measured threshold into an estimated hearing loss. Since we lack
+# device-specific RETSPL calibration the same reference is used for all
+# headphone models; the user anchors the test by setting a consistent volume.
+#
+# Values are derived from ISO 7029:2017 median data (young adult, 18–25 yrs)
+# mapped to our relative dBFS scale by assuming comfortable playback sits at
+# roughly –20 dBFS RMS and that the test starting level (–20 dBFS peak) is
+# about 30 dB above the expected threshold for a normal-hearing listener.
+
+NORMAL_HEARING_REFERENCE: dict[int, float] = {
+    500:  -48.0,
+    1000: -50.0,
+    2000: -50.0,
+    3000: -49.0,
+    4000: -47.0,
+    6000: -44.0,
+    8000: -42.0,
+}
+
+HEARING_PROFILE_FILENAME = "hearing_profile.json"
+
+
+# ── Data structures ───────────────────────────────────────────────────────────
+
+@dataclass
+class FrequencyThreshold:
+    freq_hz: int
+    level_dbfs: Optional[float]  # None when UNDETERMINED
+    ascending_runs: int
+    determined: bool
+
+
+@dataclass
+class HearingProfile:
+    left: dict[int, FrequencyThreshold]
+    right: dict[int, FrequencyThreshold]
+    tested_at: str                  # ISO 8601
+    asymmetric_freqs: list[int]     # freqs where L/R gap > ASYMMETRY_WARNING_DB
+
+    def to_dict(self) -> dict:
+        return {
+            "tested_at": self.tested_at,
+            "asymmetric_freqs": self.asymmetric_freqs,
+            "left": {str(k): asdict(v) for k, v in self.left.items()},
+            "right": {str(k): asdict(v) for k, v in self.right.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "HearingProfile":
+        def _parse_side(side: dict) -> dict[int, FrequencyThreshold]:
+            return {
+                int(k): FrequencyThreshold(**v)
+                for k, v in side.items()
+            }
+        return cls(
+            left=_parse_side(data["left"]),
+            right=_parse_side(data["right"]),
+            tested_at=data["tested_at"],
+            asymmetric_freqs=data.get("asymmetric_freqs", []),
+        )
+
+
+# ── Threshold engine ──────────────────────────────────────────────────────────
+
+class ThresholdEngine:
+    """
+    Single-ear, single-frequency pure-tone threshold state machine.
+
+    Modified Hughson-Westlake procedure (Carhart & Jerger 1959):
+    - Decrease 10 dB after a heard response.
+    - Increase 5 dB after a missed response (entering an ascending run).
+    - An ascending run completes when the user hears the tone while ascending.
+    - Threshold = lowest level heard on ≥ 2 of the last 3 ascending runs.
+    - Minimum 3 ascending runs required before threshold can be declared.
+    - Maximum MAX_ASCENDING_RUNS runs; best estimate used if not stable.
+    """
+
+    def __init__(self, freq_hz: int, start_level_dbfs: float = START_LEVEL_DBFS) -> None:
+        self.freq_hz = freq_hz
+        self._level = float(start_level_dbfs)
+        self._in_ascending = False  # True after at least one miss in current run
+        self._run_count = 0         # completed ascending runs
+        self._ascending_hits: list[float] = []
+        self._done = False
+        self._threshold: float | None = None
+
+    @property
+    def current_level_dbfs(self) -> float:
+        return self._level
+
+    @property
+    def done(self) -> bool:
+        return self._done
+
+    @property
+    def threshold(self) -> float | None:
+        return self._threshold
+
+    @property
+    def ascending_run_count(self) -> int:
+        return self._run_count
+
+    def record_response(self, heard: bool) -> None:
+        """Feed one user response for the current level."""
+        if self._done:
+            return
+
+        if heard:
+            if self._in_ascending:
+                self._run_count += 1
+                self._ascending_hits.append(round(self._level, 2))
+                threshold = self._check_threshold()
+                if threshold is not None:
+                    self._threshold = threshold
+                    self._done = True
+                    return
+                if self._run_count >= MAX_ASCENDING_RUNS:
+                    self._threshold = self._best_estimate()
+                    self._done = True
+                    return
+            # Step down after response
+            self._level = max(MIN_LEVEL_DBFS, self._level - STEP_DOWN_DB)
+            self._in_ascending = False
+        else:
+            # Step up; mark ascending phase
+            self._level = min(MAX_LEVEL_DBFS, self._level + STEP_UP_DB)
+            self._in_ascending = True
+
+    def _check_threshold(self) -> float | None:
+        if self._run_count < 3:
+            return None
+        recent = self._ascending_hits[-THRESHOLD_WINDOW:]
+        counts = Counter(recent)
+        candidates = [lev for lev, cnt in counts.items() if cnt >= THRESHOLD_RESPONSES_NEEDED]
+        return min(candidates) if candidates else None
+
+    def _best_estimate(self) -> float | None:
+        if not self._ascending_hits:
+            return None
+        counts = Counter(self._ascending_hits)
+        return min(counts, key=lambda lev: (-counts[lev], lev))
+
+
+# ── Tone generation ───────────────────────────────────────────────────────────
+
+def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000) -> np.ndarray:
+    """
+    Return a stereo (N, 2) float64 buffer: a pure sine at freq_hz scaled to
+    level_dbfs, with 30 ms raised-cosine onset and offset ramps.
+    """
+    n_total = int(round(TONE_DURATION_S * sample_rate))
+    n_ramp = int(round(RAMP_DURATION_S * sample_rate))
+
+    t = np.arange(n_total, dtype=np.float64) / sample_rate
+    mono = np.sin(2.0 * np.pi * freq_hz * t)
+
+    if n_ramp > 0 and 2 * n_ramp <= n_total:
+        ramp = 0.5 * (1.0 - np.cos(np.pi * np.arange(n_ramp) / n_ramp))
+        mono[:n_ramp] *= ramp
+        mono[-n_ramp:] *= ramp[::-1]
+
+    mono *= 10.0 ** (level_dbfs / 20.0)
+    return np.column_stack([mono, mono])
+
+
+# ── Compensation curve ────────────────────────────────────────────────────────
+
+def compute_compensation_curve(profile: HearingProfile, freq_grid: np.ndarray) -> np.ndarray:
+    """
+    Convert a HearingProfile to per-frequency EQ gain (dB) on freq_grid.
+
+    Half-gain rule (Lybarger 1944):
+        loss(f)  = measured_threshold(f) − NORMAL_HEARING_REFERENCE[f]
+        gain(f)  = clamp(loss(f) × GAIN_FRACTION, 0, MAX_COMPENSATION_DB)
+
+    L/R thresholds are averaged. Undetermined frequencies are skipped.
+    The 7-point gain array is interpolated to freq_grid via cubic spline on
+    log-frequency, then 1-octave Gaussian-smoothed to remove sharp peaks.
+    """
+    test_freqs: list[float] = []
+    test_gains: list[float] = []
+
+    for freq_hz in TEST_FREQUENCIES:
+        left_t = profile.left.get(freq_hz)
+        right_t = profile.right.get(freq_hz)
+
+        thresholds: list[float] = []
+        if left_t is not None and left_t.determined and left_t.level_dbfs is not None:
+            thresholds.append(left_t.level_dbfs)
+        if right_t is not None and right_t.determined and right_t.level_dbfs is not None:
+            thresholds.append(right_t.level_dbfs)
+
+        if not thresholds:
+            continue
+
+        avg_threshold = float(np.mean(thresholds))
+        ref = NORMAL_HEARING_REFERENCE.get(freq_hz, -50.0)
+        loss = avg_threshold - ref  # positive = worse than reference
+        gain = float(np.clip(loss * GAIN_FRACTION, 0.0, MAX_COMPENSATION_DB))
+
+        test_freqs.append(float(freq_hz))
+        test_gains.append(gain)
+
+    if len(test_freqs) < 2:
+        return np.zeros(len(freq_grid))
+
+    log_test = np.log10(test_freqs)
+    cs = CubicSpline(log_test, test_gains, bc_type="not-a-knot", extrapolate=True)
+
+    log_grid = np.log10(np.maximum(freq_grid, 1.0))
+    raw = cs(log_grid)
+    raw = np.clip(raw, 0.0, MAX_COMPENSATION_DB)
+
+    # 1-octave Gaussian smoothing to prevent sharp EQ transitions
+    smoothed = fractional_octave_smoothing(freq_grid, raw, fraction=1.0)
+    return np.maximum(smoothed, 0.0)
+
+
+def detect_asymmetric_frequencies(profile_left: dict[int, FrequencyThreshold],
+                                   profile_right: dict[int, FrequencyThreshold]) -> list[int]:
+    """Return frequencies where L/R threshold gap exceeds ASYMMETRY_WARNING_DB."""
+    asymmetric = []
+    for freq_hz in TEST_FREQUENCIES:
+        left_t = profile_left.get(freq_hz)
+        right_t = profile_right.get(freq_hz)
+        if (
+            left_t is not None and left_t.determined and left_t.level_dbfs is not None
+            and right_t is not None and right_t.determined and right_t.level_dbfs is not None
+        ):
+            gap = abs(left_t.level_dbfs - right_t.level_dbfs)
+            if gap > ASYMMETRY_WARNING_DB:
+                asymmetric.append(freq_hz)
+    return asymmetric
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+def save_hearing_profile(profile: HearingProfile) -> Path:
+    """Write profile to the platform config directory."""
+    path = config_dir() / HEARING_PROFILE_FILENAME
+    path.write_text(json.dumps(profile.to_dict(), indent=2), encoding="utf-8")
+    return path
+
+
+def load_hearing_profile() -> Optional[HearingProfile]:
+    """Return the saved profile, or None if none exists or it is unreadable."""
+    path = config_dir() / HEARING_PROFILE_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return HearingProfile.from_dict(data)
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+def hearing_profile_path() -> Path:
+    return config_dir() / HEARING_PROFILE_FILENAME
+
+
+# ── CLI test runner ───────────────────────────────────────────────────────────
+
+def run_cli_hearing_test(
+    backend,
+    output_device: str | None,
+    sample_rate: int = 48000,
+    *,
+    on_status=None,
+) -> HearingProfile:
+    """
+    Headless hearing test runner for CLI / TUI use.
+
+    Plays each tone via backend.play_tone(). The user presses Enter to
+    indicate they heard the tone; a response window timer handles silence.
+    Returns a completed HearingProfile.
+    """
+    import sys
+    import threading
+
+    def _status(msg: str) -> None:
+        if on_status:
+            on_status(msg)
+        else:
+            print(msg, flush=True)
+
+    def _ask_heard(timeout_s: float) -> bool:
+        """Return True if user presses Enter within timeout_s seconds."""
+        heard_event = threading.Event()
+
+        def _read():
+            try:
+                sys.stdin.readline()
+                heard_event.set()
+            except (EOFError, OSError):
+                pass
+
+        t = threading.Thread(target=_read, daemon=True)
+        t.start()
+        return heard_event.wait(timeout=timeout_s)
+
+    def _test_ear(ear_label: str) -> dict[int, FrequencyThreshold]:
+        thresholds: dict[int, FrequencyThreshold] = {}
+        processed: set[int] = set()
+
+        for freq_hz in TEST_ORDER:
+            if freq_hz in processed:
+                continue
+            processed.add(freq_hz)
+
+            engine = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
+            _status(f"\n  {ear_label} ear — {freq_hz} Hz")
+
+            while not engine.done:
+                level = engine.current_level_dbfs
+                samples = generate_tone(freq_hz, level, sample_rate)
+                backend.play_tone(samples, sample_rate, output_device)
+                heard = _ask_heard(RESPONSE_WINDOW_S)
+                engine.record_response(heard)
+
+            threshold = engine.threshold
+            determined = threshold is not None
+            thresholds[freq_hz] = FrequencyThreshold(
+                freq_hz=freq_hz,
+                level_dbfs=threshold,
+                ascending_runs=engine.ascending_run_count,
+                determined=determined,
+            )
+            if determined:
+                _status(f"    threshold: {threshold:.1f} dBFS after {engine.ascending_run_count} runs")
+            else:
+                _status(f"    threshold undetermined after {engine.ascending_run_count} runs")
+
+        return thresholds
+
+    _status("\n=== Hearing Threshold Test ===")
+    _status("Instructions:")
+    _status("  Set your headphone volume to a comfortable music-listening level.")
+    _status("  Press Enter each time you hear a tone. Stay still and quiet.")
+    _status("  If you do not hear the tone, do nothing — the test will advance.")
+    _status("\nStarting left ear. Cover or plug your right ear.")
+    input("  Press Enter to begin...")
+
+    left = _test_ear("Left")
+
+    _status("\nRight ear. Cover or plug your left ear.")
+    input("  Press Enter to continue...")
+
+    right = _test_ear("Right")
+
+    asymmetric = detect_asymmetric_frequencies(left, right)
+
+    profile = HearingProfile(
+        left=left,
+        right=right,
+        tested_at=datetime.now(timezone.utc).isoformat(),
+        asymmetric_freqs=asymmetric,
+    )
+    return profile

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -274,7 +274,7 @@ def compute_compensation_curve(profile: HearingProfile, freq_grid: np.ndarray) -
 
     # 1-octave Gaussian smoothing to prevent sharp EQ transitions
     smoothed = fractional_octave_smoothing(freq_grid, raw, fraction=1.0)
-    return np.maximum(smoothed, 0.0)
+    return np.maximum(smoothed, 0.0)  # type: ignore[no-any-return]
 
 
 def detect_asymmetric_frequencies(profile_left: dict[int, FrequencyThreshold],

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -112,11 +112,17 @@ def _metrics(freqs_hz: np.ndarray, measured_db: np.ndarray, target_db: np.ndarra
     return rms, max_abs
 
 
-def fit_from_measurement(result: MeasurementResult, target: TargetCurve, sample_rate: int, max_filters: int = 8, *, filter_budget: FilterBudget | None = None) -> tuple[list[PEQBand], list[PEQBand], dict]:
+def fit_from_measurement(result: MeasurementResult, target: TargetCurve, sample_rate: int, max_filters: int = 8, *, filter_budget: FilterBudget | None = None, hearing_profile=None) -> tuple[list[PEQBand], list[PEQBand], dict]:
     filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
     resolved_target = _resolve_target_curves(result, target)
-    left_eq_target = resolved_target.left_values_db - result.left_db
-    right_eq_target = resolved_target.right_values_db - result.right_db
+    if hearing_profile is not None:
+        from .hearing_test import compute_compensation_curve
+        compensation = compute_compensation_curve(hearing_profile, result.freqs_hz)
+        left_eq_target = (resolved_target.left_values_db + compensation) - result.left_db
+        right_eq_target = (resolved_target.right_values_db + compensation) - result.right_db
+    else:
+        left_eq_target = resolved_target.left_values_db - result.left_db
+        right_eq_target = resolved_target.right_values_db - result.right_db
     left_bands = fit_peq(result.freqs_hz, left_eq_target, sample_rate, max_filters=max_filters, budget=filter_budget)
     right_bands = fit_peq(result.freqs_hz, right_eq_target, sample_rate, max_filters=max_filters, budget=filter_budget)
     left_pred = result.left_db + peq_chain_response_db(result.freqs_hz, sample_rate, left_bands)
@@ -151,16 +157,17 @@ def fit_from_measurement(result: MeasurementResult, target: TargetCurve, sample_
         'quality_concern': clipping_assessment.quality_concern,
     }
     report['confidence'] = summarize_trustworthiness(result, report).to_dict()
+    report['hearing_compensation_applied'] = hearing_profile is not None
     return left_bands, right_bands, report
 
 
-def process_single_measurement(recording_wav: str | Path, out_dir: str | Path, sweep_spec: SweepSpec, target_path: str | Path | None = None, max_filters: int = 8, *, filter_budget: FilterBudget | None = None) -> dict:
+def process_single_measurement(recording_wav: str | Path, out_dir: str | Path, sweep_spec: SweepSpec, target_path: str | Path | None = None, max_filters: int = 8, *, filter_budget: FilterBudget | None = None, hearing_profile=None) -> dict:
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     result = analyze_measurement(recording_wav, sweep_spec, out_dir=out_dir)
     target = load_curve(target_path) if target_path else create_flat_target(result.freqs_hz)
     filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
-    left_bands, right_bands, report = fit_from_measurement(result, target, sweep_spec.sample_rate, max_filters=max_filters, filter_budget=filter_budget)
+    left_bands, right_bands, report = fit_from_measurement(result, target, sweep_spec.sample_rate, max_filters=max_filters, filter_budget=filter_budget, hearing_profile=hearing_profile)
     write_fit_artifacts(
         out_dir,
         kind='fit',
@@ -178,6 +185,173 @@ def process_single_measurement(recording_wav: str | Path, out_dir: str | Path, s
 
 def build_clone_curve(source_curve_path: str | Path, target_curve_path: str | Path, out_path: str | Path) -> TargetCurve:
     return clone_target_from_source_target(source_curve_path, target_curve_path, out_path)
+
+
+def fit_from_hearing_profile(
+    profile,
+    sample_rate: int,
+    target_path: str | Path | None = None,
+    max_filters: int = 8,
+    *,
+    filter_budget: FilterBudget | None = None,
+) -> tuple[list[PEQBand], list[PEQBand], dict]:
+    """
+    Fit PEQ bands from a hearing profile alone — no headphone measurement needed.
+
+    Assumes the headphone has a flat frequency response. The combined EQ target is:
+        eq_target(f) = target(f) + hearing_compensation(f)
+    where compensation comes from the half-gain rule (Lybarger 1944).
+    """
+    from .hearing_test import compute_compensation_curve
+    from .signals import geometric_log_grid
+
+    filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
+    freqs = geometric_log_grid(20.0, 20000.0, 512)
+    flat = np.zeros(len(freqs))
+
+    if target_path:
+        target = load_curve(target_path)
+    else:
+        target = create_flat_target(freqs)
+    target_resampled = resample_curve(target, freqs)
+    if target_resampled.semantics == 'relative':
+        target_values = flat + target_resampled.values_db
+    else:
+        target_values = target_resampled.values_db.copy()
+
+    compensation = compute_compensation_curve(profile, freqs)
+    eq_target = target_values + compensation
+
+    left_bands = fit_peq(freqs, eq_target, sample_rate, max_filters=max_filters, budget=filter_budget)
+    right_bands = fit_peq(freqs, eq_target, sample_rate, max_filters=max_filters, budget=filter_budget)
+
+    left_pred = flat + peq_chain_response_db(freqs, sample_rate, left_bands)
+    right_pred = flat + peq_chain_response_db(freqs, sample_rate, right_bands)
+    l_rms, l_max = _metrics(freqs, left_pred, eq_target)
+    r_rms, r_max = _metrics(freqs, right_pred, eq_target)
+
+    identity = get_app_identity()
+    report = {
+        'generated_by': identity.as_metadata(),
+        'mode': 'hearing_only',
+        'target': target_resampled.name,
+        'predicted_left_rms_error_db': l_rms,
+        'predicted_right_rms_error_db': r_rms,
+        'predicted_left_max_error_db': l_max,
+        'predicted_right_max_error_db': r_max,
+        'hearing_compensation_applied': True,
+        'hearing_profile_summary': {
+            'tested_at': profile.tested_at,
+            'asymmetric_freqs': profile.asymmetric_freqs,
+        },
+        'filter_budget': {
+            'family': filter_budget.family,
+            'max_filters': filter_budget.max_filters,
+            'fill_policy': filter_budget.fill_policy,
+            'profile': filter_budget.profile,
+        },
+        'left_bands': [asdict(b) for b in left_bands],
+        'right_bands': [asdict(b) for b in right_bands],
+    }
+    clipping_assessment = assess_eq_clipping(freqs, sample_rate, left_bands, right_bands)
+    report['eq_clipping'] = {
+        'will_clip': clipping_assessment.will_clip,
+        'left_peak_boost_db': clipping_assessment.left_peak_boost_db,
+        'right_peak_boost_db': clipping_assessment.right_peak_boost_db,
+        'preamp_db': clipping_assessment.total_preamp_db,
+        'headroom_loss_db': clipping_assessment.headroom_loss_db,
+        'quality_concern': clipping_assessment.quality_concern,
+    }
+    return left_bands, right_bands, report
+
+
+def _write_hearing_fit_readme(out_dir: Path, report: dict) -> None:
+    target = report.get('target', 'flat')
+    l_rms = report.get('predicted_left_rms_error_db', 0.0)
+    r_rms = report.get('predicted_right_rms_error_db', 0.0)
+    lines = [
+        "headmatch hearing-fit results",
+        "==============================",
+        "",
+        "Generated by headmatch from a hearing profile only (no headphone measurement).",
+        "The EQ target is: target curve + hearing compensation (half-gain rule, Lybarger 1944).",
+        f"Target curve: {target}",
+        f"Predicted residual: L {l_rms:.2f} dB RMS, R {r_rms:.2f} dB RMS",
+        "",
+        "Files",
+        "-----",
+        "- equalizer_apo.txt: Equalizer APO parametric preset.",
+        "- equalizer_apo_graphiceq.txt: GraphicEQ-format preset.",
+        "- camilladsp_full.yaml: Full CamillaDSP config template.",
+        "- camilladsp_filters_only.yaml: Filters-only CamillaDSP snippet.",
+        "- hearing_fit_report.json: Full fit details and filter band list.",
+        "",
+        "Notes",
+        "-----",
+        "- This preset assumes a flat headphone frequency response.",
+        "- For a more accurate result, measure your headphones and use --with-hearing-compensation.",
+        "- Re-run the hearing test periodically or when your volume setting changes.",
+    ]
+    (out_dir / RESULTS_GUIDE_NAME).write_text('\n'.join(lines) + '\n', encoding="utf-8")
+
+
+def run_hearing_fit(
+    profile,
+    out_dir: str | Path,
+    sample_rate: int = 48000,
+    target_path: str | Path | None = None,
+    max_filters: int = 8,
+    *,
+    filter_budget: FilterBudget | None = None,
+) -> dict:
+    """
+    Equipment-free EQ pipeline: hearing profile → ready-to-load EQ preset files.
+
+    Writes equalizer_apo.txt, camilladsp_full.yaml, camilladsp_filters_only.yaml,
+    equalizer_apo_graphiceq.txt, hearing_fit_report.json, and README.txt to out_dir.
+    Returns the fit report dict.
+    """
+    from .exporters import (
+        export_camilladsp_filter_snippet_yaml,
+        export_camilladsp_filters_yaml,
+        export_equalizer_apo_graphiceq_txt,
+        export_equalizer_apo_parametric_txt,
+    )
+    from .signals import geometric_log_grid
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
+
+    left_bands, right_bands, report = fit_from_hearing_profile(
+        profile, sample_rate, target_path=target_path,
+        max_filters=max_filters, filter_budget=filter_budget,
+    )
+
+    clipping = report.get('eq_clipping') if isinstance(report.get('eq_clipping'), dict) else None
+    export_equalizer_apo_parametric_txt(
+        out_dir / 'equalizer_apo.txt',
+        left_bands,
+        right_bands,
+        preamp_db=(float(clipping['preamp_db']) if clipping and clipping.get('will_clip') else None),
+    )
+    export_camilladsp_filters_yaml(out_dir / 'camilladsp_full.yaml', left_bands, right_bands, samplerate=sample_rate)
+    export_camilladsp_filter_snippet_yaml(out_dir / 'camilladsp_filters_only.yaml', left_bands, right_bands)
+
+    freqs = geometric_log_grid(20.0, 20000.0, 512)
+    left_fitted_eq = peq_chain_response_db(freqs, sample_rate, left_bands)
+    right_fitted_eq = peq_chain_response_db(freqs, sample_rate, right_bands)
+    export_equalizer_apo_graphiceq_txt(
+        out_dir / 'equalizer_apo_graphiceq.txt',
+        freqs,
+        left_fitted_eq,
+        right_fitted_eq,
+    )
+
+    save_json(out_dir / 'hearing_fit_report.json', report)
+    _write_hearing_fit_readme(out_dir, report)
+
+    return report
 
 
 def _average_measurements(results: list[MeasurementResult]) -> MeasurementResult:
@@ -215,6 +389,7 @@ def iterative_measure_and_fit(
     *,
     filter_budget: FilterBudget | None = None,
     iteration_mode: str = 'independent',
+    hearing_profile=None,
 ) -> list[dict]:
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -238,7 +413,7 @@ def iterative_measure_and_fit(
         averaged = _average_measurements(all_results)
         save_fr_csv(output_dir / 'measurement_left.csv', averaged.freqs_hz, averaged.left_db)
         save_fr_csv(output_dir / 'measurement_right.csv', averaged.freqs_hz, averaged.right_db)
-        left_bands, right_bands, report = fit_from_measurement(averaged, target_curve, sweep_spec.sample_rate, max_filters=max_filters, filter_budget=filter_budget)  # type: ignore[arg-type]
+        left_bands, right_bands, report = fit_from_measurement(averaged, target_curve, sweep_spec.sample_rate, max_filters=max_filters, filter_budget=filter_budget, hearing_profile=hearing_profile)  # type: ignore[arg-type]
         run_summary = write_fit_artifacts(
             output_dir,
             kind='fit',
@@ -256,7 +431,7 @@ def iterative_measure_and_fit(
     else:
         for i, result in enumerate(all_results, 1):
             iter_dir = output_dir / f'iter_{i:02d}'
-            left_bands, right_bands, report = fit_from_measurement(result, target_curve, sweep_spec.sample_rate, max_filters=max_filters, filter_budget=filter_budget)  # type: ignore[arg-type]
+            left_bands, right_bands, report = fit_from_measurement(result, target_curve, sweep_spec.sample_rate, max_filters=max_filters, filter_budget=filter_budget, hearing_profile=hearing_profile)  # type: ignore[arg-type]
             run_summary = write_fit_artifacts(
                 iter_dir,
                 kind='iteration',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -575,3 +575,142 @@ def test_clone_target_and_offline_commands(monkeypatch, capsys, tmp_path):
     cli.main(["analyze", "--recording", "r.wav", "--out-dir", str(tmp_path / "analysis")])
     out = capsys.readouterr().out
     assert "Analysis written" in out
+
+
+# ── hearing-fit and hearing-test --fit ───────────────────────────────────────
+
+def _make_hearing_profile():
+    from headmatch.hearing_test import (
+        NORMAL_HEARING_REFERENCE,
+        TEST_FREQUENCIES,
+        FrequencyThreshold,
+        HearingProfile,
+    )
+    side = {
+        f: FrequencyThreshold(
+            freq_hz=f,
+            level_dbfs=NORMAL_HEARING_REFERENCE[f],
+            ascending_runs=3,
+            determined=True,
+        )
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(
+        left=dict(side),
+        right=dict(side),
+        tested_at="2026-01-01T00:00:00+00:00",
+        asymmetric_freqs=[],
+    )
+
+
+def test_hearing_fit_command_dispatches_run_hearing_fit(monkeypatch, capsys, tmp_path):
+    profile = _make_hearing_profile()
+    calls = {}
+
+    monkeypatch.setattr("headmatch.hearing_test.load_hearing_profile", lambda: profile)
+    monkeypatch.setattr(
+        "headmatch.pipeline.run_hearing_fit",
+        lambda p, out_dir, **kw: calls.update({"out_dir": out_dir}) or {},
+    )
+
+    cli.main(["hearing-fit", "--out-dir", str(tmp_path / "fit")])
+
+    assert calls["out_dir"] == str(tmp_path / "fit")
+    out = capsys.readouterr().out
+    assert "hearing fit complete" in out.lower()
+
+
+def test_hearing_fit_command_json_output(monkeypatch, capsys, tmp_path):
+    profile = _make_hearing_profile()
+    out_dir = tmp_path / "fit"
+    out_dir.mkdir()
+    report = {"mode": "hearing_only", "hearing_compensation_applied": True}
+    (out_dir / "hearing_fit_report.json").write_text(
+        __import__("json").dumps(report), encoding="utf-8"
+    )
+
+    monkeypatch.setattr("headmatch.hearing_test.load_hearing_profile", lambda: profile)
+    monkeypatch.setattr("headmatch.pipeline.run_hearing_fit", lambda *a, **kw: {})
+
+    cli.main(["hearing-fit", "--out-dir", str(out_dir), "--json"])
+
+    out = capsys.readouterr().out
+    assert '"mode"' in out
+    assert "hearing_only" in out
+
+
+def test_hearing_fit_exits_when_no_saved_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr("headmatch.hearing_test.load_hearing_profile", lambda: None)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.hearing_profile_path",
+        lambda: tmp_path / "hearing_profile.json",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["hearing-fit", "--out-dir", str(tmp_path)])
+    assert exc.value.code == 2
+
+
+def test_hearing_fit_next_steps_message(capsys, tmp_path):
+    import types
+    args = types.SimpleNamespace(out_dir=str(tmp_path), cmd="hearing-fit")
+    cli.print_next_steps("hearing-fit", args)
+    out = capsys.readouterr().out
+    assert "hearing fit complete" in out.lower()
+    assert "equalizer_apo.txt" in out
+
+
+def test_hearing_test_fit_flag_runs_run_hearing_fit(monkeypatch, capsys, tmp_path):
+    profile = _make_hearing_profile()
+    fit_calls = {}
+
+    class FakeBackend:
+        def play_tone(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr("headmatch.audio_backend.get_audio_backend", lambda: FakeBackend())
+    monkeypatch.setattr(
+        "headmatch.hearing_test.run_cli_hearing_test",
+        lambda *a, **kw: profile,
+    )
+    monkeypatch.setattr(
+        "headmatch.hearing_test.save_hearing_profile",
+        lambda p: tmp_path / "hearing_profile.json",
+    )
+    monkeypatch.setattr(
+        "headmatch.pipeline.run_hearing_fit",
+        lambda p, out_dir, **kw: fit_calls.update({"out_dir": out_dir}) or {},
+    )
+
+    out_dir = str(tmp_path / "eq")
+    cli.main(["hearing-test", "--fit", "--out-dir", out_dir])
+
+    assert fit_calls.get("out_dir") == out_dir
+    out = capsys.readouterr().out
+    assert "Generating EQ preset" in out
+    assert "Done. EQ files written" in out
+
+
+def test_hearing_test_fit_flag_uses_default_out_dir_when_omitted(monkeypatch, capsys, tmp_path):
+    profile = _make_hearing_profile()
+    fit_calls = {}
+
+    class FakeBackend:
+        def play_tone(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr("headmatch.audio_backend.get_audio_backend", lambda: FakeBackend())
+    monkeypatch.setattr("headmatch.hearing_test.run_cli_hearing_test", lambda *a, **kw: profile)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.save_hearing_profile",
+        lambda p: tmp_path / "hearing_profile.json",
+    )
+    monkeypatch.setattr(
+        "headmatch.pipeline.run_hearing_fit",
+        lambda p, out_dir, **kw: fit_calls.update({"out_dir": out_dir}) or {},
+    )
+
+    cli.main(["hearing-test", "--fit"])
+
+    assert "out_dir" in fit_calls
+    assert "hearing_fit" in fit_calls["out_dir"]

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -209,6 +209,7 @@ def test_load_gui_state_uses_safe_defaults_when_config_is_empty(tmp_path):
 def test_navigation_items_cover_shell_sections():
     assert [item.key for item in NAV_ITEMS] == [
         "measure-online",
+        "hearing-test",
         "setup-check",
         "prepare-offline",
         "target-editor",
@@ -217,7 +218,7 @@ def test_navigation_items_cover_shell_sections():
         "history",
     ]
     assert [item.label for item in NAV_ITEMS] == [
-        "Measure", "Setup Check", "Prepare Offline",
+        "Measure", "Hearing Test", "Setup Check", "Prepare Offline",
         "Target Editor", "Import APO", "Fetch Curve", "Results",
     ]
 
@@ -489,7 +490,7 @@ def test_create_app_builds_shell_on_fake_root(tmp_path, fake_tk, monkeypatch):
     assert root.minsize_value == (880, 560)
     assert app.history_root_var.get() == str(tmp_path / 'out')
     assert app.offline_fit_output_var.get().endswith('fit')
-    assert nav_labels == ['Measure', 'Setup Check', 'Prepare Offline', 'Target Editor', 'Import APO', 'Fetch Curve', 'Results']
+    assert nav_labels == ['Measure', 'Hearing Test', 'Setup Check', 'Prepare Offline', 'Target Editor', 'Import APO', 'Fetch Curve', 'Results']
     assert all('\n' not in label for label in nav_labels)
 
 
@@ -1116,3 +1117,139 @@ class TestCurvePreviewWithAddedPoints:
         _render_curve_preview(canvas, editor)
         ovals = [i for i in canvas.items if i[0] == 'oval']
         assert len(ovals) == 2
+
+
+# ── _show_hearing_followup / _start_hearing_fit ───────────────────────────────
+
+def _make_hearing_profile_for_gui():
+    from headmatch.hearing_test import (
+        NORMAL_HEARING_REFERENCE,
+        TEST_FREQUENCIES,
+        FrequencyThreshold,
+        HearingProfile,
+    )
+    side = {
+        f: FrequencyThreshold(
+            freq_hz=f,
+            level_dbfs=NORMAL_HEARING_REFERENCE[f],
+            ascending_runs=3,
+            determined=True,
+        )
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(
+        left=dict(side),
+        right=dict(side),
+        tested_at="2026-01-01T00:00:00+00:00",
+        asymmetric_freqs=[],
+    )
+
+
+def test_show_hearing_followup_renders_two_buttons():
+    from headmatch.gui.shell import HeadMatchGuiApp
+
+    profile = _make_hearing_profile_for_gui()
+    ttk = RecordingTtk()
+    content = DummyWidget()
+    commands = {}
+
+    app = SimpleNamespace(
+        hearing_profile=None,
+        content=content,
+        _ttk=ttk,
+        state=SimpleNamespace(default_output_dir="/tmp/hm/session_01"),
+        show_view=lambda key: commands.setdefault("show_view", key),
+        _start_hearing_fit=lambda p, out: commands.update({"start_fit": out}),
+    )
+
+    HeadMatchGuiApp._show_hearing_followup(app, profile)
+
+    buttons = [w for w in ttk.created if getattr(w, "kind", None) == "Button"]
+    assert len(buttons) >= 2
+    labels = [w.kwargs.get("text", "") for w in buttons]
+    assert any("Generate" in lbl or "EQ" in lbl for lbl in labels)
+    assert any("Measurement" in lbl or "Measure" in lbl for lbl in labels)
+
+
+def test_show_hearing_followup_generate_button_calls_start_hearing_fit():
+    from headmatch.gui.shell import HeadMatchGuiApp
+
+    profile = _make_hearing_profile_for_gui()
+    ttk = RecordingTtk()
+    content = DummyWidget()
+    calls = {}
+
+    app = SimpleNamespace(
+        content=content,
+        _ttk=ttk,
+        state=SimpleNamespace(default_output_dir="/tmp/hm/session_01"),
+        show_view=lambda key: None,
+        _start_hearing_fit=lambda p, out: calls.update({"profile": p, "out": out}),
+    )
+
+    HeadMatchGuiApp._show_hearing_followup(app, profile)
+
+    generate_btn = next(
+        (w for w in ttk.created if getattr(w, "kind", None) == "Button"
+         and ("Generate" in (w.kwargs.get("text") or "") or "EQ" in (w.kwargs.get("text") or ""))),
+        None,
+    )
+    assert generate_btn is not None
+    generate_btn.command()
+
+    assert "out" in calls
+    assert "hearing_fit" in calls["out"]
+
+
+def test_show_hearing_followup_measure_button_navigates_to_measure_online():
+    from headmatch.gui.shell import HeadMatchGuiApp
+
+    profile = _make_hearing_profile_for_gui()
+    ttk = RecordingTtk()
+    content = DummyWidget()
+    navigated = {}
+
+    app = SimpleNamespace(
+        content=content,
+        _ttk=ttk,
+        state=SimpleNamespace(default_output_dir="/tmp/hm/session_01"),
+        show_view=lambda key: navigated.update({"key": key}),
+        _start_hearing_fit=lambda *a: None,
+    )
+
+    HeadMatchGuiApp._show_hearing_followup(app, profile)
+
+    measure_btn = next(
+        (w for w in ttk.created if getattr(w, "kind", None) == "Button"
+         and ("Measurement" in (w.kwargs.get("text") or "") or "Measure" in (w.kwargs.get("text") or ""))),
+        None,
+    )
+    assert measure_btn is not None
+    measure_btn.command()
+
+    assert navigated.get("key") == "measure-online"
+
+
+def test_start_hearing_fit_runs_background_task(monkeypatch):
+    from headmatch.gui.shell import HeadMatchGuiApp
+
+    profile = _make_hearing_profile_for_gui()
+    fit_calls = {}
+
+    monkeypatch.setattr(
+        "headmatch.pipeline.run_hearing_fit",
+        lambda p, out_dir, **kw: fit_calls.update({"out_dir": out_dir}) or {},
+    )
+
+    bg_calls = {}
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(sample_rate=48000),
+        _run_background_task=lambda **kw: bg_calls.update(kw) or kw["worker"](),
+        _set_completion=lambda **kw: None,
+    )
+
+    HeadMatchGuiApp._start_hearing_fit(app, profile, "/tmp/hearing_fit")
+
+    assert fit_calls.get("out_dir") == "/tmp/hearing_fit"
+    assert bg_calls.get("task_name") == "hearing-fit"

--- a/tests/test_hearing_compensation.py
+++ b/tests/test_hearing_compensation.py
@@ -1,0 +1,138 @@
+"""Integration tests: hearing compensation through the pipeline."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from headmatch.hearing_test import (
+    NORMAL_HEARING_REFERENCE,
+    TEST_FREQUENCIES,
+    FrequencyThreshold,
+    HearingProfile,
+    compute_compensation_curve,
+)
+from headmatch.pipeline import fit_from_measurement
+from headmatch.signals import geometric_log_grid
+from headmatch.targets import create_flat_target
+from headmatch.analysis import MeasurementResult
+
+
+def _flat_result(n: int = 512) -> MeasurementResult:
+    freqs = geometric_log_grid(20.0, 20000.0, 48)[:n]
+    flat = np.zeros(len(freqs))
+    return MeasurementResult(
+        freqs_hz=freqs,
+        left_db=flat.copy(),
+        right_db=flat.copy(),
+        left_raw_db=flat.copy(),
+        right_raw_db=flat.copy(),
+        diagnostics={
+            "alignment_reference_score": 1.0,
+            "alignment_peak_ratio": 1.0,
+            "channel_mismatch_rms_db": 0.0,
+            "left_roughness_db": 0.0,
+            "right_roughness_db": 0.0,
+            "capture_rms_dbfs": -20.0,
+        },
+    )
+
+
+def _make_profile(loss_db: float = 0.0) -> HearingProfile:
+    side = {
+        f: FrequencyThreshold(
+            freq_hz=f,
+            level_dbfs=NORMAL_HEARING_REFERENCE[f] + loss_db,
+            ascending_runs=3,
+            determined=True,
+        )
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(
+        left=dict(side),
+        right=dict(side),
+        tested_at="2026-01-01T00:00:00+00:00",
+        asymmetric_freqs=[],
+    )
+
+
+class TestHearingCompensationInPipeline:
+    def test_no_compensation_without_profile(self):
+        result = _flat_result()
+        target = create_flat_target(result.freqs_hz)
+        left_bands, right_bands, report = fit_from_measurement(
+            result, target, sample_rate=48000, max_filters=4
+        )
+        assert report["hearing_compensation_applied"] is False
+
+    def test_compensation_applied_flag_when_profile_present(self):
+        result = _flat_result()
+        target = create_flat_target(result.freqs_hz)
+        profile = _make_profile(loss_db=0.0)
+        _, _, report = fit_from_measurement(
+            result, target, sample_rate=48000, max_filters=4,
+            hearing_profile=profile,
+        )
+        assert report["hearing_compensation_applied"] is True
+
+    def test_normal_hearing_produces_near_flat_target(self):
+        """For a person at the normal hearing reference, compensation ≈ 0 dB → same EQ as without."""
+        result = _flat_result()
+        target = create_flat_target(result.freqs_hz)
+        profile = _make_profile(loss_db=0.0)
+
+        left_no_comp, _, _ = fit_from_measurement(result, target, sample_rate=48000, max_filters=4)
+        left_with_comp, _, _ = fit_from_measurement(
+            result, target, sample_rate=48000, max_filters=4,
+            hearing_profile=profile,
+        )
+        # With 0 dB compensation, both fits should be very similar
+        from headmatch.peq import peq_chain_response_db
+        r_no = peq_chain_response_db(result.freqs_hz, 48000, left_no_comp)
+        r_with = peq_chain_response_db(result.freqs_hz, 48000, left_with_comp)
+        diff = np.abs(r_with - r_no)
+        assert float(np.max(diff)) < 3.0  # within 3 dB
+
+    def test_20dB_loss_shifts_eq_upward(self):
+        """20 dB loss → half-gain = 10 dB compensation → EQ bands boosted."""
+        result = _flat_result()
+        target = create_flat_target(result.freqs_hz)
+        profile = _make_profile(loss_db=20.0)
+
+        left_no_comp, _, _ = fit_from_measurement(result, target, sample_rate=48000, max_filters=8)
+        left_with_comp, _, _ = fit_from_measurement(
+            result, target, sample_rate=48000, max_filters=8,
+            hearing_profile=profile,
+        )
+        from headmatch.peq import peq_chain_response_db
+        r_no = peq_chain_response_db(result.freqs_hz, 48000, left_no_comp)
+        r_with = peq_chain_response_db(result.freqs_hz, 48000, left_with_comp)
+
+        # The compensated version should have more total boost
+        mask = (result.freqs_hz >= 500) & (result.freqs_hz <= 8000)
+        boost_no = float(np.mean(r_no[mask]))
+        boost_with = float(np.mean(r_with[mask]))
+        assert boost_with > boost_no
+
+
+class TestComputeCompensationCurveProperties:
+    def test_monotonic_with_loss(self):
+        """More loss → more compensation (checked at 1 kHz)."""
+        grid = geometric_log_grid(20.0, 20000.0, 48)
+        gains = []
+        for loss in (0.0, 10.0, 20.0, 30.0):
+            profile = _make_profile(loss_db=loss)
+            comp = compute_compensation_curve(profile, grid)
+            # Pick the grid point nearest 1 kHz
+            idx = int(np.argmin(np.abs(grid - 1000.0)))
+            gains.append(float(comp[idx]))
+        assert gains[0] <= gains[1] <= gains[2] <= gains[3]
+
+    def test_gain_fraction_relationship(self):
+        """At exactly 20 dB loss, expected gain at 1 kHz ≈ 10 dB (before smoothing)."""
+        from headmatch.hearing_test import GAIN_FRACTION
+        grid = np.array([1000.0])
+        profile = _make_profile(loss_db=20.0)
+        comp = compute_compensation_curve(profile, grid)
+        expected = 20.0 * GAIN_FRACTION
+        # Within 2 dB due to interpolation and smoothing
+        assert abs(float(comp[0]) - expected) < 2.0

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -1,0 +1,215 @@
+"""Tests for the equipment-free hearing-fit pipeline."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from headmatch.hearing_test import (
+    NORMAL_HEARING_REFERENCE,
+    TEST_FREQUENCIES,
+    FrequencyThreshold,
+    HearingProfile,
+)
+from headmatch.pipeline import fit_from_hearing_profile, run_hearing_fit
+
+
+def _make_profile(loss_db: float = 0.0) -> HearingProfile:
+    side = {
+        f: FrequencyThreshold(
+            freq_hz=f,
+            level_dbfs=NORMAL_HEARING_REFERENCE[f] + loss_db,
+            ascending_runs=3,
+            determined=True,
+        )
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(
+        left=dict(side),
+        right=dict(side),
+        tested_at="2026-01-01T00:00:00+00:00",
+        asymmetric_freqs=[],
+    )
+
+
+class TestFitFromHearingProfile:
+    def test_returns_band_lists_and_report(self):
+        profile = _make_profile(loss_db=10.0)
+        left_bands, right_bands, report = fit_from_hearing_profile(
+            profile, sample_rate=48000, max_filters=4
+        )
+        assert isinstance(left_bands, list)
+        assert isinstance(right_bands, list)
+        assert isinstance(report, dict)
+
+    def test_mode_is_hearing_only(self):
+        profile = _make_profile()
+        _, _, report = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=4)
+        assert report["mode"] == "hearing_only"
+
+    def test_compensation_flag_set(self):
+        profile = _make_profile()
+        _, _, report = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=4)
+        assert report["hearing_compensation_applied"] is True
+
+    def test_report_has_predicted_error(self):
+        profile = _make_profile(loss_db=10.0)
+        _, _, report = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=4)
+        assert "predicted_left_rms_error_db" in report
+        assert "predicted_right_rms_error_db" in report
+        assert isinstance(report["predicted_left_rms_error_db"], float)
+
+    def test_report_has_eq_clipping(self):
+        profile = _make_profile(loss_db=10.0)
+        _, _, report = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=4)
+        assert "eq_clipping" in report
+        assert "will_clip" in report["eq_clipping"]
+
+    def test_report_has_hearing_profile_summary(self):
+        profile = _make_profile()
+        _, _, report = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=4)
+        assert "hearing_profile_summary" in report
+        assert report["hearing_profile_summary"]["tested_at"] == "2026-01-01T00:00:00+00:00"
+
+    def test_normal_hearing_gives_small_boost(self):
+        """Normal hearing → near-zero compensation → near-flat EQ with flat target."""
+        from headmatch.peq import peq_chain_response_db
+        from headmatch.signals import geometric_log_grid
+        profile = _make_profile(loss_db=0.0)
+        left_bands, _, _ = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=8)
+        grid = geometric_log_grid(200.0, 8000.0, 48)
+        resp = peq_chain_response_db(grid, 48000, left_bands)
+        assert float(np.max(np.abs(resp))) < 2.0  # very near flat
+
+    def test_20dB_loss_produces_boost(self):
+        """20 dB hearing loss → ~10 dB half-gain compensation → EQ bands with positive gain."""
+        from headmatch.peq import peq_chain_response_db
+        from headmatch.signals import geometric_log_grid
+        profile = _make_profile(loss_db=20.0)
+        left_bands, _, _ = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=8)
+        grid = geometric_log_grid(500.0, 8000.0, 48)
+        resp = peq_chain_response_db(grid, 48000, left_bands)
+        assert float(np.mean(resp)) > 1.0
+
+    def test_symmetric_left_right_bands(self):
+        """Symmetric hearing profile → left and right bands identical."""
+        profile = _make_profile(loss_db=15.0)
+        left_bands, right_bands, _ = fit_from_hearing_profile(
+            profile, sample_rate=48000, max_filters=4
+        )
+        assert len(left_bands) == len(right_bands)
+        for lb, rb in zip(left_bands, right_bands):
+            assert lb.freq == pytest.approx(rb.freq, abs=0.1)
+            assert lb.gain_db == pytest.approx(rb.gain_db, abs=0.01)
+
+    def test_with_target_csv(self, tmp_path):
+        """Passing a target CSV path is accepted and runs without error."""
+        csv = tmp_path / "target.csv"
+        csv.write_text("frequency_hz,response_db\n20,0\n1000,0\n20000,0\n", encoding="utf-8")
+        profile = _make_profile(loss_db=10.0)
+        left_bands, _, report = fit_from_hearing_profile(
+            profile, sample_rate=48000, max_filters=4, target_path=csv
+        )
+        assert isinstance(left_bands, list)
+        assert isinstance(report["target"], str)
+
+    def test_filter_budget_respected(self):
+        from headmatch.peq import FilterBudget
+        profile = _make_profile(loss_db=20.0)
+        budget = FilterBudget(max_filters=2, fill_policy="exact_n")
+        left_bands, right_bands, _ = fit_from_hearing_profile(
+            profile, sample_rate=48000, max_filters=2, filter_budget=budget
+        )
+        assert len(left_bands) <= 2
+        assert len(right_bands) <= 2
+
+
+class TestRunHearingFit:
+    def _profile(self, loss_db: float = 10.0) -> HearingProfile:
+        return _make_profile(loss_db=loss_db)
+
+    def test_writes_all_expected_files(self, tmp_path):
+        profile = self._profile()
+        run_hearing_fit(profile, tmp_path, sample_rate=48000)
+        assert (tmp_path / "equalizer_apo.txt").exists()
+        assert (tmp_path / "equalizer_apo_graphiceq.txt").exists()
+        assert (tmp_path / "camilladsp_full.yaml").exists()
+        assert (tmp_path / "camilladsp_filters_only.yaml").exists()
+        assert (tmp_path / "hearing_fit_report.json").exists()
+        assert (tmp_path / "README.txt").exists()
+
+    def test_report_json_valid(self, tmp_path):
+        profile = self._profile()
+        run_hearing_fit(profile, tmp_path, sample_rate=48000)
+        data = json.loads((tmp_path / "hearing_fit_report.json").read_text(encoding="utf-8"))
+        assert data["mode"] == "hearing_only"
+        assert data["hearing_compensation_applied"] is True
+        assert "left_bands" in data
+        assert "right_bands" in data
+        assert "eq_clipping" in data
+
+    def test_returns_report_dict(self, tmp_path):
+        profile = self._profile()
+        result = run_hearing_fit(profile, tmp_path, sample_rate=48000)
+        assert isinstance(result, dict)
+        assert "mode" in result
+
+    def test_creates_output_dir(self, tmp_path):
+        profile = self._profile()
+        out = tmp_path / "nested" / "hearing_fit"
+        run_hearing_fit(profile, out, sample_rate=48000)
+        assert out.is_dir()
+        assert (out / "equalizer_apo.txt").exists()
+
+    def test_readme_contains_key_info(self, tmp_path):
+        profile = self._profile(loss_db=20.0)
+        run_hearing_fit(profile, tmp_path, sample_rate=48000)
+        readme = (tmp_path / "README.txt").read_text(encoding="utf-8")
+        assert "hearing_only" in readme or "hearing-fit" in readme or "hearing profile" in readme.lower()
+        assert "equalizer_apo.txt" in readme
+
+    def test_with_target_csv(self, tmp_path):
+        csv = tmp_path / "target.csv"
+        csv.write_text("frequency_hz,response_db\n20,0\n1000,0\n20000,0\n", encoding="utf-8")
+        out = tmp_path / "fit"
+        profile = self._profile()
+        run_hearing_fit(profile, out, sample_rate=48000, target_path=csv)
+        assert (out / "equalizer_apo.txt").exists()
+
+    def test_equalizer_apo_parametric_format(self, tmp_path):
+        profile = self._profile(loss_db=15.0)
+        run_hearing_fit(profile, tmp_path, sample_rate=48000)
+        content = (tmp_path / "equalizer_apo.txt").read_text(encoding="utf-8")
+        assert "Filter" in content or "Preamp" in content
+
+
+class TestFitFromHearingProfileRelativeTarget:
+    """Cover the 'relative' semantics branch in fit_from_hearing_profile."""
+
+    def test_relative_semantics_target_csv(self, tmp_path):
+        csv = tmp_path / "clone_something_to_other.csv"
+        csv.write_text(
+            "# headmatch_target_semantics=relative\nfrequency_hz,response_db\n20,0\n1000,0\n20000,0\n",
+            encoding="utf-8",
+        )
+        side = {
+            f: FrequencyThreshold(
+                freq_hz=f,
+                level_dbfs=NORMAL_HEARING_REFERENCE[f] + 10.0,
+                ascending_runs=3,
+                determined=True,
+            )
+            for f in TEST_FREQUENCIES
+        }
+        profile = HearingProfile(
+            left=dict(side), right=dict(side),
+            tested_at="2026-01-01T00:00:00+00:00",
+            asymmetric_freqs=[],
+        )
+        left_bands, right_bands, report = fit_from_hearing_profile(
+            profile, sample_rate=48000, max_filters=4, target_path=csv
+        )
+        assert isinstance(left_bands, list)
+        assert report["hearing_compensation_applied"] is True

--- a/tests/test_hearing_test.py
+++ b/tests/test_hearing_test.py
@@ -1,0 +1,323 @@
+"""Tests for the hearing threshold engine and tone generation."""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from headmatch.hearing_test import (
+    GAIN_FRACTION,
+    MAX_ASCENDING_RUNS,
+    MAX_COMPENSATION_DB,
+    NORMAL_HEARING_REFERENCE,
+    RAMP_DURATION_S,
+    START_LEVEL_DBFS,
+    STEP_DOWN_DB,
+    STEP_UP_DB,
+    TEST_FREQUENCIES,
+    TEST_ORDER,
+    TONE_DURATION_S,
+    FrequencyThreshold,
+    HearingProfile,
+    ThresholdEngine,
+    compute_compensation_curve,
+    detect_asymmetric_frequencies,
+    generate_tone,
+    load_hearing_profile,
+    save_hearing_profile,
+)
+from headmatch.signals import geometric_log_grid
+
+
+# ── ThresholdEngine ───────────────────────────────────────────────────────────
+
+class TestThresholdEngine:
+    def test_starts_at_start_level(self):
+        e = ThresholdEngine(1000)
+        assert e.current_level_dbfs == START_LEVEL_DBFS
+
+    def test_step_down_after_heard(self):
+        e = ThresholdEngine(1000)
+        level_before = e.current_level_dbfs
+        e.record_response(True)
+        assert e.current_level_dbfs == pytest.approx(level_before - STEP_DOWN_DB)
+
+    def test_step_up_after_miss(self):
+        e = ThresholdEngine(1000)
+        e.record_response(True)  # step down first
+        level_before = e.current_level_dbfs
+        e.record_response(False)
+        assert e.current_level_dbfs == pytest.approx(level_before + STEP_UP_DB)
+
+    def test_stable_threshold_at_same_level_3_times(self):
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        # Drive to a stable threshold: simulate a perfect listener at -50 dBFS
+        target = -50.0
+        for _ in range(20):
+            if e.done:
+                break
+            heard = e.current_level_dbfs >= target
+            e.record_response(heard)
+        assert e.done
+        assert e.threshold is not None
+        # Threshold should be at or near target within step resolution
+        assert e.threshold <= target + STEP_UP_DB + 1.0
+
+    def test_threshold_not_declared_before_3_ascending_runs(self):
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        # Manually drive 2 ascending runs at same level
+        # Simulate: hear → down → miss → up → hear (run 1) → down → miss → up → hear (run 2)
+        e.record_response(True)    # hear at -30; step down to -40; not ascending
+        e.record_response(False)   # miss at -40; step up to -35; ascending
+        e.record_response(True)    # hear at -35; run 1; step down to -45
+        assert not e.done
+        e.record_response(False)   # miss at -45; step up to -40
+        e.record_response(True)    # hear at -40; run 2; step down to -50
+        assert not e.done  # need 3 runs minimum
+
+    def test_max_runs_terminates(self):
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        # Force MAX_ASCENDING_RUNS by always hearing at different levels
+        level = -30.0
+        for _ in range(MAX_ASCENDING_RUNS * 3):
+            if e.done:
+                break
+            # Alternate miss/hear to keep ascending run count rising
+            e.record_response(False)
+            if e.done:
+                break
+            e.record_response(True)
+        assert e.done
+
+    def test_not_done_initially(self):
+        e = ThresholdEngine(1000)
+        assert not e.done
+
+    def test_ascending_run_count_increments(self):
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        e.record_response(True)   # not ascending
+        e.record_response(False)  # ascending
+        e.record_response(True)   # ascending run 1
+        assert e.ascending_run_count == 1
+
+    def test_record_after_done_is_noop(self):
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        target = -50.0
+        for _ in range(30):
+            if e.done:
+                break
+            e.record_response(e.current_level_dbfs >= target)
+        assert e.done
+        level_after = e.current_level_dbfs
+        threshold_after = e.threshold
+        e.record_response(True)
+        assert e.current_level_dbfs == level_after
+        assert e.threshold == threshold_after
+
+
+# ── generate_tone ─────────────────────────────────────────────────────────────
+
+class TestGenerateTone:
+    def test_shape_is_stereo(self):
+        samples = generate_tone(1000, -20.0, sample_rate=48000)
+        expected_n = int(round(TONE_DURATION_S * 48000))
+        assert samples.shape == (expected_n, 2)
+
+    def test_dtype_is_float64(self):
+        samples = generate_tone(1000, -20.0)
+        assert samples.dtype == np.float64
+
+    def test_level_scales_rms(self):
+        samples_loud = generate_tone(1000, -6.0, sample_rate=48000)
+        samples_quiet = generate_tone(1000, -20.0, sample_rate=48000)
+        rms_loud = np.sqrt(np.mean(samples_loud ** 2))
+        rms_quiet = np.sqrt(np.mean(samples_quiet ** 2))
+        # 14 dB difference expected (within 1 dB due to ramps)
+        ratio_db = 20 * np.log10(rms_loud / rms_quiet)
+        assert abs(ratio_db - 14.0) < 1.5
+
+    def test_ramps_reduce_clicks(self):
+        samples = generate_tone(1000, -6.0, sample_rate=48000)
+        n_ramp = int(round(RAMP_DURATION_S * 48000))
+        # First and last sample should be near zero (ramp effect)
+        assert abs(float(samples[0, 0])) < 0.001
+        assert abs(float(samples[-1, 0])) < 0.001
+
+    def test_channels_are_identical(self):
+        samples = generate_tone(2000, -30.0)
+        np.testing.assert_array_equal(samples[:, 0], samples[:, 1])
+
+    def test_frequency_content(self):
+        sr = 48000
+        samples = generate_tone(1000, -6.0, sample_rate=sr)
+        mono = samples[:, 0]
+        fft = np.abs(np.fft.rfft(mono))
+        freqs = np.fft.rfftfreq(len(mono), d=1.0 / sr)
+        peak_freq = freqs[np.argmax(fft)]
+        # Peak should be within a few Hz of 1000 Hz
+        assert abs(peak_freq - 1000.0) < 20.0
+
+
+# ── compute_compensation_curve ────────────────────────────────────────────────
+
+def _make_profile(thresholds_dbfs: dict[int, float]) -> HearingProfile:
+    """Helper: build a symmetric HearingProfile from a freq→level dict."""
+    side = {
+        f: FrequencyThreshold(freq_hz=f, level_dbfs=t, ascending_runs=3, determined=True)
+        for f, t in thresholds_dbfs.items()
+    }
+    return HearingProfile(left=dict(side), right=dict(side), tested_at="2026-01-01T00:00:00+00:00", asymmetric_freqs=[])
+
+
+class TestComputeCompensationCurve:
+    def _grid(self):
+        return geometric_log_grid(100.0, 20000.0, 48)
+
+    def test_flat_at_reference_gives_zero_gain(self):
+        """A person with normal hearing (thresholds at reference) gets 0 dB compensation."""
+        grid = self._grid()
+        profile = _make_profile(NORMAL_HEARING_REFERENCE)
+        comp = compute_compensation_curve(profile, grid)
+        assert np.all(comp >= 0.0)
+        assert np.max(comp) < 0.5  # near zero
+
+    def test_20dB_loss_gives_10dB_gain(self):
+        """Half-gain rule: 20 dB of loss → 10 dB of gain."""
+        grid = self._grid()
+        thresholds = {f: NORMAL_HEARING_REFERENCE[f] + 20.0 for f in TEST_FREQUENCIES}
+        profile = _make_profile(thresholds)
+        comp = compute_compensation_curve(profile, grid)
+        # Near 1-4 kHz the compensation should be around 10 dB
+        mask = (grid >= 1000) & (grid <= 4000)
+        avg_in_band = float(np.mean(comp[mask]))
+        assert 7.0 < avg_in_band <= MAX_COMPENSATION_DB
+
+    def test_gain_capped_at_max(self):
+        """Extreme loss should be capped at MAX_COMPENSATION_DB."""
+        grid = self._grid()
+        thresholds = {f: NORMAL_HEARING_REFERENCE[f] + 100.0 for f in TEST_FREQUENCIES}
+        profile = _make_profile(thresholds)
+        comp = compute_compensation_curve(profile, grid)
+        assert np.all(comp <= MAX_COMPENSATION_DB + 0.01)  # small tolerance for smoothing
+
+    def test_no_negative_gain(self):
+        """Never apply negative EQ compensation (no cuts below reference)."""
+        grid = self._grid()
+        thresholds = {f: NORMAL_HEARING_REFERENCE[f] - 10.0 for f in TEST_FREQUENCIES}
+        profile = _make_profile(thresholds)
+        comp = compute_compensation_curve(profile, grid)
+        assert np.all(comp >= 0.0)
+
+    def test_returns_zeros_for_undetermined_profile(self):
+        """If no frequencies are determined, return a zero array."""
+        grid = self._grid()
+        side = {
+            f: FrequencyThreshold(freq_hz=f, level_dbfs=None, ascending_runs=0, determined=False)
+            for f in TEST_FREQUENCIES
+        }
+        profile = HearingProfile(left=dict(side), right=dict(side), tested_at="2026-01-01T00:00:00+00:00", asymmetric_freqs=[])
+        comp = compute_compensation_curve(profile, grid)
+        assert np.all(comp == 0.0)
+
+    def test_output_length_matches_grid(self):
+        grid = self._grid()
+        profile = _make_profile(NORMAL_HEARING_REFERENCE)
+        comp = compute_compensation_curve(profile, grid)
+        assert len(comp) == len(grid)
+
+    def test_left_only_profile(self):
+        """Profile with only left ear determined should still produce compensation."""
+        grid = self._grid()
+        thresholds = {f: NORMAL_HEARING_REFERENCE[f] + 20.0 for f in TEST_FREQUENCIES}
+        left = {
+            f: FrequencyThreshold(freq_hz=f, level_dbfs=t, ascending_runs=3, determined=True)
+            for f, t in thresholds.items()
+        }
+        right = {
+            f: FrequencyThreshold(freq_hz=f, level_dbfs=None, ascending_runs=0, determined=False)
+            for f in TEST_FREQUENCIES
+        }
+        profile = HearingProfile(left=left, right=right, tested_at="2026-01-01T00:00:00+00:00", asymmetric_freqs=[])
+        comp = compute_compensation_curve(profile, grid)
+        assert np.max(comp) > 1.0
+
+
+# ── detect_asymmetric_frequencies ────────────────────────────────────────────
+
+class TestDetectAsymmetricFrequencies:
+    def _t(self, freq_hz: int, level: float) -> FrequencyThreshold:
+        return FrequencyThreshold(freq_hz=freq_hz, level_dbfs=level, ascending_runs=3, determined=True)
+
+    def test_symmetric_gives_empty(self):
+        left = {f: self._t(f, -40.0) for f in TEST_FREQUENCIES}
+        right = {f: self._t(f, -40.0) for f in TEST_FREQUENCIES}
+        assert detect_asymmetric_frequencies(left, right) == []
+
+    def test_large_gap_detected(self):
+        left = {f: self._t(f, -40.0) for f in TEST_FREQUENCIES}
+        right = {f: self._t(f, -40.0) for f in TEST_FREQUENCIES}
+        right[4000] = self._t(4000, -20.0)  # 20 dB gap
+        result = detect_asymmetric_frequencies(left, right)
+        assert 4000 in result
+
+    def test_small_gap_not_flagged(self):
+        left = {f: self._t(f, -40.0) for f in TEST_FREQUENCIES}
+        right = {f: self._t(f, -40.0) for f in TEST_FREQUENCIES}
+        right[1000] = self._t(1000, -33.0)  # 7 dB gap — below threshold
+        result = detect_asymmetric_frequencies(left, right)
+        assert 1000 not in result
+
+
+# ── HearingProfile serialisation ──────────────────────────────────────────────
+
+class TestHearingProfileSerialisation:
+    def _sample_profile(self) -> HearingProfile:
+        side = {
+            f: FrequencyThreshold(freq_hz=f, level_dbfs=-40.0, ascending_runs=3, determined=True)
+            for f in TEST_FREQUENCIES
+        }
+        return HearingProfile(
+            left=dict(side),
+            right=dict(side),
+            tested_at="2026-01-01T00:00:00+00:00",
+            asymmetric_freqs=[],
+        )
+
+    def test_round_trip(self):
+        profile = self._sample_profile()
+        data = profile.to_dict()
+        restored = HearingProfile.from_dict(data)
+        assert restored.tested_at == profile.tested_at
+        assert restored.asymmetric_freqs == profile.asymmetric_freqs
+        for freq_hz in TEST_FREQUENCIES:
+            orig = profile.left[freq_hz]
+            rest = restored.left[freq_hz]
+            assert orig.freq_hz == rest.freq_hz
+            assert orig.level_dbfs == pytest.approx(rest.level_dbfs)
+            assert orig.determined == rest.determined
+
+    def test_json_serialisable(self):
+        profile = self._sample_profile()
+        data = profile.to_dict()
+        text = json.dumps(data)
+        assert isinstance(text, str)
+        assert "tested_at" in text
+
+    def test_save_load(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("headmatch.hearing_test.config_dir", lambda: tmp_path)
+        profile = self._sample_profile()
+        path = save_hearing_profile(profile)
+        assert path.exists()
+        loaded = load_hearing_profile()
+        assert loaded is not None
+        assert loaded.tested_at == profile.tested_at
+
+    def test_load_returns_none_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("headmatch.hearing_test.config_dir", lambda: tmp_path)
+        assert load_hearing_profile() is None
+
+    def test_load_returns_none_on_corrupt_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("headmatch.hearing_test.config_dir", lambda: tmp_path)
+        (tmp_path / "hearing_profile.json").write_text("not valid json", encoding="utf-8")
+        assert load_hearing_profile() is None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -262,7 +262,7 @@ def test_average_iteration_mode_runs_passes_consecutively_before_averaging(monke
             diagnostics={'alignment_score': float(index)},
         )
 
-    def fake_fit_from_measurement(result, target, sample_rate, *, max_filters, filter_budget):
+    def fake_fit_from_measurement(result, target, sample_rate, *, max_filters, filter_budget, hearing_profile=None):
         call_order.append(('fit', int(result.left_db[0])))
         return [], [], {'predicted_error_db': {'left_rms': 0.1, 'right_rms': 0.1, 'left_max': 0.2, 'right_max': 0.2}}
 


### PR DESCRIPTION
## Summary

- **Hearing threshold test**: Modified Hughson-Westlake pure-tone audiometry (Carhart & Jerger 1959, public domain) across 7 ISO 8253-1 frequencies per ear. Stores a `HearingProfile` to the config directory.
- **EQ compensation**: Half-gain rule (Lybarger 1944, public domain) converts measured thresholds to per-frequency gain, interpolated via cubic spline + 1-octave Gaussian smoothing.
- **Equipment-free pipeline**: `headmatch hearing-fit --out-dir <dir>` generates a complete EQ preset from a hearing profile alone — no microphone or measurement device required. Assumes flat headphone response.
- **Full pipeline integration**: `headmatch fit --with-hearing-compensation` folds compensation into the target curve before fitting, leaving all existing analysis and confidence scoring untouched.
- **GUI**: Hearing Test nav item with interactive tone-response loop; post-test screen offers "Generate EQ Preset Now" or "Run a Measurement".
- **Architecture doc**: `docs/designs/hearing-personalization.md` with full scientific references (ISO 7029:2017, ISO 8253-1, CTA-2118 2023).
- **54 new tests** — 672 total, 0 regressions.

## New CLI surface

```bash
headmatch hearing-test [--fit --out-dir DIR]
headmatch hearing-fit --out-dir DIR [--target-csv FILE]
headmatch fit --recording rec.wav --out-dir DIR --with-hearing-compensation
```

## Test plan

- [ ] `python3 -m pytest -q` — all 672 tests pass
- [ ] `headmatch hearing-test` — interactive test runs, profile saved
- [ ] `headmatch hearing-fit --out-dir /tmp/hf` — EQ files written without a microphone
- [ ] GUI: Hearing Test nav item → test loop → "Generate EQ Preset Now" → completion screen