### PR TITLE
Release 0.8.1 — fix macOS hearing-test crash

### DIFF
--- a/docs/releases/0.8.1.md
+++ b/docs/releases/0.8.1.md
@@ -1,0 +1,78 @@
+# HeadMatch 0.8.1 Release Notes
+
+Released: 2026-06-14
+
+## Overview
+
+0.8.1 is a patch release fixing a macOS crash in the hearing-test GUI introduced in
+0.8.0. On macOS the hearing test failed to open at all, raising a `_tkinter.TclError`
+the moment the view was rendered. The same latent fault is fixed in a second view that
+had been masked by a broad exception handler.
+
+---
+
+## Bug Fixes
+
+### HIGH — Hearing test crashed on macOS with `unknown option "-background"` (`gui/views/hearing_test.py`)
+
+Opening the **Hearing Test** view on macOS raised:
+
+```
+_tkinter.TclError: unknown option "-background"
+```
+
+The intro screen built a `tk.Text` widget whose background was taken from
+`frame.cget("background")`, guarded by `hasattr(frame, "cget")`. That guard is
+ineffective — every Tk/ttk widget has a `cget` method — and the real problem is that
+`frame` is a `ttk.Frame`, which does **not** expose a `-background` option under
+macOS's strict `aqua` theme. Querying it raised `TclError` and aborted the Tkinter
+callback. On Linux/Windows the default/`clam` themes tolerate the query, so the bug
+never surfaced there (including in CI).
+
+The background colour is now resolved through the active ttk theme
+(`ttk.Style().lookup("TFrame", "background")`) via a new shared helper
+`headmatch.gui.widgets.theme_background`, with a neutral fallback when the theme reports
+nothing usable. No widget option that ttk may reject is queried.
+
+### MEDIUM — Readiness report could silently fail to render on macOS (`gui/views/_legacy.py`)
+
+The setup-check readiness report used the identical `report_card.cget("background")`
+anti-pattern on a `ttk.LabelFrame`. It was wrapped in a `try/except` that swallowed the
+error, so on macOS the report text silently failed to render rather than crashing. It
+now uses the same `theme_background` helper.
+
+---
+
+## Why 0.8.0 CI did not catch this
+
+Two independent gaps allowed the crash through a green test suite:
+
+1. **The GUI render path had no test.** `render_hearing_test` was never invoked by any
+   test; hearing-test coverage exercised the threshold *engine*, not the view.
+2. **GUI tests mock the toolkit.** The dummy widgets have no `cget` method, so the
+   `hasattr` guard evaluated to `False` and the crashing branch was never executed.
+   Line coverage marked the line as covered; only branch coverage — or a real ttk
+   widget on `aqua` — would have exposed it.
+
+A regression test (`tests/test_gui_widgets.py`) now exercises the theme-lookup failure
+mode directly, including the path that previously raised `TclError`.
+
+---
+
+## Test Coverage
+
+- **686 tests passing** (up from 683 in 0.8.0)
+- New test module: `test_gui_widgets.py` covering `theme_background` across the
+  theme-available, empty-theme, and lookup-failure (macOS aqua) cases
+
+---
+
+## Upgrade Notes
+
+No breaking changes. macOS users who could not open the Hearing Test should upgrade.
+
+```bash
+pip install --upgrade headmatch
+headmatch --version
+# headmatch 0.8.1
+```

--- a/headmatch/app_identity.py
+++ b/headmatch/app_identity.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 APP_NAME = 'headmatch'
 APP_DISPLAY_NAME = 'HeadMatch'
-_VERSION = '0.8.0'
+_VERSION = '0.8.1'
 
 
 @dataclass(frozen=True)

--- a/headmatch/gui/views/_legacy.py
+++ b/headmatch/gui/views/_legacy.py
@@ -6,6 +6,7 @@ from ...history import build_history_selection
 import subprocess
 import sys
 from ...troubleshooting import confidence_troubleshooting_steps
+from ..widgets import theme_background
 
 
 ONLINE_STEPS = (
@@ -177,7 +178,7 @@ def render_setup_check(ttk, frame, *, report: str, on_refresh, on_measure) -> No
     frame.rowconfigure(3, weight=1)
     try:
         import tkinter as tk
-        text_widget = tk.Text(report_card, wrap="word", height=12, relief="flat", bg=report_card.cget("background") if hasattr(report_card, 'cget') else "#ffffff")
+        text_widget = tk.Text(report_card, wrap="word", height=12, relief="flat", bg=theme_background(ttk, fallback="#ffffff"))
         text_widget.insert("1.0", report)
         text_widget.config(state="disabled")
         scrollbar = ttk.Scrollbar(report_card, orient="vertical", command=text_widget.yview)

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -20,6 +20,7 @@ from ...hearing_test import (
     generate_tone,
     save_hearing_profile,
 )
+from ..widgets import theme_background
 
 from datetime import datetime, timezone
 
@@ -127,7 +128,7 @@ def render_hearing_test(
         )
         info_text = tk.Text(
             frame, height=10, width=62, state="normal",
-            relief="flat", background=frame.cget("background") if hasattr(frame, "cget") else "#f0f0f0",
+            relief="flat", background=theme_background(ttk),
             wrap="word",
         )
         info_text.insert("1.0", "\n".join(instructions))

--- a/headmatch/gui/widgets.py
+++ b/headmatch/gui/widgets.py
@@ -1,0 +1,22 @@
+"""Small shared helpers for building GUI widgets safely across platforms."""
+from __future__ import annotations
+
+
+def theme_background(ttk, fallback: str = "#ECECEC") -> str:
+    """Resolve a usable background colour for plain ``tk`` widgets.
+
+    Plain ``tk`` widgets (Text, Canvas, ...) often need a background colour
+    that blends with the surrounding ``ttk`` frame. The obvious approach —
+    ``frame.cget("background")`` — is a trap: ``ttk`` widgets do **not** expose
+    a ``-background`` option on every platform. On macOS's ``aqua`` theme it
+    raises ``_tkinter.TclError: unknown option "-background"``. (A ``hasattr``
+    guard does not help: every Tk widget has a ``cget`` method.)
+
+    Resolve the colour through the active ``ttk`` theme instead, falling back
+    to a neutral default when the theme reports nothing usable.
+    """
+    try:
+        bg = ttk.Style().lookup("TFrame", "background")
+    except Exception:
+        bg = None
+    return str(bg) if bg else fallback

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -1,0 +1,49 @@
+"""Regression tests for headmatch.gui.widgets.theme_background.
+
+These guard against the macOS 'aqua' crash where querying a ttk widget's
+``-background`` option raises ``_tkinter.TclError: unknown option
+"-background"`` (regression from TASK-116, hearing_test.py:130).
+"""
+from __future__ import annotations
+
+import pytest
+
+from headmatch.gui.widgets import theme_background
+
+
+class _Style:
+    def __init__(self, *, value=None, raises=False):
+        self._value = value
+        self._raises = raises
+
+    def lookup(self, *_args, **_kwargs):
+        if self._raises:
+            raise RuntimeError("unknown option \"-background\"")  # mimics TclError
+        return self._value
+
+
+class _Ttk:
+    def __init__(self, style):
+        self._style = style
+
+    def Style(self):
+        return self._style
+
+
+def test_returns_theme_background_when_available():
+    ttk = _Ttk(_Style(value="#dcdcdc"))
+    assert theme_background(ttk) == "#dcdcdc"
+
+
+def test_falls_back_when_theme_reports_empty():
+    # macOS aqua frequently returns "" from Style().lookup for background.
+    ttk = _Ttk(_Style(value=""))
+    assert theme_background(ttk) == "#ECECEC"
+    assert theme_background(ttk, fallback="#ffffff") == "#ffffff"
+
+
+def test_does_not_raise_when_lookup_fails():
+    # The original bug: this code path raised TclError on macOS and crashed
+    # the Tkinter callback. It must now degrade to the fallback instead.
+    ttk = _Ttk(_Style(raises=True))
+    assert theme_background(ttk, fallback="#ffffff") == "#ffffff"


### PR DESCRIPTION
## Summary

Patch release fixing a macOS crash in the hearing-test GUI introduced in 0.8.0. On macOS the Hearing Test view failed to open at all, raising `_tkinter.TclError: unknown option "-background"` the moment it rendered.

## Root cause

`gui/views/hearing_test.py` built a `tk.Text` whose background came from `frame.cget("background")`, guarded by `hasattr(frame, "cget")`. That guard is ineffective — every Tk/ttk widget has `cget` — and `frame` is a `ttk.Frame`, which does **not** expose a `-background` option under macOS's strict `aqua` theme. The query raised `TclError` and aborted the Tkinter callback. Linux/Windows default/`clam` themes tolerate the query, so CI never saw it.

## Changes

- New shared helper `headmatch.gui.widgets.theme_background` resolves the background via `ttk.Style().lookup("TFrame", "background")` with a neutral fallback — never queries a widget option ttk may reject.
- `hearing_test.py` (the reported crash) and `_legacy.py` (identical latent anti-pattern on a `ttk.LabelFrame`, previously masked by a broad `except`) both use the helper.
- Version bumped to `0.8.1`; release notes added at `docs/releases/0.8.1.md`.

## Why 0.8.0 CI missed it

1. `render_hearing_test` was never invoked by any test — coverage exercised the threshold engine, not the view.
2. GUI tests mock the toolkit; the dummy widgets have no `cget`, so the `hasattr` guard was `False` and the crashing branch never ran. Line coverage marked the line covered; only branch coverage or a real ttk widget on `aqua` would have exposed it.

## Tests

- New `tests/test_gui_widgets.py` exercises the theme-lookup failure mode directly, including the path that previously raised `TclError`.
- Full suite: **686 passing** (up from 683).