### PR TITLE
Release 0.8.2 — clam GUI theme + hearing-test render/CLI test coverage

### DIFF
--- a/docs/designs/measurement-resolution-eq.md
+++ b/docs/designs/measurement-resolution-eq.md
@@ -1,106 +1,106 @@
 # Design: Measurement-resolution EQ generation
 
-Status: adopted for the hearing-fit path (0.8.2). Retrofit across the other
-fitting mechanisms is **pending a literature review** validating that the
-approach (prescription rule, band placement, GraphicEQ frequency set) is optimal
-— see "Open questions for the literature review" below.
+Status: **adopted project-wide** (0.8.2). Grounded in a literature review (see
+"Evidence" below); applies to the hearing-fit and measurement-fit paths.
 
 ## Principle
 
-**The resolution of the generated EQ must match the resolution of the
-measurement that produced it.** Do not manufacture frequency resolution the
-data does not have.
+**The resolution and aggressiveness of the generated EQ must match the
+resolution and *reliability* of the measurement that produced it.** Do not
+manufacture frequency resolution the data lacks, and do not turn measurement
+noise into EQ.
 
-The hearing test measures hearing thresholds at exactly seven audiometric
-frequencies (ISO 8253-1: 500, 1000, 2000, 3000, 4000, 6000, 8000 Hz). The EQ has
-seven degrees of freedom — no more. Cubic-spline-interpolating those seven points
-onto a dense grid and then greedily fitting parametric bands (or exporting a
-~5,000-point GraphicEQ) invents detail that was never measured, is slower, and —
-in the GraphicEQ case — produced files large enough to crash downstream
-consumers such as EasyEffects.
+The hearing test measures thresholds at seven audiometric frequencies (ISO
+8253-1: 500, 1000, 2000, 3000, 4000, 6000, 8000 Hz) — seven degrees of freedom,
+each with ~5 dB+ test-retest spread. The EQ must reflect that.
 
 ## Approach
 
-Build the EQ **directly from the measured points**:
+1. **Per-frequency gains with a noise deadband.** Compute the half-gain
+   compensation at each measured frequency, `gain = clamp((threshold −
+   reference) × 0.5, 0, 12 dB)`, L/R averaged — but **ignore losses below a
+   ~10 dB deadband** (`HEARING_DEADBAND_DB`), which are within self-test noise
+   and where the half-gain rule over-prescribes. `compute_compensation_points()`.
 
-1. **Per-frequency gains.** Compute the target gain at each *measured* frequency
-   (for the hearing fit: half-gain compensation `clamp((threshold − reference) ×
-   0.5, 0, 12 dB)`, L/R averaged). This is `compute_compensation_points()` →
-   `{freq_hz: gain_db}`.
+2. **Interaction-aware parametric realization.** One peaking filter per measured
+   frequency (Q from inter-band octave spacing, `Q = sqrt(2^N)/(2^N − 1)` as an
+   approximation of the RBJ octave↔Q relation). Band **gains are solved by
+   least squares against an interaction matrix** so the realised chain hits the
+   target points (overlapping bands sum) — not by assigning each band its raw
+   point gain. `peq.solve_band_gains_lsq()`, `eq_bands_from_gain_points()`.
+   Verified: realised response lands within ~0.3 dB of target at every measured
+   frequency.
 
-2. **Parametric EQ.** One peaking filter per frequency that needs gain, placed
-   *at* the measured frequency. Each filter's Q is derived from the band's
-   spacing to its neighbours so adjacent bands meet near their −3 dB points
-   instead of stacking:
+3. **Unified standard GraphicEQ grid.** Every GraphicEQ export (hearing-fit AND
+   measurement-fit) renders the fitted PEQ chain onto the **AutoEq 127-point log
+   grid** (`signals.standard_graphic_eq_grid()`, step 1.0563 from 20 Hz). This is
+   the de-facto density standard, loads comfortably in Equalizer APO/EasyEffects,
+   and replaced the ~5,103-point grid that crashed EasyEffects.
 
-   ```
-   N      = mean octave distance to neighbouring measured frequencies
-   Q(N)   = sqrt(2^N) / (2^N − 1)      # N=1 oct → 1.41 ; N=0.5 oct → 2.87
-   ```
+A modest 48-points/octave grid is still used for prediction/clipping metrics and
+target sampling — never to manufacture EQ resolution.
 
-   `eq_bands_from_gain_points()`. When a smaller filter budget is requested, the
-   largest-magnitude bands are kept (advanced mode can lower the budget; basic
-   uses all measured points).
+## What was retrofitted
 
-3. **GraphicEQ.** The measured points plus *hold-edge* anchors at 20 Hz and
-   20 kHz (the nearest measured gain, so the host bounds its interpolation
-   instead of ramping to zero). ~9 points total — `hearing_graphiceq_curve()`.
+- **Hearing-fit** (`fit_from_hearing_profile`, `run_hearing_fit`): deadband +
+  least-squares band gains + standard-grid GraphicEQ.
+- **Measurement-fit** (`pipeline_artifacts.write_fit_artifacts`): GraphicEQ moved
+  from the raw analysis grid to the standard 127-point grid. The parametric
+  fitter (`fit_peq`, greedy residual placement) operates at true measurement
+  resolution and is unchanged — placing bands at measured resolution does not
+  violate the principle.
+- **Shared utilities:** `signals.standard_graphic_eq_grid`,
+  `peq.solve_band_gains_lsq`.
 
-A modest 48-points/octave grid is still used, but **only** for prediction/
-clipping metrics and for sampling a target curve at the measured frequencies —
-never to manufacture EQ resolution.
+## Evidence (literature review)
 
-### Why this is also "not random"
+Prescription rule (Q1):
+- Half-gain (Lybarger) is an empirically validated first-order rule for
+  sensorineural loss (~500 fitted clients) — Schwartz/Larson, *A Reexamination
+  of the One-Half Gain Rule*, Ear & Hearing 1980 (PMID 7409361).
+- It **over-prescribes for mild loss** (same source) → motivates the deadband.
+- Modern formulas (NAL-NL2) are model-based, compressive optimizations, not a
+  fixed fraction — Keidser et al., *Trends in Amplification* 2011,
+  doi:10.1177/1084713812468511.
+- Listeners **prefer the softer prescription** and cut aggressive HF gain by
+  ~4 dB; gain is reduced for inexperienced users — Moore et al., PMID 23357807;
+  doi:10.1177/1084713812465494 → keep the 0.5 fraction + 12 dB cap conservative.
 
-The legacy parametric fitter (`fit_peq`) is a deterministic greedy
-residual-peak placer, not random. But running it over a spline-interpolated
-dense grid still fabricates resolution. Placing bands at the measured/standard
-frequencies is both deterministic *and* honest about the data.
+Band placement / Q (Q2):
+- Fixed standard-frequency bands + weighted least squares reconstruct an
+  arbitrary target to <0.81 dB; band interaction must be modelled via an
+  interaction matrix — Välimäki & Liski / Rämö et al., MDPI Appl. Sci. 2020
+  10(4):1222; Aalto "Graphic EQ design with symmetric biquad filters".
+- RBJ peaking realization `A = 10^(dBgain/40)` and the octave↔Q relation —
+  webaudio Audio-EQ-Cookbook. AutoEq uses fixed Q (√2 octave, 4.318 for 31-band).
 
-## Retrofit plan (unify all fitting mechanisms)
+GraphicEQ grid (Q3):
+- Equalizer APO GraphicEQ accepts an arbitrary point list (no documented max),
+  interpolated linearly in log-frequency — SourceForge APO config reference. The
+  EasyEffects crash was the point *count*, not the format.
+- AutoEq's 127-point grid (step 1.0563) is the de-facto density standard —
+  github.com/jaakkopasanen/AutoEq. Band sets follow ANSI S1.11-2004 / ISO 266.
 
-The measurement-based fit (`fit_from_measurement` / `write_fit_artifacts`) and
-the target-fit path should adopt the same principle:
+Validity of uncalibrated self-audiometry (Q4):
+- App audiometry can approximate clinical thresholds (no significant difference
+  0.5–4 kHz), **but** test-retest within 5 dB is only 60–77% per frequency, and
+  uncalibrated audiograms are sensitive to calibration/noise — Saliba et al.,
+  AJA 2022, doi:10.1044/2022_AJA-21-00191; medRxiv 2024.06.25.24309468 →
+  motivates the deadband and conservative, capped gains.
 
-- **Microphone measurement fit.** The analysis grid (~48 ppo) is a real
-  measurement resolution, so its parametric fit is defensible — but the GraphicEQ
-  export should be emitted on a **standard, bounded frequency set** (e.g. the ISO
-  ⅓-octave preferred frequencies, or the AutoEq GraphicEQ standard set) rather
-  than the full analysis grid, for consistent, host-safe files.
-- **Shared GraphicEQ writer.** Centralise GraphicEQ point selection in one place
-  with a single default frequency set and an advanced-mode override, so basic
-  mode is identical everywhere and advanced mode exposes the same knob across
-  hearing-fit, online measure, and offline fit.
-- **Shared band-budget semantics.** `max_filters` / `FilterBudget` already unify
-  the parametric count; extend the same default-in-basic / selectable-in-advanced
-  pattern to GraphicEQ density.
-- **Per-ear option.** The hearing test measures per ear but currently averages
-  L/R into one curve. A future option can emit per-ear EQ from the per-ear
-  thresholds.
+## Possible future work
 
-## Open questions for the literature review
-
-Before retrofitting, validate against peer-reviewed literature / standards:
-
-1. Is the half-gain (Lybarger) rule the right prescription for a music-listening
-   EQ from audiometric thresholds, or do NAL-NL2 / DSL v5 / CAM2 apply better?
-2. Is placing parametric filters at the audiometric frequencies (Q from spacing)
-   optimal vs optimisation-based placement for a sparse target?
-3. What is the recommended standard GraphicEQ frequency set and point count?
-4. What are the validity limits of uncalibrated (dBFS, no RETSPL) self-test
-   audiometry as an EQ basis, and how should that bound the applied gain?
-
-## References
-
-- ISO 8253-1 — pure-tone audiometry test frequencies.
-- ISO 266 — preferred (⅓-octave) frequencies for graphic-EQ band sets.
-- Lybarger half-gain prescription rule (compensation gains).
-- RBJ / standard peaking-filter Q ↔ octave-bandwidth relationship.
+- Taper the gain fraction at mild loss (Libby ⅓-gain style) rather than a hard
+  deadband knee.
+- Per-ear EQ from the per-ear thresholds (currently L/R averaged).
+- Optional ISO-266 ⅓-octave GraphicEQ export alongside the AutoEq grid.
 
 ## Implementation pointers
 
 - `headmatch/hearing_test.py`: `compute_compensation_points`,
-  `eq_bands_from_gain_points`, `hearing_graphiceq_curve`,
-  `_peaking_q_for_octave_bandwidth`.
-- `headmatch/pipeline.py`: `fit_from_hearing_profile`, `run_hearing_fit`.
-- Tests: `tests/test_hearing_test_bugfixes.py`.
+  `eq_bands_from_gain_points`, `_peaking_q_for_octave_bandwidth`,
+  `HEARING_DEADBAND_DB`.
+- `headmatch/peq.py`: `solve_band_gains_lsq`.
+- `headmatch/signals.py`: `standard_graphic_eq_grid`.
+- `headmatch/pipeline.py`, `headmatch/pipeline_artifacts.py`: GraphicEQ export.
+- Tests: `tests/test_hearing_test_bugfixes.py`, `tests/test_e2e_fitting.py`.

--- a/docs/designs/measurement-resolution-eq.md
+++ b/docs/designs/measurement-resolution-eq.md
@@ -1,0 +1,106 @@
+# Design: Measurement-resolution EQ generation
+
+Status: adopted for the hearing-fit path (0.8.2). Retrofit across the other
+fitting mechanisms is **pending a literature review** validating that the
+approach (prescription rule, band placement, GraphicEQ frequency set) is optimal
+— see "Open questions for the literature review" below.
+
+## Principle
+
+**The resolution of the generated EQ must match the resolution of the
+measurement that produced it.** Do not manufacture frequency resolution the
+data does not have.
+
+The hearing test measures hearing thresholds at exactly seven audiometric
+frequencies (ISO 8253-1: 500, 1000, 2000, 3000, 4000, 6000, 8000 Hz). The EQ has
+seven degrees of freedom — no more. Cubic-spline-interpolating those seven points
+onto a dense grid and then greedily fitting parametric bands (or exporting a
+~5,000-point GraphicEQ) invents detail that was never measured, is slower, and —
+in the GraphicEQ case — produced files large enough to crash downstream
+consumers such as EasyEffects.
+
+## Approach
+
+Build the EQ **directly from the measured points**:
+
+1. **Per-frequency gains.** Compute the target gain at each *measured* frequency
+   (for the hearing fit: half-gain compensation `clamp((threshold − reference) ×
+   0.5, 0, 12 dB)`, L/R averaged). This is `compute_compensation_points()` →
+   `{freq_hz: gain_db}`.
+
+2. **Parametric EQ.** One peaking filter per frequency that needs gain, placed
+   *at* the measured frequency. Each filter's Q is derived from the band's
+   spacing to its neighbours so adjacent bands meet near their −3 dB points
+   instead of stacking:
+
+   ```
+   N      = mean octave distance to neighbouring measured frequencies
+   Q(N)   = sqrt(2^N) / (2^N − 1)      # N=1 oct → 1.41 ; N=0.5 oct → 2.87
+   ```
+
+   `eq_bands_from_gain_points()`. When a smaller filter budget is requested, the
+   largest-magnitude bands are kept (advanced mode can lower the budget; basic
+   uses all measured points).
+
+3. **GraphicEQ.** The measured points plus *hold-edge* anchors at 20 Hz and
+   20 kHz (the nearest measured gain, so the host bounds its interpolation
+   instead of ramping to zero). ~9 points total — `hearing_graphiceq_curve()`.
+
+A modest 48-points/octave grid is still used, but **only** for prediction/
+clipping metrics and for sampling a target curve at the measured frequencies —
+never to manufacture EQ resolution.
+
+### Why this is also "not random"
+
+The legacy parametric fitter (`fit_peq`) is a deterministic greedy
+residual-peak placer, not random. But running it over a spline-interpolated
+dense grid still fabricates resolution. Placing bands at the measured/standard
+frequencies is both deterministic *and* honest about the data.
+
+## Retrofit plan (unify all fitting mechanisms)
+
+The measurement-based fit (`fit_from_measurement` / `write_fit_artifacts`) and
+the target-fit path should adopt the same principle:
+
+- **Microphone measurement fit.** The analysis grid (~48 ppo) is a real
+  measurement resolution, so its parametric fit is defensible — but the GraphicEQ
+  export should be emitted on a **standard, bounded frequency set** (e.g. the ISO
+  ⅓-octave preferred frequencies, or the AutoEq GraphicEQ standard set) rather
+  than the full analysis grid, for consistent, host-safe files.
+- **Shared GraphicEQ writer.** Centralise GraphicEQ point selection in one place
+  with a single default frequency set and an advanced-mode override, so basic
+  mode is identical everywhere and advanced mode exposes the same knob across
+  hearing-fit, online measure, and offline fit.
+- **Shared band-budget semantics.** `max_filters` / `FilterBudget` already unify
+  the parametric count; extend the same default-in-basic / selectable-in-advanced
+  pattern to GraphicEQ density.
+- **Per-ear option.** The hearing test measures per ear but currently averages
+  L/R into one curve. A future option can emit per-ear EQ from the per-ear
+  thresholds.
+
+## Open questions for the literature review
+
+Before retrofitting, validate against peer-reviewed literature / standards:
+
+1. Is the half-gain (Lybarger) rule the right prescription for a music-listening
+   EQ from audiometric thresholds, or do NAL-NL2 / DSL v5 / CAM2 apply better?
+2. Is placing parametric filters at the audiometric frequencies (Q from spacing)
+   optimal vs optimisation-based placement for a sparse target?
+3. What is the recommended standard GraphicEQ frequency set and point count?
+4. What are the validity limits of uncalibrated (dBFS, no RETSPL) self-test
+   audiometry as an EQ basis, and how should that bound the applied gain?
+
+## References
+
+- ISO 8253-1 — pure-tone audiometry test frequencies.
+- ISO 266 — preferred (⅓-octave) frequencies for graphic-EQ band sets.
+- Lybarger half-gain prescription rule (compensation gains).
+- RBJ / standard peaking-filter Q ↔ octave-bandwidth relationship.
+
+## Implementation pointers
+
+- `headmatch/hearing_test.py`: `compute_compensation_points`,
+  `eq_bands_from_gain_points`, `hearing_graphiceq_curve`,
+  `_peaking_q_for_octave_bandwidth`.
+- `headmatch/pipeline.py`: `fit_from_hearing_profile`, `run_hearing_fit`.
+- Tests: `tests/test_hearing_test_bugfixes.py`.

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -4,11 +4,14 @@ Released: 2026-06-14
 
 ## Overview
 
-0.8.2 follows up the macOS hearing-test crash fixed in 0.8.1. It fixes three further
-hearing-test bugs (per-ear tone routing, unrenderable status glyphs, and a test that
-could hang on the first frequency), closes the test-coverage gap that allowed the 0.8.1
-crash to ship, and ships a consistent, polished cross-platform GUI theme that also
-removes the class of `aqua`-theme styling pitfall behind the original crash.
+0.8.2 follows up the macOS hearing-test crash fixed in 0.8.1. It fixes several
+hearing-test bugs (per-ear tone routing, a test that could hang, and a no-op/EasyEffects-
+crashing EQ export), reworks hearing EQ generation to a literature-grounded
+measured-resolution design, and ships a consistent cross-platform GUI theme that removes
+the `aqua`-styling pitfall behind the original crash. It also adds GUI reuse of a saved
+hearing profile, advanced-mode tonal-target selection, end-to-end tests across every
+fitting workflow, and ASCII-only GUI glyphs. It closes the test-coverage gap that let the
+0.8.1 crash ship.
 
 ---
 
@@ -20,7 +23,7 @@ removes the class of `aqua`-theme styling pitfall behind the original crash.
 which require missed tones. A listener who heard (or missed) **every** presentation
 never produced an ascending run, so the level pinned at the floor (or ceiling) and the
 frequency never finished — the test appeared stuck on "Frequency 1 / 7" no matter how
-many times "I hear it" was pressed. A `MAX_PRESENTATIONS` safety cap (20) now guarantees
+many times "I hear it" was pressed. A `MAX_PRESENTATIONS` safety cap (10) now guarantees
 the staircase terminates: with a usable estimate it uses that, if every tone was heard
 it records a threshold at the floor, and if nothing was ever heard it records the
 frequency as undetermined. The intro screen also now warns that an over-high volume
@@ -54,15 +57,24 @@ literature-grounded design (`docs/designs/measurement-resolution-eq.md`):
 
 ### MEDIUM — Hearing test felt slow on well-heard frequencies (`hearing_test.py`)
 
-`MAX_PRESENTATIONS` lowered 20 → 10 so each frequency resolves (or bails to a
-best estimate) promptly instead of dragging on for frequencies the listener
-hears down to the floor.
+`MAX_PRESENTATIONS` is set to 10 so each frequency resolves (or bails to a best estimate)
+promptly instead of dragging on for frequencies the listener hears down to the floor.
 
-### MEDIUM — Status glyphs failed to render (`gui/views/hearing_test.py`)
+### MEDIUM — Tonal target was dropped when there was no hearing loss (`pipeline.py`)
 
-The per-tone status indicator used decorative non-ASCII glyphs (`♪`, `✓`, `—`, `…`) that
-render as tofu/boxes in some platform Tk fonts. The status strings are now plain ASCII
-("Playing tone...", "Heard", "Not heard").
+The measured-resolution rework keyed the EQ only off the hearing-compensation
+frequencies, so selecting a tonal target (e.g. Harman) produced an *empty* EQ for a
+listener with no measurable loss. The EQ control points are now the union of the measured
+audiometric frequencies and the target curve's own frequencies, so a target applies even
+with zero hearing loss.
+
+### MEDIUM — Unrenderable GUI glyphs across the app (`gui/views/*`, `history.py`)
+
+Decorative non-ASCII glyphs rendered as tofu/boxes in some platform Tk fonts. All
+GUI-displayed glyphs are now plain ASCII: the per-tone hearing-test status (`♪`/`✓`/`—`/`…`
+→ "Playing tone..."/"Heard"/"Not heard"), the target-editor delete button (`✕` → `X`), the
+clipping-assessment indicator, and the confidence badges (`✓`/`⚠`/`✗` → `[OK]`/`[!]`/`[X]`)
+in the basic view and the Results/history page. (CLI terminal glyphs are unchanged.)
 
 ---
 
@@ -100,6 +112,12 @@ top of the hearing compensation — while **basic** mode keeps the flat default.
 live in `headmatch/builtin_targets.py`; the CLI `hearing-fit --target-csv` already
 supported this.
 
+### Hearing profile copied into the results directory
+
+`run_hearing_fit` now writes a copy of the raw `hearing_profile.json` alongside the EQ
+artifacts for traceability. The canonical profile still lives in the platform config
+directory (`hearing_profile_path()`), which the GUI and CLI reuse.
+
 ---
 
 ## Test Hardening
@@ -126,14 +144,17 @@ This release covers those paths directly:
 | `gui/theme.py` (new) | — | 89% |
 | `gui/widgets.py` | — | 100% |
 
-- **715 tests passing** (up from 686 in 0.8.1).
+- **724 tests passing** (up from 686 in 0.8.1).
 - New module `test_hearing_test_bugfixes.py` covers per-ear channel routing, ASCII status
-  strings, guaranteed engine termination, and the measured-resolution EQ output.
+  strings, guaranteed engine termination, the noise deadband, and the interaction-aware
+  least-squares EQ realisation.
 - New module `test_e2e_fitting.py` — end-to-end tests of every fitting workflow on
   synthetic data with known ground truth (no hardware): offline fit and clone-target
   round-trips using a real published HD 650 curve, iterative/online measure-and-fit
   (capture mocked) in both modes, and hearing-fit on a presbycusis audiogram.
-- GUI saved-profile reuse covered in `test_gui.py`.
+- New module `test_builtin_targets.py` covers the advanced-mode tonal targets.
+- GUI saved-profile reuse, the advanced-mode target resolver, and the profile-copy to the
+  results dir are covered in `test_gui.py` / `test_hearing_fit.py`.
 
 ---
 
@@ -141,8 +162,15 @@ This release covers those paths directly:
 
 No breaking changes. Single-ear hearing tests now play the tone only in the ear under
 test (previously both), so re-running a hearing test is recommended for an accurate
-per-ear profile. The GUI's visual theme changes on Windows and Linux (now the
+per-ear profile. GraphicEQ exports now use the standard 127-point grid (loads cleanly in
+Equalizer APO / EasyEffects). The GUI's visual theme changes on Windows and Linux (now the
 `clam`-based HeadMatch theme rather than the OS-native ttk theme).
+
+Note on the hearing test: because the pure-tone test is **uncalibrated** (relative dBFS,
+no SPL reference), the absolute "loss" it derives is volume-dependent — at a high volume
+you may measure as having no loss and correctly get little or no EQ. Set a comfortable
+level where the quietest tones are inaudible. A more robust, calibration-invariant
+hearing measurement is planned for 0.8.3.
 
 ```bash
 pip install --upgrade headmatch

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -4,10 +4,39 @@ Released: 2026-06-14
 
 ## Overview
 
-0.8.2 is a quality release that follows up the macOS hearing-test crash fixed in 0.8.1.
-It closes the test-coverage gap that allowed that crash to ship, and ships a consistent,
-polished cross-platform GUI theme that also removes the class of `aqua`-theme styling
-pitfall behind the original bug. No functional behaviour changes.
+0.8.2 follows up the macOS hearing-test crash fixed in 0.8.1. It fixes three further
+hearing-test bugs (per-ear tone routing, unrenderable status glyphs, and a test that
+could hang on the first frequency), closes the test-coverage gap that allowed the 0.8.1
+crash to ship, and ships a consistent, polished cross-platform GUI theme that also
+removes the class of `aqua`-theme styling pitfall behind the original crash.
+
+---
+
+## Bug Fixes
+
+### HIGH — Hearing test could hang on the first frequency (`hearing_test.py`)
+
+`ThresholdEngine`'s Hughson-Westlake staircase only completes via *ascending runs*,
+which require missed tones. A listener who heard (or missed) **every** presentation
+never produced an ascending run, so the level pinned at the floor (or ceiling) and the
+frequency never finished — the test appeared stuck on "Frequency 1 / 7" no matter how
+many times "I hear it" was pressed. A `MAX_PRESENTATIONS` safety cap now guarantees the
+staircase terminates: with a usable estimate it uses that, if every tone was heard it
+records a threshold at the floor, and if nothing was ever heard it records the frequency
+as undetermined.
+
+### HIGH — Tone played in both ears during a single-ear test (`hearing_test.py`)
+
+`generate_tone` always duplicated the mono sine into both stereo channels, so "Testing
+Left Ear" actually played in both ears and measured the better ear rather than the one
+under test. `generate_tone` now takes an `ear` argument and silences the untested
+channel; both the GUI and the CLI runner pass the ear currently being tested.
+
+### MEDIUM — Status glyphs failed to render (`gui/views/hearing_test.py`)
+
+The per-tone status indicator used decorative non-ASCII glyphs (`♪`, `✓`, `—`, `…`) that
+render as tofu/boxes in some platform Tk fonts. The status strings are now plain ASCII
+("Playing tone...", "Heard", "Not heard").
 
 ---
 
@@ -56,14 +85,19 @@ This release covers those paths directly:
 | `gui/theme.py` (new) | — | 89% |
 | `gui/widgets.py` | — | 100% |
 
-- **697 tests passing** (up from 686 in 0.8.1).
+- **704 tests passing** (up from 686 in 0.8.1).
+- New module `test_hearing_test_bugfixes.py` covers the three fixes above: per-ear
+  channel routing, ASCII status strings, and guaranteed engine termination when every
+  tone is heard or missed.
 
 ---
 
 ## Upgrade Notes
 
-No breaking changes and no behaviour changes. The GUI's visual theme changes on Windows
-and Linux (now the `clam`-based HeadMatch theme rather than the OS-native ttk theme).
+No breaking changes. Single-ear hearing tests now play the tone only in the ear under
+test (previously both), so re-running a hearing test is recommended for an accurate
+per-ear profile. The GUI's visual theme changes on Windows and Linux (now the
+`clam`-based HeadMatch theme rather than the OS-native ttk theme).
 
 ```bash
 pip install --upgrade headmatch

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -92,6 +92,14 @@ Opening **Hearing Test** when a saved profile exists now offers a landing screen
 **run a new test**. The profile already persisted to disk and the `hearing-fit` CLI
 reused it; the GUI previously always forced a fresh test.
 
+### Advanced-mode tonal target selection
+
+In **advanced** mode the hearing-fit screen now offers a **target-curve** selector —
+built-in **Harman / Free field / Diffuse field** curves (or a custom CSV) layered on
+top of the hearing compensation — while **basic** mode keeps the flat default. Built-ins
+live in `headmatch/builtin_targets.py`; the CLI `hearing-fit --target-csv` already
+supported this.
+
 ---
 
 ## Test Hardening

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -80,6 +80,13 @@ the 0.8.1 crash). Standardising on `clam` therefore does two things at once:
 **Visible change:** Windows and Linux users previously saw their native ttk theme; they
 will now see the `clam`-based HeadMatch theme. All workflows and behaviour are unchanged.
 
+### Reuse a saved hearing profile in the GUI
+
+Opening **Hearing Test** when a saved profile exists now offers a landing screen to
+**reuse it** ("Use Saved Profile" → generate an EQ preset without repeating the test) or
+**run a new test**. The profile already persisted to disk and the `hearing-fit` CLI
+reused it; the GUI previously always forced a fresh test.
+
 ---
 
 ## Test Hardening
@@ -106,10 +113,14 @@ This release covers those paths directly:
 | `gui/theme.py` (new) | — | 89% |
 | `gui/widgets.py` | — | 100% |
 
-- **705 tests passing** (up from 686 in 0.8.1).
-- New module `test_hearing_test_bugfixes.py` covers the three fixes above: per-ear
-  channel routing, ASCII status strings, and guaranteed engine termination when every
-  tone is heard or missed.
+- **715 tests passing** (up from 686 in 0.8.1).
+- New module `test_hearing_test_bugfixes.py` covers per-ear channel routing, ASCII status
+  strings, guaranteed engine termination, and the measured-resolution EQ output.
+- New module `test_e2e_fitting.py` — end-to-end tests of every fitting workflow on
+  synthetic data with known ground truth (no hardware): offline fit and clone-target
+  round-trips using a real published HD 650 curve, iterative/online measure-and-fit
+  (capture mocked) in both modes, and hearing-fit on a presbycusis audiogram.
+- GUI saved-profile reuse covered in `test_gui.py`.
 
 ---
 

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -1,0 +1,72 @@
+# HeadMatch 0.8.2 Release Notes
+
+Released: 2026-06-14
+
+## Overview
+
+0.8.2 is a quality release that follows up the macOS hearing-test crash fixed in 0.8.1.
+It closes the test-coverage gap that allowed that crash to ship, and ships a consistent,
+polished cross-platform GUI theme that also removes the class of `aqua`-theme styling
+pitfall behind the original bug. No functional behaviour changes.
+
+---
+
+## Improvements
+
+### Consistent, prettier cross-platform GUI theme
+
+The GUI now standardises on Tk's bundled `clam` theme on every platform — via the new
+`headmatch.gui.theme.apply_theme` — instead of each OS's native theme. `clam` honours
+`background` / `foreground` / `style.map` customisation, whereas macOS's `aqua` ignores
+most of it and rejects options such as `-background` on ttk widgets (the root cause of
+the 0.8.1 crash). Standardising on `clam` therefore does two things at once:
+
+- **Prettier and consistent:** a cohesive palette, typography scale, consistent spacing,
+  and accent-coloured primary buttons (`Accent.TButton`) for the main calls to action
+  (e.g. "Start Test", "Save & Use for EQ", "Generate EQ Preset Now").
+- **Structurally safer:** the app no longer depends on per-platform styling quirks, so
+  the `aqua` option-rejection class of bug cannot recur through theme styling.
+
+**Visible change:** Windows and Linux users previously saw their native ttk theme; they
+will now see the `clam`-based HeadMatch theme. All workflows and behaviour are unchanged.
+
+---
+
+## Test Hardening
+
+0.8.1's crash slipped through "100% coverage" because the GUI render path was never
+invoked by a test and the GUI tests mock the toolkit (so the crashing branch never ran).
+This release covers those paths directly:
+
+- **`tests/test_gui_hearing_render.py`** — drives the full hearing-test render flow
+  (intro → both ears → results → save) with a fake toolkit and a fake threshold engine,
+  asserting completion *and* guarding that the render path never touches `frame.cget`
+  (the exact macOS regression).
+- **`tests/test_hearing_test_runner.py`** — covers the headless `run_cli_hearing_test`
+  CLI driver, previously untested.
+- **`tests/test_gui_theme.py`** — covers `apply_theme`: `clam` selection, graceful
+  fallback when `clam` is unavailable, and palette overrides.
+
+### Coverage of critical paths
+
+| Module | Before | After |
+|---|---|---|
+| `gui/views/hearing_test.py` (render path) | 4% | 93% |
+| `hearing_test.py` (threshold engine + CLI runner) | 75% | 98% |
+| `gui/theme.py` (new) | — | 89% |
+| `gui/widgets.py` | — | 100% |
+
+- **697 tests passing** (up from 686 in 0.8.1).
+
+---
+
+## Upgrade Notes
+
+No breaking changes and no behaviour changes. The GUI's visual theme changes on Windows
+and Linux (now the `clam`-based HeadMatch theme rather than the OS-native ttk theme).
+
+```bash
+pip install --upgrade headmatch
+headmatch --version
+# headmatch 0.8.2
+```

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -41,11 +41,16 @@ The hearing fit cubic-spline-interpolated the 7 measured thresholds onto a
 octave*), greedily fit parametric bands to it, and exported a ~5,103-point
 GraphicEQ. That dense GraphicEQ crashed EasyEffects, and with good hearing / a
 too-loud test the whole preset came out flat. The EQ is now built **directly
-from the 7 audiometric frequencies** (the only resolution the test has): one
-peaking filter per measured frequency with Q derived from band spacing, and a
-compact ~9-point GraphicEQ (the measured points + hold-edge anchors at 20 Hz /
-20 kHz). Deterministic, host-safe, and faster. See
-`docs/designs/measurement-resolution-eq.md`.
+from the 7 audiometric frequencies** (the only resolution the test has), with a
+literature-grounded design (`docs/designs/measurement-resolution-eq.md`):
+
+- a **~10 dB noise deadband** so within-noise / mild losses are not EQ'd (half-gain
+  over-prescribes mild loss; self-test thresholds vary ±5 dB);
+- **interaction-aware least-squares band gains** so overlapping peaking filters
+  realise the target within ~0.3 dB, instead of each band taking its raw gain;
+- a **unified standard 127-point GraphicEQ grid** (AutoEq de-facto standard) used by
+  *all* fitting workflows — replacing both the ~5,103-point hearing grid and the raw
+  analysis grid in the measurement fit, and fixing the EasyEffects crash by construction.
 
 ### MEDIUM — Hearing test felt slow on well-heard frequencies (`hearing_test.py`)
 

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -34,6 +34,25 @@ Left Ear" actually played in both ears and measured the better ear rather than t
 under test. `generate_tone` now takes an `ear` argument and silences the untested
 channel; both the GUI and the CLI runner pass the ear currently being tested.
 
+### HIGH — Hearing EQ was a no-op / crashed EasyEffects; reworked to measured-resolution output (`hearing_test.py`, `pipeline.py`)
+
+The hearing fit cubic-spline-interpolated the 7 measured thresholds onto a
+~5,103-point grid (`geometric_log_grid(20, 20000, 512)` — 512 is *points per
+octave*), greedily fit parametric bands to it, and exported a ~5,103-point
+GraphicEQ. That dense GraphicEQ crashed EasyEffects, and with good hearing / a
+too-loud test the whole preset came out flat. The EQ is now built **directly
+from the 7 audiometric frequencies** (the only resolution the test has): one
+peaking filter per measured frequency with Q derived from band spacing, and a
+compact ~9-point GraphicEQ (the measured points + hold-edge anchors at 20 Hz /
+20 kHz). Deterministic, host-safe, and faster. See
+`docs/designs/measurement-resolution-eq.md`.
+
+### MEDIUM — Hearing test felt slow on well-heard frequencies (`hearing_test.py`)
+
+`MAX_PRESENTATIONS` lowered 20 → 10 so each frequency resolves (or bails to a
+best estimate) promptly instead of dragging on for frequencies the listener
+hears down to the floor.
+
 ### MEDIUM — Status glyphs failed to render (`gui/views/hearing_test.py`)
 
 The per-tone status indicator used decorative non-ASCII glyphs (`♪`, `✓`, `—`, `…`) that

--- a/docs/releases/0.8.2.md
+++ b/docs/releases/0.8.2.md
@@ -20,10 +20,12 @@ removes the class of `aqua`-theme styling pitfall behind the original crash.
 which require missed tones. A listener who heard (or missed) **every** presentation
 never produced an ascending run, so the level pinned at the floor (or ceiling) and the
 frequency never finished — the test appeared stuck on "Frequency 1 / 7" no matter how
-many times "I hear it" was pressed. A `MAX_PRESENTATIONS` safety cap now guarantees the
-staircase terminates: with a usable estimate it uses that, if every tone was heard it
-records a threshold at the floor, and if nothing was ever heard it records the frequency
-as undetermined.
+many times "I hear it" was pressed. A `MAX_PRESENTATIONS` safety cap (20) now guarantees
+the staircase terminates: with a usable estimate it uses that, if every tone was heard
+it records a threshold at the floor, and if nothing was ever heard it records the
+frequency as undetermined. The intro screen also now warns that an over-high volume
+makes every tone audible (so no threshold can be found) and tells the user to set a
+comfortable level first.
 
 ### HIGH — Tone played in both ears during a single-ear test (`hearing_test.py`)
 
@@ -85,7 +87,7 @@ This release covers those paths directly:
 | `gui/theme.py` (new) | — | 89% |
 | `gui/widgets.py` | — | 100% |
 
-- **704 tests passing** (up from 686 in 0.8.1).
+- **705 tests passing** (up from 686 in 0.8.1).
 - New module `test_hearing_test_bugfixes.py` covers the three fixes above: per-ear
   channel routing, ASCII status strings, and guaranteed engine termination when every
   tone is heard or missed.

--- a/headmatch/app_identity.py
+++ b/headmatch/app_identity.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 APP_NAME = 'headmatch'
 APP_DISPLAY_NAME = 'HeadMatch'
-_VERSION = '0.8.1'
+_VERSION = '0.8.2'
 
 
 @dataclass(frozen=True)

--- a/headmatch/builtin_targets.py
+++ b/headmatch/builtin_targets.py
@@ -1,0 +1,58 @@
+"""Built-in tonal target curves selectable in advanced mode.
+
+These are compact, illustrative *absolute* tonal targets (normalised at 1 kHz).
+They are intended as convenient starting points layered on top of the hearing
+compensation; a user can still browse to any custom target CSV. Curves mirror
+the example CSVs in docs/examples/targets/.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# name -> (display label, [(freq_hz, target_db), ...])  -- absolute semantics, 1 kHz = 0
+BUILTIN_TARGET_DEFS: dict[str, tuple[str, list[tuple[float, float]]]] = {
+    "flat": ("Flat (default)", [
+        (20, 0.0), (50, 0.0), (100, 0.0), (200, 0.0), (500, 0.0), (1000, 0.0),
+        (2000, 0.0), (3000, 0.0), (6000, 0.0), (10000, 0.0), (16000, 0.0), (20000, 0.0),
+    ]),
+    "harman": ("Harman", [
+        (20, 6.0), (50, 5.0), (100, 3.5), (200, 2.0), (500, 0.8), (1000, 0.0),
+        (2000, 1.2), (3000, 2.0), (6000, 0.5), (10000, -1.0), (16000, -2.2), (20000, -3.0),
+    ]),
+    "free_field": ("Free field", [
+        (20, -0.6), (50, -0.4), (100, -0.2), (200, 0.0), (500, 0.3), (1000, 0.0),
+        (2000, 1.5), (3000, 2.2), (6000, 1.0), (10000, 0.0), (16000, -0.6), (20000, -1.0),
+    ]),
+    "diffuse_field": ("Diffuse field", [
+        (20, -1.0), (50, -0.8), (100, -0.4), (200, 0.0), (500, 0.6), (1000, 0.0),
+        (2000, 2.2), (3000, 3.2), (6000, 1.5), (10000, 0.2), (16000, -0.8), (20000, -1.2),
+    ]),
+}
+
+# "flat" needs no target file (it is the default no-op target).
+SELECTABLE_TARGET_NAMES = [name for name in BUILTIN_TARGET_DEFS if name != "flat"]
+
+
+def builtin_target_label(name: str) -> str:
+    return BUILTIN_TARGET_DEFS[name][0]
+
+
+def label_to_name(label: str) -> str | None:
+    """Map a display label back to its built-in name (None for flat/unknown)."""
+    for name, (lbl, _pts) in BUILTIN_TARGET_DEFS.items():
+        if lbl == label:
+            return None if name == "flat" else name
+    return None
+
+
+def materialize_builtin_target(name: str, dest_dir: str | Path) -> Path:
+    """Write a built-in target curve to ``dest_dir/<name>_target.csv`` and return it."""
+    if name not in BUILTIN_TARGET_DEFS:
+        raise KeyError(f"unknown built-in target: {name}")
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    path = dest_dir / f"{name}_target.csv"
+    lines = ["frequency_hz,target_db"]
+    lines += [f"{int(freq)},{db}" for freq, db in BUILTIN_TARGET_DEFS[name][1]]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path

--- a/headmatch/gui/shell.py
+++ b/headmatch/gui/shell.py
@@ -213,6 +213,7 @@ class HeadMatchGuiApp:
         self.basic_clone_output_var = tk.StringVar(master=root, value="")
         self.hearing_profile = None  # HearingProfile | None; set after a successful test
         self._force_new_hearing_test = False  # skip the saved-profile landing once
+        self.hearing_target_var = tk.StringVar(master=root, value="Flat (default)")  # advanced-mode tonal target
         self.basic_progress_var = tk.StringVar(master=root, value="")
         self.progress_title_var = tk.StringVar(master=root, value="")
         self.progress_body_var = tk.StringVar(master=root, value="")
@@ -667,13 +668,27 @@ class HeadMatchGuiApp:
             justify="left",
         ).grid(row=1, column=0, sticky="w", pady=(0, 16))
 
+        # Advanced mode: choose a tonal target curve to layer on the compensation.
+        # Basic mode keeps the flat default.
+        if self.mode_var.get() == "advanced":
+            from ..builtin_targets import BUILTIN_TARGET_DEFS
+            target_frame = ttk.Frame(self.content)
+            target_frame.grid(row=2, column=0, sticky="w", pady=(0, 12))
+            ttk.Label(target_frame, text="Target curve:").grid(row=0, column=0, sticky="w", padx=(0, 8))
+            values = [label for label, _pts in BUILTIN_TARGET_DEFS.values()] + ["Custom CSV…"]
+            ttk.Combobox(
+                target_frame, textvariable=self.hearing_target_var,
+                values=values, state="readonly", width=20,
+            ).grid(row=0, column=1, sticky="w")
+            ttk.Button(target_frame, text="Browse…", command=self.choose_target_csv).grid(row=0, column=2, padx=(8, 0))
+
         def _generate_now():
             from pathlib import Path as _Path
             out_dir = str(_Path(self.state.default_output_dir).expanduser().parent / "hearing_fit")
-            self._start_hearing_fit(profile, out_dir)
+            self._start_hearing_fit(profile, out_dir, target_path=self._resolve_hearing_target_path(out_dir))
 
         btn_frame = ttk.Frame(self.content)
-        btn_frame.grid(row=2, column=0, sticky="w")
+        btn_frame.grid(row=3, column=0, sticky="w")
         ttk.Button(btn_frame, text="Generate EQ Preset Now", command=_generate_now, style="Accent.TButton").grid(
             row=0, column=0, padx=(0, 8)
         )
@@ -682,13 +697,33 @@ class HeadMatchGuiApp:
             command=lambda: self.show_view("measure-online"),
         ).grid(row=0, column=1)
 
-    def _start_hearing_fit(self, profile, out_dir: str) -> None:
+    def _resolve_hearing_target_path(self, out_dir: str) -> str | None:
+        """Resolve the advanced-mode tonal target selection to a CSV path.
+
+        Returns None (flat default) in basic mode, for the Flat selection, or
+        when Custom CSV is chosen without a file. Built-in curves are
+        materialised next to the fit output.
+        """
+        if self.mode_var.get() != "advanced":
+            return None
+        from ..builtin_targets import label_to_name, materialize_builtin_target
+        label = self.hearing_target_var.get().strip()
+        if label in ("", "Flat (default)"):
+            return None
+        if label == "Custom CSV…":
+            return self.target_csv_var.get().strip() or None
+        name = label_to_name(label)
+        if name is None:
+            return None
+        return str(materialize_builtin_target(name, out_dir))
+
+    def _start_hearing_fit(self, profile, out_dir: str, target_path: str | None = None) -> None:
         from ..pipeline import run_hearing_fit
         self._run_background_task(
             task_name="hearing-fit",
             progress_title="Generating EQ preset from hearing profile",
             progress_body=f"Fitting EQ bands to your hearing compensation curve. Writing output to {out_dir}.",
-            worker=lambda: run_hearing_fit(profile, out_dir, sample_rate=self.state.sample_rate),
+            worker=lambda: run_hearing_fit(profile, out_dir, sample_rate=self.state.sample_rate, target_path=target_path),
             on_success=lambda result: self._set_completion(
                 title="Hearing EQ preset ready",
                 summary=f"EQ preset written to {out_dir}.",

--- a/headmatch/gui/shell.py
+++ b/headmatch/gui/shell.py
@@ -212,6 +212,7 @@ class HeadMatchGuiApp:
         self.basic_clone_target_var = tk.StringVar(master=root, value="")
         self.basic_clone_output_var = tk.StringVar(master=root, value="")
         self.hearing_profile = None  # HearingProfile | None; set after a successful test
+        self._force_new_hearing_test = False  # skip the saved-profile landing once
         self.basic_progress_var = tk.StringVar(master=root, value="")
         self.progress_title_var = tk.StringVar(master=root, value="")
         self.progress_body_var = tk.StringVar(master=root, value="")
@@ -568,6 +569,16 @@ class HeadMatchGuiApp:
         self.root.after(8000, status.destroy)
 
     def _render_hearing_test(self) -> None:
+        from ..hearing_test import load_hearing_profile
+
+        # Reuse a previously saved hearing profile instead of forcing a retest.
+        if not self._force_new_hearing_test:
+            saved = load_hearing_profile()
+            if saved is not None:
+                self._show_saved_hearing_profile_landing(saved)
+                return
+        self._force_new_hearing_test = False
+
         from ..audio_backend import get_audio_backend
         try:
             backend = get_audio_backend()
@@ -593,6 +604,48 @@ class HeadMatchGuiApp:
             on_complete=_on_complete,
             on_cancel=_on_cancel,
         )
+
+    def _show_saved_hearing_profile_landing(self, profile) -> None:
+        """Offer to reuse a saved hearing profile (regenerate EQ) or retest."""
+        for child in self.content.winfo_children():  # type: ignore[attr-defined]
+            child.destroy()
+        ttk = self._ttk
+        self.content.columnconfigure(0, weight=1)  # type: ignore[attr-defined]
+
+        determined = sum(
+            1 for side in (profile.left, profile.right) for t in side.values()
+            if getattr(t, "determined", False)
+        )
+        total = len(profile.left) + len(profile.right)
+
+        ttk.Label(self.content, text="Hearing Test", style="Title.TLabel").grid(
+            row=0, column=0, sticky="w", pady=(0, 8)
+        )
+        ttk.Label(
+            self.content,
+            text=(
+                f"A saved hearing profile from {profile.tested_at} was found "
+                f"({determined}/{total} thresholds determined). You can reuse it to "
+                "generate an EQ preset without repeating the test, or run a new test."
+            ),
+            wraplength=560,
+            justify="left",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 16))
+
+        def _use_saved() -> None:
+            self.hearing_profile = profile
+            self._show_hearing_followup(profile)
+
+        def _run_new() -> None:
+            self._force_new_hearing_test = True
+            self.show_view("hearing-test")
+
+        btn_frame = ttk.Frame(self.content)
+        btn_frame.grid(row=2, column=0, sticky="w")
+        ttk.Button(btn_frame, text="Use Saved Profile", command=_use_saved, style="Accent.TButton").grid(
+            row=0, column=0, padx=(0, 8)
+        )
+        ttk.Button(btn_frame, text="Run New Test", command=_run_new).grid(row=0, column=1)
 
     def _show_hearing_followup(self, profile) -> None:
         for child in self.content.winfo_children():  # type: ignore[attr-defined]

--- a/headmatch/gui/shell.py
+++ b/headmatch/gui/shell.py
@@ -251,18 +251,8 @@ class HeadMatchGuiApp:
         self.input_target_var.set(self._resolve_device_display(selection.selected_capture, self.input_target_options))
 
     def _configure_theme_defaults(self) -> None:
-        style_factory = getattr(self._ttk, "Style", None)
-        if style_factory is None:
-            return
-        styles = style_factory(self.root)
-        try:
-            current_theme = styles.theme_use()
-        except Exception:
-            current_theme = None
-        if current_theme:
-            styles.theme_use(current_theme)
-        styles.configure("Title.TLabel", font=("TkDefaultFont", 14, "bold"))
-        styles.configure("Heading.TLabel", font=("TkDefaultFont", 10, "bold"))
+        from .theme import apply_theme
+        apply_theme(self._ttk, self.root)
 
     def _build_shell(self) -> None:
         ttk = self._ttk
@@ -631,7 +621,7 @@ class HeadMatchGuiApp:
 
         btn_frame = ttk.Frame(self.content)
         btn_frame.grid(row=2, column=0, sticky="w")
-        ttk.Button(btn_frame, text="Generate EQ Preset Now", command=_generate_now).grid(
+        ttk.Button(btn_frame, text="Generate EQ Preset Now", command=_generate_now, style="Accent.TButton").grid(
             row=0, column=0, padx=(0, 8)
         )
         ttk.Button(

--- a/headmatch/gui/theme.py
+++ b/headmatch/gui/theme.py
@@ -1,0 +1,106 @@
+"""Cross-platform ttk theming for the HeadMatch GUI.
+
+HeadMatch standardises on the bundled ``clam`` theme on every platform rather
+than the OS-native theme. ``clam`` honours ``background`` / ``foreground`` /
+``style.map`` customisation, whereas macOS's ``aqua`` ignores most of it (and
+rejects options such as ``-background`` on ttk widgets — see
+``headmatch.gui.widgets.theme_background``). Standardising on ``clam`` gives a
+consistent, customisable look across platforms *and* sidesteps the aqua
+pitfalls that previously crashed the hearing-test view.
+"""
+from __future__ import annotations
+
+PALETTE = {
+    "bg": "#f4f5f7",          # window / frame background
+    "surface": "#ffffff",     # entries, text areas, cards
+    "accent": "#3b6ea5",      # primary actions (calm slate-blue)
+    "accent_active": "#2f5985",
+    "accent_text": "#ffffff",
+    "text": "#1f2430",
+    "muted": "#6b7280",
+    "border": "#d4d8e0",
+    "disabled": "#9aa1ad",
+}
+
+BASE_FONT = ("TkDefaultFont", 10)
+TITLE_FONT = ("TkDefaultFont", 16, "bold")
+HEADING_FONT = ("TkDefaultFont", 10, "bold")
+SUBTITLE_FONT = ("TkDefaultFont", 11)
+
+
+def apply_theme(ttk, root=None, palette=None) -> bool:
+    """Apply the HeadMatch ``clam``-based theme.
+
+    Returns ``True`` when styling was applied, ``False`` when the toolkit
+    exposes no ``Style`` factory (e.g. the mocked widgets used in tests), in
+    which case the call is a no-op. Every individual styling call is guarded so
+    that an unexpected platform never hard-fails GUI construction over cosmetics.
+    """
+    style_factory = getattr(ttk, "Style", None)
+    if style_factory is None:
+        return False
+
+    p = {**PALETTE, **(palette or {})}
+    styles = style_factory(root) if root is not None else style_factory()
+
+    try:
+        styles.theme_use("clam")
+    except Exception:
+        # 'clam' ships with Tk everywhere, but never hard-fail on theming:
+        # fall back to whatever theme is already active.
+        try:
+            current = styles.theme_use()
+            if current:
+                styles.theme_use(current)
+        except Exception:
+            pass
+
+    def _cfg(*args, **kwargs) -> None:
+        try:
+            styles.configure(*args, **kwargs)
+        except Exception:
+            pass
+
+    def _map(*args, **kwargs) -> None:
+        try:
+            styles.map(*args, **kwargs)
+        except Exception:
+            pass
+
+    _cfg(".", background=p["bg"], foreground=p["text"], font=BASE_FONT,
+         bordercolor=p["border"], focuscolor=p["accent"])
+    _cfg("TFrame", background=p["bg"])
+    _cfg("TLabel", background=p["bg"], foreground=p["text"])
+    _cfg("Title.TLabel", font=TITLE_FONT, foreground=p["text"])
+    _cfg("Heading.TLabel", font=HEADING_FONT, foreground=p["muted"])
+    _cfg("Subtitle.TLabel", font=SUBTITLE_FONT, foreground=p["muted"])
+
+    _cfg("TButton", padding=(12, 6), background=p["surface"], foreground=p["text"],
+         bordercolor=p["border"], focusthickness=1, focuscolor=p["accent"])
+    _map("TButton",
+         background=[("active", p["border"]), ("pressed", p["border"])],
+         foreground=[("disabled", p["disabled"])])
+
+    _cfg("Accent.TButton", padding=(14, 7), background=p["accent"],
+         foreground=p["accent_text"], font=HEADING_FONT, bordercolor=p["accent"])
+    _map("Accent.TButton",
+         background=[("active", p["accent_active"]), ("pressed", p["accent_active"]),
+                     ("disabled", p["border"])],
+         foreground=[("disabled", p["disabled"])])
+
+    _cfg("TEntry", fieldbackground=p["surface"], bordercolor=p["border"],
+         foreground=p["text"], padding=4)
+    _cfg("TCombobox", fieldbackground=p["surface"], background=p["surface"],
+         bordercolor=p["border"], foreground=p["text"], padding=4)
+    _cfg("TLabelframe", background=p["bg"], bordercolor=p["border"])
+    _cfg("TLabelframe.Label", background=p["bg"], foreground=p["muted"], font=HEADING_FONT)
+    _cfg("TCheckbutton", background=p["bg"], foreground=p["text"])
+    _cfg("TRadiobutton", background=p["bg"], foreground=p["text"])
+    _cfg("Vertical.TScrollbar", background=p["bg"], troughcolor=p["bg"], bordercolor=p["border"])
+
+    if root is not None:
+        try:
+            root.configure(background=p["bg"])
+        except Exception:
+            pass
+    return True

--- a/headmatch/gui/views/_legacy.py
+++ b/headmatch/gui/views/_legacy.py
@@ -240,7 +240,7 @@ def render_completion(ttk, frame, *, title: str, body: str, steps: tuple[str, ..
         card = ttk.LabelFrame(frame, text="EQ clipping assessment", padding=SECTION_PAD)
         card.grid(row=row, column=0, sticky="ew")
         card.columnconfigure(1, weight=1)
-        indicator = "⚠" if clipping_assessment.get("will_clip") else "✓"
+        indicator = "[!]" if clipping_assessment.get("will_clip") else "[OK]"
         status = "Clipping risk detected" if clipping_assessment.get("will_clip") else "No clipping risk detected"
         ttk.Label(card, text=f"{indicator} {status}", style="Heading.TLabel").grid(row=0, column=0, columnspan=2, sticky="w")
         ttk.Label(card, text="Preamp recommendation").grid(row=1, column=0, sticky="w", padx=(0, 12), pady=2)
@@ -330,9 +330,9 @@ def render_history(ttk, frame, *, history_root_var, config_path: Path):
 
 
 _CONFIDENCE_BADGES = {
-    'high': '✓',
-    'medium': '⚠',
-    'low': '✗',
+    'high': '[OK]',
+    'medium': '[!]',
+    'low': '[X]',
 }
 
 
@@ -783,7 +783,7 @@ def render_target_editor(ttk, frame, *, editor, on_save, on_reset, on_load=None,
         ttk.Button(points_frame, text="+", command=_add_after, width=3).grid(
             row=row, column=3, sticky="w", pady=2)
         if len(editor.points) > 2:
-            ttk.Button(points_frame, text="\u2715", command=lambda i=idx: _remove_point(i), width=3).grid(
+            ttk.Button(points_frame, text="X", command=lambda i=idx: _remove_point(i), width=3).grid(
                 row=row, column=4, sticky="w", pady=2)
 
     _vars["setup_done"] = True

--- a/headmatch/gui/views/common.py
+++ b/headmatch/gui/views/common.py
@@ -69,7 +69,7 @@ def render_history(ttk, frame, *, history_root_var, config_path: Path):
     return build_history_selection(history_root_var.get(), config_path.parent)
 
 
-_CONFIDENCE_BADGES = {'high': '✓', 'medium': '⚠', 'low': '✗'}
+_CONFIDENCE_BADGES = {'high': '[OK]', 'medium': '[!]', 'low': '[X]'}
 
 
 def _confidence_display(label: str) -> str:

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -25,6 +25,13 @@ from ..widgets import theme_background
 from datetime import datetime, timezone
 
 
+# Speaker-status strings. Kept ASCII-only — decorative glyphs (♪ ✓ — …) fail to
+# render in some platform Tk fonts and show as tofu/boxes.
+_STATUS_PLAYING = "Playing tone..."
+_STATUS_HEARD = "Heard"
+_STATUS_NOT_HEARD = "Not heard"
+
+
 _FREQ_LABELS = {
     500: "500 Hz",
     1000: "1 kHz",
@@ -86,7 +93,7 @@ def render_hearing_test(
         """Play tone in a background thread so Tkinter stays responsive."""
         def _worker():
             try:
-                samples = generate_tone(freq_hz, level_dbfs, sample_rate)
+                samples = generate_tone(freq_hz, level_dbfs, sample_rate, ear=_state["ear"])
                 backend.play_tone(samples, sample_rate, output_device)
             except Exception:
                 pass
@@ -212,7 +219,7 @@ def render_hearing_test(
         ).grid(row=1, column=0, sticky="w", pady=(0, 12))
 
         # Speaker indicator
-        _state["speaker_label_var"] = tk.StringVar(value="♪ Playing tone …")
+        _state["speaker_label_var"] = tk.StringVar(value=_STATUS_PLAYING)
         ttk.Label(frame, textvariable=_state["speaker_label_var"]).grid(
             row=2, column=0, sticky="w", pady=(0, 12)
         )
@@ -244,7 +251,7 @@ def render_hearing_test(
         # Update speaker indicator
         speaker_var = _state.get("speaker_label_var")
         if speaker_var:
-            speaker_var.set("♪ Playing tone …")
+            speaker_var.set(_STATUS_PLAYING)
 
         _play_tone_async(freq_hz, level)
 
@@ -264,7 +271,7 @@ def render_hearing_test(
         engine.record_response(True)
         speaker_var = _state.get("speaker_label_var")
         if speaker_var:
-            speaker_var.set("✓ Heard")
+            speaker_var.set(_STATUS_HEARD)
         if engine.done:
             frame.after(300, _on_freq_done)
         else:
@@ -279,7 +286,7 @@ def render_hearing_test(
         engine.record_response(False)
         speaker_var = _state.get("speaker_label_var")
         if speaker_var:
-            speaker_var.set("— Not heard")
+            speaker_var.set(_STATUS_NOT_HEARD)
         if engine.done:
             frame.after(300, _on_freq_done)
         else:

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -137,7 +137,7 @@ def render_hearing_test(
 
         btn_frame = ttk.Frame(frame)
         btn_frame.grid(row=3, column=0, sticky="w")
-        ttk.Button(btn_frame, text="Start Test", command=_begin_left).grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btn_frame, text="Start Test", command=_begin_left, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
         ttk.Button(btn_frame, text="Cancel", command=on_cancel).grid(row=0, column=1)
 
     def _begin_left():
@@ -164,7 +164,7 @@ def render_hearing_test(
             text=f"Cover or plug your {cover} ear. Click Ready when set.",
             wraplength=560,
         ).grid(row=1, column=0, sticky="w", pady=(0, 16))
-        ttk.Button(frame, text="Ready — Start", command=callback).grid(row=2, column=0, sticky="w")
+        ttk.Button(frame, text="Ready — Start", command=callback, style="Accent.TButton").grid(row=2, column=0, sticky="w")
         ttk.Button(frame, text="Stop Test", command=_stop_test).grid(row=3, column=0, sticky="w", pady=(8, 0))
 
     # ── test loop ─────────────────────────────────────────────────────────────
@@ -406,7 +406,7 @@ def render_hearing_test(
             save_hearing_profile(profile)
             on_cancel()
 
-        ttk.Button(btn_frame, text="Save & Use for EQ", command=_save_and_apply).grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btn_frame, text="Save & Use for EQ", command=_save_and_apply, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
         ttk.Button(btn_frame, text="Save Without Applying", command=_save_only).grid(row=0, column=1, padx=(0, 8))
         ttk.Button(btn_frame, text="Discard", command=on_cancel).grid(row=0, column=2)
 

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -31,6 +31,29 @@ _STATUS_PLAYING = "Playing tone..."
 _STATUS_HEARD = "Heard"
 _STATUS_NOT_HEARD = "Not heard"
 
+# Intro instructions shown before the test starts. ASCII-only so they render in
+# every platform Tk font. The volume guidance matters: if the volume is too
+# high the listener hears every tone, no threshold can be found, and the
+# staircase only stops via the engine's safety cap.
+_INTRO_INSTRUCTIONS = (
+    "Before you start:",
+    "  - Set your headphone volume to a comfortable",
+    "    music-listening level, then leave it unchanged",
+    "    for the whole test.",
+    "  - Volume check: at the right level the quietest tones",
+    "    are inaudible. If you can hear EVERY tone the volume",
+    "    is too high - turn it down, otherwise no hearing",
+    "    threshold can be measured.",
+    "  - Go to a quiet room and minimise background noise.",
+    "  - The test takes about 5 minutes total.",
+    "",
+    "During the test:",
+    "  - Click 'I hear it' each time you hear a tone.",
+    "  - If you don't hear a tone, do nothing; it advances",
+    "    automatically.",
+    "  - Test your LEFT ear first, then your RIGHT ear.",
+)
+
 
 _FREQ_LABELS = {
     500: "500 Hz",
@@ -122,23 +145,12 @@ def render_hearing_test(
             justify="left",
         ).grid(row=1, column=0, sticky="w", pady=(0, 12))
 
-        instructions = (
-            "Before you start:",
-            "  • Set your headphone volume to a comfortable music-listening level.",
-            "  • Go to a quiet room.",
-            "  • The test takes about 5 minutes total.",
-            "",
-            "During the test:",
-            "  • Click 'I hear it' each time you hear a tone.",
-            "  • If you don't hear the tone, do nothing — the test advances automatically.",
-            "  • Test your LEFT ear first, then your RIGHT ear.",
-        )
         info_text = tk.Text(
-            frame, height=10, width=62, state="normal",
+            frame, height=len(_INTRO_INSTRUCTIONS) + 1, width=62, state="normal",
             relief="flat", background=theme_background(ttk),
             wrap="word",
         )
-        info_text.insert("1.0", "\n".join(instructions))
+        info_text.insert("1.0", "\n".join(_INTRO_INSTRUCTIONS))
         info_text.configure(state="disabled")
         info_text.grid(row=2, column=0, sticky="ew", pady=(0, 16))
 

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -59,6 +59,11 @@ RESPONSE_WINDOW_S: float = 3.0
 
 GAIN_FRACTION: float = 0.50         # half-gain rule (Lybarger 1944)
 MAX_COMPENSATION_DB: float = 12.0
+# Self-administered, uncalibrated thresholds have ~5 dB+ test-retest spread
+# (Saliba et al. 2022, AJA), and the half-gain rule over-prescribes for mild
+# losses (Schwartz et al. 1980). Ignore measured "loss" below this deadband so
+# we don't EQ within-noise differences. See docs/designs/measurement-resolution-eq.md.
+HEARING_DEADBAND_DB: float = 10.0
 ASYMMETRY_WARNING_DB: float = 15.0
 NOISE_GATE_THRESHOLD_DBFS: float = -30.0
 
@@ -288,6 +293,8 @@ def compute_compensation_points(profile: HearingProfile) -> dict[int, float]:
         avg_threshold = float(np.mean(thresholds))
         ref = NORMAL_HEARING_REFERENCE.get(freq_hz, -50.0)
         loss = avg_threshold - ref  # positive = worse than reference
+        if loss < HEARING_DEADBAND_DB:
+            continue  # within self-test noise / clinically insignificant — don't EQ
         gain = float(np.clip(loss * GAIN_FRACTION, 0.0, MAX_COMPENSATION_DB))
         points[freq_hz] = round(gain, 2)
     return points
@@ -306,72 +313,51 @@ def _peaking_q_for_octave_bandwidth(n_octaves: float) -> float:
 def eq_bands_from_gain_points(
     points: dict[int, float],
     *,
+    sample_rate: int | None = None,
     max_filters: int | None = None,
     max_gain_db: float = MAX_COMPENSATION_DB,
     min_gain_db: float = 0.1,
 ) -> list:
     """Build peaking PEQ bands placed directly at the measured frequencies.
 
-    One peaking filter per frequency with a non-trivial gain; the Q of each
-    band is derived from its spacing to neighbouring measured frequencies so
-    adjacent bands meet near their -3 dB points instead of overlapping. When
-    ``max_filters`` is set and fewer are allowed than there are points, the
-    largest-magnitude bands are kept.
+    One peaking filter per frequency; each band's Q is derived from its spacing
+    to neighbouring measured frequencies. When ``sample_rate`` is given, the band
+    gains are solved by interaction-aware least squares so the realised chain
+    matches the target points (overlapping bands sum) rather than each band
+    taking its raw point gain. ``max_filters`` keeps the largest-magnitude bands.
     """
-    from .peq import PEQBand
+    from .peq import PEQBand, solve_band_gains_lsq
 
     freqs = sorted(points)
     if not freqs:
         return []
     logs = [np.log2(f) for f in freqs]
 
-    bands: list = []
-    for i, freq in enumerate(freqs):
-        gain = float(np.clip(points[freq], -max_gain_db, max_gain_db))
-        if abs(gain) < min_gain_db:
-            continue
+    qs: list[float] = []
+    for i, _freq in enumerate(freqs):
         gaps = []
         if i > 0:
             gaps.append(logs[i] - logs[i - 1])
         if i < len(freqs) - 1:
             gaps.append(logs[i + 1] - logs[i])
         n_oct = float(np.mean(gaps)) if gaps else 1.0
-        q = round(min(4.5, max(0.5, _peaking_q_for_octave_bandwidth(n_oct))), 3)
-        bands.append(PEQBand("peaking", float(freq), round(gain, 2), q))
+        qs.append(round(min(4.5, max(0.5, _peaking_q_for_octave_bandwidth(n_oct))), 3))
 
+    target = [float(points[f]) for f in freqs]
+    if sample_rate:
+        gains = solve_band_gains_lsq(freqs, target, sample_rate, freqs, qs, max_gain_db=max_gain_db)
+    else:
+        gains = [float(np.clip(g, -max_gain_db, max_gain_db)) for g in target]
+
+    bands: list = [
+        PEQBand("peaking", float(f), round(g, 2), q)
+        for f, g, q in zip(freqs, gains, qs)
+        if abs(g) >= min_gain_db
+    ]
     if max_filters is not None and len(bands) > max_filters:
         bands = sorted(bands, key=lambda b: abs(b.gain_db), reverse=True)[:max_filters]
         bands.sort(key=lambda b: b.freq)
     return bands
-
-
-def hearing_graphiceq_curve(
-    points: dict[int, float],
-    f_min: float = 20.0,
-    f_max: float = 20000.0,
-) -> tuple[list[float], list[float]]:
-    """Compact GraphicEQ curve from the measured points, with hold-edge anchors.
-
-    Returns ``(freqs_hz, gains_db)`` consisting of the measured frequencies plus
-    flat-held anchors at ``f_min``/``f_max`` so Equalizer APO / EasyEffects bound
-    their interpolation instead of ramping to zero. Tiny by construction (≤9
-    points) — no dense grid is manufactured from the ~7 measured points.
-    """
-    freqs = sorted(points)
-    if not freqs:
-        return [f_min, f_max], [0.0, 0.0]
-    out_f: list[float] = []
-    out_g: list[float] = []
-    if freqs[0] > f_min:
-        out_f.append(f_min)
-        out_g.append(points[freqs[0]])  # hold lowest measured gain down to f_min
-    for f in freqs:
-        out_f.append(float(f))
-        out_g.append(round(float(points[f]), 2))
-    if freqs[-1] < f_max:
-        out_f.append(f_max)
-        out_g.append(points[freqs[-1]])  # hold highest measured gain up to f_max
-    return out_f, out_g
 
 
 def compute_compensation_curve(profile: HearingProfile, freq_grid: np.ndarray) -> np.ndarray:

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -46,6 +46,12 @@ STEP_UP_DB: float = 5.0             # increase after no response
 MAX_ASCENDING_RUNS: int = 8
 THRESHOLD_RESPONSES_NEEDED: int = 2
 THRESHOLD_WINDOW: int = 3
+# Safety cap: the Hughson-Westlake staircase only completes via ascending runs,
+# which require misses. A listener who hears (or misses) every presentation
+# never produces an ascending run, so without this cap the frequency would
+# never finish and the test would hang on it. 30 is well above a normal
+# convergence (~10-20 presentations).
+MAX_PRESENTATIONS: int = 30
 RESPONSE_WINDOW_S: float = 3.0
 
 # ── Compensation parameters ───────────────────────────────────────────────────
@@ -144,6 +150,8 @@ class ThresholdEngine:
         self._ascending_hits: list[float] = []
         self._done = False
         self._threshold: float | None = None
+        self._presentations = 0     # total tones presented (safety cap)
+        self._ever_heard = False    # any heard response at all
 
     @property
     def current_level_dbfs(self) -> float:
@@ -166,7 +174,9 @@ class ThresholdEngine:
         if self._done:
             return
 
+        self._presentations += 1
         if heard:
+            self._ever_heard = True
             if self._in_ascending:
                 self._run_count += 1
                 self._ascending_hits.append(round(self._level, 2))
@@ -187,6 +197,20 @@ class ThresholdEngine:
             self._level = min(MAX_LEVEL_DBFS, self._level + STEP_UP_DB)
             self._in_ascending = True
 
+        # Safety cap: guarantee termination even when the staircase never
+        # produces an ascending run (listener hears or misses everything).
+        if not self._done and self._presentations >= MAX_PRESENTATIONS:
+            est = self._best_estimate()
+            if est is not None:
+                self._threshold = est
+            elif self._ever_heard:
+                # Heard even the quietest tone -> threshold at/near the floor.
+                self._threshold = round(self._level, 2)
+            else:
+                # Never heard anything -> threshold genuinely undetermined.
+                self._threshold = None
+            self._done = True
+
     def _check_threshold(self) -> float | None:
         if self._run_count < 3:
             return None
@@ -204,10 +228,15 @@ class ThresholdEngine:
 
 # ── Tone generation ───────────────────────────────────────────────────────────
 
-def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000) -> np.ndarray:
+def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000,
+                  ear: str = "both") -> np.ndarray:
     """
     Return a stereo (N, 2) float64 buffer: a pure sine at freq_hz scaled to
     level_dbfs, with 30 ms raised-cosine onset and offset ramps.
+
+    ``ear`` routes the tone to a single channel so that a one-ear threshold
+    test is actually measured in that ear: "left" silences the right channel,
+    "right" silences the left, and "both" (default) plays the tone in both.
     """
     n_total = int(round(TONE_DURATION_S * sample_rate))
     n_ramp = int(round(RAMP_DURATION_S * sample_rate))
@@ -221,6 +250,13 @@ def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000) -> 
         mono[-n_ramp:] *= ramp[::-1]
 
     mono *= 10.0 ** (level_dbfs / 20.0)
+    silent = np.zeros_like(mono)
+
+    side = (ear or "both").lower()
+    if side == "left":
+        return np.column_stack([mono, silent])
+    if side == "right":
+        return np.column_stack([silent, mono])
     return np.column_stack([mono, mono])
 
 
@@ -373,7 +409,7 @@ def run_cli_hearing_test(
 
             while not engine.done:
                 level = engine.current_level_dbfs
-                samples = generate_tone(freq_hz, level, sample_rate)
+                samples = generate_tone(freq_hz, level, sample_rate, ear=ear_label.lower())
                 backend.play_tone(samples, sample_rate, output_device)
                 heard = _ask_heard(RESPONSE_WINDOW_S)
                 engine.record_response(heard)

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -49,10 +49,10 @@ THRESHOLD_WINDOW: int = 3
 # Safety cap: the Hughson-Westlake staircase only completes via ascending runs,
 # which require misses. A listener who hears (or misses) every presentation
 # never produces an ascending run, so without this cap the frequency would
-# never finish and the test would hang on it. 20 is above a normal
-# convergence (~10-15 presentations) but bails out promptly on a degenerate
-# (hear-everything / miss-everything) response pattern.
-MAX_PRESENTATIONS: int = 20
+# never finish and the test would hang on it. 10 keeps each frequency short
+# (it also bounds the descent for very good hearing, which otherwise feels
+# like it takes forever) while still allowing a normal staircase to resolve.
+MAX_PRESENTATIONS: int = 10
 RESPONSE_WINDOW_S: float = 3.0
 
 # ── Compensation parameters ───────────────────────────────────────────────────
@@ -263,6 +263,117 @@ def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000,
 
 # ── Compensation curve ────────────────────────────────────────────────────────
 
+def compute_compensation_points(profile: HearingProfile) -> dict[int, float]:
+    """Half-gain EQ compensation (dB) at each *determined* audiometric frequency.
+
+    Returns ``{freq_hz: gain_db}`` keyed by the ISO 8253 test frequencies. L/R
+    thresholds are averaged; undetermined frequencies are omitted. This is the
+    raw, measurement-resolution compensation — the hearing test has only these
+    ~7 degrees of freedom, so the EQ is built directly from these points rather
+    than from a dense interpolated grid.
+    """
+    points: dict[int, float] = {}
+    for freq_hz in TEST_FREQUENCIES:
+        left_t = profile.left.get(freq_hz)
+        right_t = profile.right.get(freq_hz)
+
+        thresholds: list[float] = []
+        if left_t is not None and left_t.determined and left_t.level_dbfs is not None:
+            thresholds.append(left_t.level_dbfs)
+        if right_t is not None and right_t.determined and right_t.level_dbfs is not None:
+            thresholds.append(right_t.level_dbfs)
+        if not thresholds:
+            continue
+
+        avg_threshold = float(np.mean(thresholds))
+        ref = NORMAL_HEARING_REFERENCE.get(freq_hz, -50.0)
+        loss = avg_threshold - ref  # positive = worse than reference
+        gain = float(np.clip(loss * GAIN_FRACTION, 0.0, MAX_COMPENSATION_DB))
+        points[freq_hz] = round(gain, 2)
+    return points
+
+
+def _peaking_q_for_octave_bandwidth(n_octaves: float) -> float:
+    """Q of a peaking filter whose -3 dB bandwidth spans ``n_octaves``.
+
+    Standard relationship: Q = sqrt(2^N) / (2^N - 1). For N=1 octave Q≈1.41;
+    for N=0.5 octave Q≈2.87.
+    """
+    n = max(0.05, float(n_octaves))
+    return float((2.0 ** (n / 2.0)) / (2.0 ** n - 1.0))
+
+
+def eq_bands_from_gain_points(
+    points: dict[int, float],
+    *,
+    max_filters: int | None = None,
+    max_gain_db: float = MAX_COMPENSATION_DB,
+    min_gain_db: float = 0.1,
+) -> list:
+    """Build peaking PEQ bands placed directly at the measured frequencies.
+
+    One peaking filter per frequency with a non-trivial gain; the Q of each
+    band is derived from its spacing to neighbouring measured frequencies so
+    adjacent bands meet near their -3 dB points instead of overlapping. When
+    ``max_filters`` is set and fewer are allowed than there are points, the
+    largest-magnitude bands are kept.
+    """
+    from .peq import PEQBand
+
+    freqs = sorted(points)
+    if not freqs:
+        return []
+    logs = [np.log2(f) for f in freqs]
+
+    bands: list = []
+    for i, freq in enumerate(freqs):
+        gain = float(np.clip(points[freq], -max_gain_db, max_gain_db))
+        if abs(gain) < min_gain_db:
+            continue
+        gaps = []
+        if i > 0:
+            gaps.append(logs[i] - logs[i - 1])
+        if i < len(freqs) - 1:
+            gaps.append(logs[i + 1] - logs[i])
+        n_oct = float(np.mean(gaps)) if gaps else 1.0
+        q = round(min(4.5, max(0.5, _peaking_q_for_octave_bandwidth(n_oct))), 3)
+        bands.append(PEQBand("peaking", float(freq), round(gain, 2), q))
+
+    if max_filters is not None and len(bands) > max_filters:
+        bands = sorted(bands, key=lambda b: abs(b.gain_db), reverse=True)[:max_filters]
+        bands.sort(key=lambda b: b.freq)
+    return bands
+
+
+def hearing_graphiceq_curve(
+    points: dict[int, float],
+    f_min: float = 20.0,
+    f_max: float = 20000.0,
+) -> tuple[list[float], list[float]]:
+    """Compact GraphicEQ curve from the measured points, with hold-edge anchors.
+
+    Returns ``(freqs_hz, gains_db)`` consisting of the measured frequencies plus
+    flat-held anchors at ``f_min``/``f_max`` so Equalizer APO / EasyEffects bound
+    their interpolation instead of ramping to zero. Tiny by construction (≤9
+    points) — no dense grid is manufactured from the ~7 measured points.
+    """
+    freqs = sorted(points)
+    if not freqs:
+        return [f_min, f_max], [0.0, 0.0]
+    out_f: list[float] = []
+    out_g: list[float] = []
+    if freqs[0] > f_min:
+        out_f.append(f_min)
+        out_g.append(points[freqs[0]])  # hold lowest measured gain down to f_min
+    for f in freqs:
+        out_f.append(float(f))
+        out_g.append(round(float(points[f]), 2))
+    if freqs[-1] < f_max:
+        out_f.append(f_max)
+        out_g.append(points[freqs[-1]])  # hold highest measured gain up to f_max
+    return out_f, out_g
+
+
 def compute_compensation_curve(profile: HearingProfile, freq_grid: np.ndarray) -> np.ndarray:
     """
     Convert a HearingProfile to per-frequency EQ gain (dB) on freq_grid.
@@ -275,32 +386,12 @@ def compute_compensation_curve(profile: HearingProfile, freq_grid: np.ndarray) -
     The 7-point gain array is interpolated to freq_grid via cubic spline on
     log-frequency, then 1-octave Gaussian-smoothed to remove sharp peaks.
     """
-    test_freqs: list[float] = []
-    test_gains: list[float] = []
-
-    for freq_hz in TEST_FREQUENCIES:
-        left_t = profile.left.get(freq_hz)
-        right_t = profile.right.get(freq_hz)
-
-        thresholds: list[float] = []
-        if left_t is not None and left_t.determined and left_t.level_dbfs is not None:
-            thresholds.append(left_t.level_dbfs)
-        if right_t is not None and right_t.determined and right_t.level_dbfs is not None:
-            thresholds.append(right_t.level_dbfs)
-
-        if not thresholds:
-            continue
-
-        avg_threshold = float(np.mean(thresholds))
-        ref = NORMAL_HEARING_REFERENCE.get(freq_hz, -50.0)
-        loss = avg_threshold - ref  # positive = worse than reference
-        gain = float(np.clip(loss * GAIN_FRACTION, 0.0, MAX_COMPENSATION_DB))
-
-        test_freqs.append(float(freq_hz))
-        test_gains.append(gain)
-
-    if len(test_freqs) < 2:
+    points = compute_compensation_points(profile)
+    if len(points) < 2:
         return np.zeros(len(freq_grid))
+
+    test_freqs = [float(f) for f in sorted(points)]
+    test_gains = [points[int(f)] for f in test_freqs]
 
     log_test = np.log10(test_freqs)
     cs = CubicSpline(log_test, test_gains, bc_type="not-a-knot", extrapolate=True)

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -49,9 +49,10 @@ THRESHOLD_WINDOW: int = 3
 # Safety cap: the Hughson-Westlake staircase only completes via ascending runs,
 # which require misses. A listener who hears (or misses) every presentation
 # never produces an ascending run, so without this cap the frequency would
-# never finish and the test would hang on it. 30 is well above a normal
-# convergence (~10-20 presentations).
-MAX_PRESENTATIONS: int = 30
+# never finish and the test would hang on it. 20 is above a normal
+# convergence (~10-15 presentations) but bails out promptly on a degenerate
+# (hear-everything / miss-everything) response pattern.
+MAX_PRESENTATIONS: int = 20
 RESPONSE_WINDOW_S: float = 3.0
 
 # ── Compensation parameters ───────────────────────────────────────────────────

--- a/headmatch/history.py
+++ b/headmatch/history.py
@@ -130,9 +130,9 @@ def build_history_selection(search_root: str | Path, config_root: str | Path | N
 # ── Display helpers ──
 
 _CONFIDENCE_ICONS = {
-    "high": "\u2713",   # ✓
-    "medium": "\u26A0", # ⚠
-    "low": "\u2717",    # ✗
+    "high": "[OK]",
+    "medium": "[!]",
+    "low": "[X]",
 }
 
 

--- a/headmatch/peq.py
+++ b/headmatch/peq.py
@@ -220,6 +220,39 @@ def peq_chain_response_db(freqs_hz: np.ndarray, fs: int, bands: List[PEQBand]) -
     return total
 
 
+def solve_band_gains_lsq(
+    target_freqs_hz: "np.ndarray | list[float]",
+    target_gains_db: "np.ndarray | list[float]",
+    sample_rate: int,
+    band_freqs_hz: "np.ndarray | list[float]",
+    band_qs: "np.ndarray | list[float]",
+    *,
+    max_gain_db: float = 12.0,
+) -> list[float]:
+    """Solve per-band peaking-filter gains so the realised chain matches a sparse
+    target, accounting for inter-band interaction (overlapping bands sum).
+
+    Builds an interaction matrix M (response in dB at each target frequency of
+    each unit-gain band) and solves M·g = target by least squares, then clamps
+    to ±max_gain_db. This is the weighted-least-squares realisation recommended
+    in the graphic-EQ literature (Välimäki & Liski; Rämö et al.), rather than
+    assigning each band its raw point gain and ignoring overlap.
+    """
+    tfreqs = np.asarray(target_freqs_hz, dtype=np.float64)
+    tgains = np.asarray(target_gains_db, dtype=np.float64)
+    band_freqs = list(band_freqs_hz)
+    band_qs = list(band_qs)
+    if not band_freqs:
+        return []
+    columns = [
+        biquad_response_db(tfreqs, sample_rate, PEQBand("peaking", float(f), 1.0, float(q)))
+        for f, q in zip(band_freqs, band_qs)
+    ]
+    matrix = np.column_stack(columns)
+    gains, *_ = np.linalg.lstsq(matrix, tgains, rcond=None)
+    return [float(np.clip(g, -max_gain_db, max_gain_db)) for g in gains]
+
+
 def graphic_eq_bands(profile: GraphicEQProfile, gains_db: np.ndarray | list[float]) -> list[PEQBand]:
     gains = list(gains_db)
     return [PEQBand("peaking", float(freq), float(gain), profile.q) for freq, gain in zip(profile.freqs_hz, gains)]

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -202,11 +202,19 @@ def fit_from_hearing_profile(
         eq_target(f) = target(f) + hearing_compensation(f)
     where compensation comes from the half-gain rule (Lybarger 1944).
     """
-    from .hearing_test import compute_compensation_curve
+    from .hearing_test import (
+        compute_compensation_curve,
+        compute_compensation_points,
+        eq_bands_from_gain_points,
+    )
     from .signals import geometric_log_grid
 
     filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
-    freqs = geometric_log_grid(20.0, 20000.0, 512)
+    # Modest grid used only for the prediction/clipping metrics and target
+    # sampling — NOT for manufacturing EQ resolution. The hearing test has only
+    # ~7 measured points, so the EQ is built directly from those (see
+    # docs/designs/measurement-resolution-eq.md).
+    freqs = geometric_log_grid(20.0, 20000.0, 48)
     flat = np.zeros(len(freqs))
 
     if target_path:
@@ -222,8 +230,17 @@ def fit_from_hearing_profile(
     compensation = compute_compensation_curve(profile, freqs)
     eq_target = target_values + compensation
 
-    left_bands = fit_peq(freqs, eq_target, sample_rate, max_filters=max_filters, budget=filter_budget)
-    right_bands = fit_peq(freqs, eq_target, sample_rate, max_filters=max_filters, budget=filter_budget)
+    # Build the EQ directly from the measured audiometric frequencies: combine
+    # per-frequency hearing compensation with the target sampled at those same
+    # frequencies, then place one peaking filter per point (Q from spacing).
+    comp_points = compute_compensation_points(profile)
+    eq_points = {
+        f: round(g + float(np.interp(f, target_resampled.freqs_hz, target_resampled.values_db)), 2)
+        for f, g in comp_points.items()
+    }
+    bands = eq_bands_from_gain_points(eq_points, max_filters=filter_budget.max_filters)
+    left_bands = bands
+    right_bands = list(bands)
 
     left_pred = flat + peq_chain_response_db(freqs, sample_rate, left_bands)
     right_pred = flat + peq_chain_response_db(freqs, sample_rate, right_bands)
@@ -252,6 +269,7 @@ def fit_from_hearing_profile(
         },
         'left_bands': [asdict(b) for b in left_bands],
         'right_bands': [asdict(b) for b in right_bands],
+        'hearing_eq_points': {str(f): g for f, g in eq_points.items()},
     }
     clipping_assessment = assess_eq_clipping(freqs, sample_rate, left_bands, right_bands)
     report['eq_clipping'] = {
@@ -338,14 +356,17 @@ def run_hearing_fit(
     export_camilladsp_filters_yaml(out_dir / 'camilladsp_full.yaml', left_bands, right_bands, samplerate=sample_rate)
     export_camilladsp_filter_snippet_yaml(out_dir / 'camilladsp_filters_only.yaml', left_bands, right_bands)
 
-    freqs = geometric_log_grid(20.0, 20000.0, 512)
-    left_fitted_eq = peq_chain_response_db(freqs, sample_rate, left_bands)
-    right_fitted_eq = peq_chain_response_db(freqs, sample_rate, right_bands)
+    # Compact GraphicEQ keyed to the measured frequencies (+ hold-edge anchors),
+    # not a dense grid interpolated from ~7 points.
+    from .hearing_test import hearing_graphiceq_curve
+    eq_points = {int(float(k)): v for k, v in report.get('hearing_eq_points', {}).items()}
+    gq_freqs, gq_gains = hearing_graphiceq_curve(eq_points)
     export_equalizer_apo_graphiceq_txt(
         out_dir / 'equalizer_apo_graphiceq.txt',
-        freqs,
-        left_fitted_eq,
-        right_fitted_eq,
+        gq_freqs,
+        gq_gains,
+        list(gq_gains),
+        comment='; Compact GraphicEQ at the measured audiometric frequencies (+ hold-edge anchors).',
     )
 
     save_json(out_dir / 'hearing_fit_report.json', report)

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -234,9 +234,17 @@ def fit_from_hearing_profile(
     # per-frequency hearing compensation with the target sampled at those same
     # frequencies, then place one peaking filter per point (Q from spacing).
     comp_points = compute_compensation_points(profile)
+    # Control points = the measured audiometric frequencies (hearing comp) UNION the
+    # target curve's own frequencies where it deviates from neutral. The target is
+    # known independently of the hearing test, so it must apply even when there is
+    # no measurable hearing loss. gain(f) = compensation(f) + target(f).
+    tfreqs = np.asarray(target.freqs_hz, dtype=float)
+    tvals = np.asarray(target.values_db, dtype=float)
+    control = set(comp_points)
+    control.update(int(round(f)) for f, v in zip(tfreqs, tvals) if abs(v) > 0.05)
     eq_points = {
-        f: round(g + float(np.interp(f, target_resampled.freqs_hz, target_resampled.values_db)), 2)
-        for f, g in comp_points.items()
+        f: round(comp_points.get(f, 0.0) + float(np.interp(f, tfreqs, tvals)), 2)
+        for f in sorted(control)
     }
     bands = eq_bands_from_gain_points(eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
     left_bands = bands
@@ -368,6 +376,10 @@ def run_hearing_fit(
         comment='; GraphicEQ rendered on the standard 127-point grid from the fitted bands.',
     )
 
+    # Drop a copy of the raw hearing profile alongside the EQ artifacts for
+    # traceability (the canonical copy still lives in the config dir).
+    if hasattr(profile, 'to_dict'):
+        save_json(out_dir / 'hearing_profile.json', profile.to_dict())
     save_json(out_dir / 'hearing_fit_report.json', report)
     _write_hearing_fit_readme(out_dir, report)
 

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -238,7 +238,7 @@ def fit_from_hearing_profile(
         f: round(g + float(np.interp(f, target_resampled.freqs_hz, target_resampled.values_db)), 2)
         for f, g in comp_points.items()
     }
-    bands = eq_bands_from_gain_points(eq_points, max_filters=filter_budget.max_filters)
+    bands = eq_bands_from_gain_points(eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
     left_bands = bands
     right_bands = list(bands)
 
@@ -356,17 +356,16 @@ def run_hearing_fit(
     export_camilladsp_filters_yaml(out_dir / 'camilladsp_full.yaml', left_bands, right_bands, samplerate=sample_rate)
     export_camilladsp_filter_snippet_yaml(out_dir / 'camilladsp_filters_only.yaml', left_bands, right_bands)
 
-    # Compact GraphicEQ keyed to the measured frequencies (+ hold-edge anchors),
-    # not a dense grid interpolated from ~7 points.
-    from .hearing_test import hearing_graphiceq_curve
-    eq_points = {int(float(k)): v for k, v in report.get('hearing_eq_points', {}).items()}
-    gq_freqs, gq_gains = hearing_graphiceq_curve(eq_points)
+    # GraphicEQ rendered from the fitted bands onto the standard 127-point grid
+    # (unified across all fitting workflows; EasyEffects/APO-safe).
+    from .signals import standard_graphic_eq_grid
+    gq_freqs = standard_graphic_eq_grid()
     export_equalizer_apo_graphiceq_txt(
         out_dir / 'equalizer_apo_graphiceq.txt',
         gq_freqs,
-        gq_gains,
-        list(gq_gains),
-        comment='; Compact GraphicEQ at the measured audiometric frequencies (+ hold-edge anchors).',
+        peq_chain_response_db(gq_freqs, sample_rate, left_bands),
+        peq_chain_response_db(gq_freqs, sample_rate, right_bands),
+        comment='; GraphicEQ rendered on the standard 127-point grid from the fitted bands.',
     )
 
     save_json(out_dir / 'hearing_fit_report.json', report)

--- a/headmatch/pipeline_artifacts.py
+++ b/headmatch/pipeline_artifacts.py
@@ -209,15 +209,16 @@ def write_fit_artifacts(
         right_bands,
         preamp_db=(float(clipping['preamp_db']) if clipping and clipping.get('will_clip') else None),
     )
-    # Dense GraphicEQ: export the actual PEQ-fitted response (what the parametric
-    # preset applies), not the raw correction target.
-    left_fitted_eq = peq_chain_response_db(result.freqs_hz, sample_rate, left_bands)
-    right_fitted_eq = peq_chain_response_db(result.freqs_hz, sample_rate, right_bands)
+    # GraphicEQ: export the actual PEQ-fitted response (what the parametric preset
+    # applies) on the standard 127-point grid — unified with the hearing-fit path
+    # and comfortably loadable by Equalizer APO / EasyEffects.
+    from .signals import standard_graphic_eq_grid
+    gq_freqs = standard_graphic_eq_grid()
     export_equalizer_apo_graphiceq_txt(
         out_dir / 'equalizer_apo_graphiceq.txt',
-        result.freqs_hz,
-        left_fitted_eq,
-        right_fitted_eq,
+        gq_freqs,
+        peq_chain_response_db(gq_freqs, sample_rate, left_bands),
+        peq_chain_response_db(gq_freqs, sample_rate, right_bands),
     )
     _write_fixed_band_graphiceq_artifact(
         out_dir,

--- a/headmatch/signals.py
+++ b/headmatch/signals.py
@@ -91,3 +91,15 @@ def geometric_log_grid(f_min: float = 20.0, f_max: float = 20000.0, points_per_o
     octaves = math.log2(f_max / f_min)
     points = int(octaves * points_per_octave) + 1
     return np.geomspace(f_min, f_max, points)
+
+
+# AutoEq's de-facto GraphicEQ density standard: 127 log-spaced points from 20 Hz
+# with a multiplicative step of 1.0563 (top ~19871 Hz). Equalizer APO / EasyEffects
+# load this comfortably; it is the grid all HeadMatch GraphicEQ exports use.
+STANDARD_GRAPHIC_EQ_STEP = 1.0563
+STANDARD_GRAPHIC_EQ_POINTS = 127
+
+
+def standard_graphic_eq_grid(f_min: float = 20.0, step: float = STANDARD_GRAPHIC_EQ_STEP,
+                             points: int = STANDARD_GRAPHIC_EQ_POINTS) -> np.ndarray:
+    return f_min * (step ** np.arange(points, dtype=np.float64))

--- a/tests/test_builtin_targets.py
+++ b/tests/test_builtin_targets.py
@@ -1,0 +1,38 @@
+"""Tests for built-in tonal target curves (advanced-mode selection)."""
+from __future__ import annotations
+
+from headmatch.builtin_targets import (
+    BUILTIN_TARGET_DEFS,
+    SELECTABLE_TARGET_NAMES,
+    label_to_name,
+    materialize_builtin_target,
+)
+from headmatch.targets import load_curve
+
+
+def test_selectable_excludes_flat():
+    assert "flat" not in SELECTABLE_TARGET_NAMES
+    assert {"harman", "free_field", "diffuse_field"} <= set(SELECTABLE_TARGET_NAMES)
+
+
+def test_label_to_name_maps_back_and_flat_is_none():
+    assert label_to_name("Harman") == "harman"
+    assert label_to_name("Flat (default)") is None
+    assert label_to_name("nonexistent") is None
+
+
+def test_materialize_builtin_target_writes_loadable_csv(tmp_path):
+    path = materialize_builtin_target("harman", tmp_path)
+    assert path.exists()
+    curve = load_curve(path)
+    # Harman: bass lift, 1 kHz reference ~0.
+    freqs = list(curve.freqs_hz)
+    i20 = freqs.index(min(freqs, key=lambda f: abs(f - 20)))
+    i1k = freqs.index(min(freqs, key=lambda f: abs(f - 1000)))
+    assert curve.values_db[i20] > curve.values_db[i1k]
+
+
+def test_all_builtins_materialize_and_load(tmp_path):
+    for name in BUILTIN_TARGET_DEFS:
+        curve = load_curve(materialize_builtin_target(name, tmp_path))
+        assert len(curve.freqs_hz) == 12

--- a/tests/test_e2e_fitting.py
+++ b/tests/test_e2e_fitting.py
@@ -22,14 +22,24 @@ from headmatch.hearing_test import (
     FrequencyThreshold,
     HearingProfile,
 )
+import json
+
 from headmatch.io_utils import load_fr_csv, write_wav
-from headmatch.pipeline import process_single_measurement, run_hearing_fit
+from headmatch.peq import PEQBand, peq_chain_response_db
+from headmatch.pipeline import (
+    iterative_measure_and_fit,
+    process_single_measurement,
+    run_hearing_fit,
+)
 from headmatch.signals import generate_log_sweep
+from headmatch.targets import clone_target_from_source_target
 
 from tests.test_integration_cli import _predicted_errors, _synthetic_sweep_spec
 
 REPO = Path(__file__).resolve().parent.parent
-HD650_CSV = REPO / "docs" / "examples" / "clone-targets" / "hd650_published.csv"
+CLONE_DIR = REPO / "docs" / "examples" / "clone-targets"
+HD650_CSV = CLONE_DIR / "hd650_published.csv"
+HD800S_CSV = CLONE_DIR / "hd800s_published.csv"
 
 
 def _apply_fr(signal_mono: np.ndarray, freqs_hz: np.ndarray, gains_db: np.ndarray, sample_rate: int) -> np.ndarray:
@@ -45,20 +55,24 @@ def _apply_fr(signal_mono: np.ndarray, freqs_hz: np.ndarray, gains_db: np.ndarra
     return np.fft.irfft(spectrum * (10.0 ** (g_db / 20.0)), n=n)
 
 
-def _build_real_headset_recording(tmp_path: Path, csv_path: Path):
-    spec = _synthetic_sweep_spec()
+def _inject_headset_channels(spec, csv_path: Path):
+    """Synthesise a stereo recording = analysis sweep colored by a real
+    published headphone response, with per-channel latency + noise."""
     stereo, _ = generate_log_sweep(spec)
     freqs, gains = load_fr_csv(csv_path)
-
     left = _apply_fr(stereo[:, 0], freqs, gains, spec.sample_rate)
     right = _apply_fr(stereo[:, 1], freqs, gains, spec.sample_rate)
-    # Small per-channel latency + measurement noise, like a real capture.
     left = np.concatenate([np.zeros(90), left[:-90]]) + 0.00015 * np.random.default_rng(0).standard_normal(len(left))
     right = np.concatenate([np.zeros(120), right[:-120]]) + 0.00015 * np.random.default_rng(1).standard_normal(len(right))
+    return np.column_stack([left, right]), (freqs, gains)
 
+
+def _build_real_headset_recording(tmp_path: Path, csv_path: Path):
+    spec = _synthetic_sweep_spec()
+    recording, curve = _inject_headset_channels(spec, csv_path)
     recording_path = tmp_path / "recording.wav"
-    write_wav(recording_path, np.column_stack([left, right]), spec.sample_rate)
-    return recording_path, spec, (freqs, gains)
+    write_wav(recording_path, recording, spec.sample_rate)
+    return recording_path, spec, curve
 
 
 def _normalize_at_1k(freqs: np.ndarray, values: np.ndarray) -> np.ndarray:
@@ -89,6 +103,76 @@ def test_offline_fit_e2e_recovers_real_headset_and_corrects_it(tmp_path):
     assert errs["left_after"] < errs["left_before"]
     assert errs["right_after"] < errs["right_before"]
     assert "left_bands" in report and report["left_bands"]
+
+
+def test_clone_target_e2e_makes_hd650_sound_like_hd800s(tmp_path):
+    # End-to-end clone workflow on real published curves: a clone target built
+    # from HD 650 -> HD 800S, applied as a relative target while fitting a
+    # synthesised HD 650 recording, should correct the HD 650 toward the HD 800S.
+    clone_csv = tmp_path / "hd650_to_hd800s.csv"
+    clone_target_from_source_target(HD650_CSV, HD800S_CSV, clone_csv)
+
+    recording, spec, _ = _build_real_headset_recording(tmp_path, HD650_CSV)
+    out = tmp_path / "clone_fit"
+    process_single_measurement(recording, out, spec, target_path=clone_csv)
+
+    freqs, left = load_fr_csv(out / "measurement_left.csv")
+    report = json.loads((out / "fit_report.json").read_text())
+    bands = [PEQBand(**b) for b in report["left_bands"]]
+    corrected = left + peq_chain_response_db(freqs, spec.sample_rate, bands)
+
+    f8, g8 = load_fr_csv(HD800S_CSV)
+    hd800s = np.interp(np.log10(freqs), np.log10(f8), g8, left=g8[0], right=g8[-1])
+
+    band = (freqs >= 120) & (freqs <= 7000)
+    rms = float(np.sqrt(np.mean(
+        (_normalize_at_1k(freqs, corrected)[band] - _normalize_at_1k(freqs, hd800s)[band]) ** 2
+    )))
+    assert rms < 4.0, f"cloned HD650 deviates {rms:.2f} dB RMS from HD800S target"
+
+
+def _mock_capture_with(csv_path: Path):
+    """Return a run_pipewire_measurement replacement that writes a synthetic
+    recording (real headset response injected) instead of capturing hardware."""
+    def _fake(spec, paths, _device):
+        recording, _ = _inject_headset_channels(spec, csv_path)
+        write_wav(paths.recording_wav, recording, spec.sample_rate)
+        return paths.recording_wav
+    return _fake
+
+
+def test_iterative_measure_and_fit_e2e_average_mode(monkeypatch, tmp_path):
+    monkeypatch.setattr("headmatch.pipeline.run_pipewire_measurement", _mock_capture_with(HD650_CSV))
+    spec = _synthetic_sweep_spec()
+
+    summaries = iterative_measure_and_fit(
+        tmp_path, spec, target_path=None, output_target=None, input_target=None,
+        iterations=2, iteration_mode="average",
+    )
+
+    assert summaries
+    for name in ("measurement_left.csv", "equalizer_apo.txt", "fit_report.json", "target_curve.csv"):
+        assert (tmp_path / name).exists(), f"missing {name}"
+    errs = _predicted_errors(tmp_path, spec.sample_rate)
+    assert errs["left_after"] < errs["left_before"]
+    assert errs["right_after"] < errs["right_before"]
+
+
+def test_iterative_measure_and_fit_e2e_independent_mode(monkeypatch, tmp_path):
+    monkeypatch.setattr("headmatch.pipeline.run_pipewire_measurement", _mock_capture_with(HD650_CSV))
+    spec = _synthetic_sweep_spec()
+
+    summaries = iterative_measure_and_fit(
+        tmp_path, spec, target_path=None, output_target=None, input_target=None,
+        iterations=2, iteration_mode="independent",
+    )
+
+    # One summary + artifact folder per iteration.
+    assert len(summaries) == 2
+    for i in (1, 2):
+        iter_dir = tmp_path / f"iter_{i:02d}"
+        assert (iter_dir / "equalizer_apo.txt").exists()
+        assert (iter_dir / "fit_report.json").exists()
 
 
 # A representative middle-aged (presbycusis) audiogram: gentle low-frequency

--- a/tests/test_e2e_fitting.py
+++ b/tests/test_e2e_fitting.py
@@ -210,6 +210,6 @@ def test_hearing_fit_e2e_presbycusis_boosts_high_frequencies(tmp_path):
     # Gains respect the compensation cap.
     assert all(b["gain_db"] <= MAX_COMPENSATION_DB + 1e-6 for b in bands)
 
-    # Compact GraphicEQ (measured points + anchors), not a dense grid.
+    # Standard 127-point GraphicEQ grid (not the ~5103-point grid that crashed EasyEffects).
     gq = [ln for ln in (tmp_path / "equalizer_apo_graphiceq.txt").read_text().splitlines() if ln.startswith("GraphicEQ:")]
-    assert gq and len(gq[0].split(":", 1)[1].split(";")) <= 12
+    assert gq and len(gq[0].split(":", 1)[1].split(";")) <= 130

--- a/tests/test_e2e_fitting.py
+++ b/tests/test_e2e_fitting.py
@@ -1,0 +1,131 @@
+"""End-to-end tests of the fitting workflows on synthetic data with known
+ground truth (no real microphone / hardware required).
+
+- Offline measurement fit: a real published headphone response (Sennheiser
+  HD 650, docs/examples/clone-targets/hd650_published.csv) is convolved onto
+  the analysis sweep to synthesise a recording, then the full offline pipeline
+  must (a) recover that response and (b) produce an EQ that corrects it toward
+  the target.
+- Hearing-test fit: a typical middle-aged (presbycusis) sloping high-frequency
+  loss must produce a high-frequency-weighted compensation EQ.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from headmatch.hearing_test import (
+    NORMAL_HEARING_REFERENCE,
+    MAX_COMPENSATION_DB,
+    TEST_FREQUENCIES,
+    FrequencyThreshold,
+    HearingProfile,
+)
+from headmatch.io_utils import load_fr_csv, write_wav
+from headmatch.pipeline import process_single_measurement, run_hearing_fit
+from headmatch.signals import generate_log_sweep
+
+from tests.test_integration_cli import _predicted_errors, _synthetic_sweep_spec
+
+REPO = Path(__file__).resolve().parent.parent
+HD650_CSV = REPO / "docs" / "examples" / "clone-targets" / "hd650_published.csv"
+
+
+def _apply_fr(signal_mono: np.ndarray, freqs_hz: np.ndarray, gains_db: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Apply a magnitude frequency response (dB vs Hz) to a signal via FFT."""
+    n = len(signal_mono)
+    spectrum = np.fft.rfft(signal_mono)
+    bin_freqs = np.fft.rfftfreq(n, 1.0 / sample_rate)
+    safe = np.clip(bin_freqs, 1e-6, None)
+    g_db = np.interp(
+        np.log10(safe), np.log10(freqs_hz), gains_db,
+        left=gains_db[0], right=gains_db[-1],
+    )
+    return np.fft.irfft(spectrum * (10.0 ** (g_db / 20.0)), n=n)
+
+
+def _build_real_headset_recording(tmp_path: Path, csv_path: Path):
+    spec = _synthetic_sweep_spec()
+    stereo, _ = generate_log_sweep(spec)
+    freqs, gains = load_fr_csv(csv_path)
+
+    left = _apply_fr(stereo[:, 0], freqs, gains, spec.sample_rate)
+    right = _apply_fr(stereo[:, 1], freqs, gains, spec.sample_rate)
+    # Small per-channel latency + measurement noise, like a real capture.
+    left = np.concatenate([np.zeros(90), left[:-90]]) + 0.00015 * np.random.default_rng(0).standard_normal(len(left))
+    right = np.concatenate([np.zeros(120), right[:-120]]) + 0.00015 * np.random.default_rng(1).standard_normal(len(right))
+
+    recording_path = tmp_path / "recording.wav"
+    write_wav(recording_path, np.column_stack([left, right]), spec.sample_rate)
+    return recording_path, spec, (freqs, gains)
+
+
+def _normalize_at_1k(freqs: np.ndarray, values: np.ndarray) -> np.ndarray:
+    return values - values[int(np.argmin(np.abs(freqs - 1000.0)))]
+
+
+def test_offline_fit_e2e_recovers_real_headset_and_corrects_it(tmp_path):
+    recording, spec, (inj_f, inj_g) = _build_real_headset_recording(tmp_path, HD650_CSV)
+    out = tmp_path / "fit"
+
+    report = process_single_measurement(recording, out, spec, target_path=None)  # flat target
+
+    # All artifacts written.
+    for name in ("equalizer_apo.txt", "equalizer_apo_graphiceq.txt", "measurement_left.csv", "fit_report.json"):
+        assert (out / name).exists(), f"missing {name}"
+
+    # (a) The analyzed response recovers the injected HD 650 curve (shape, 1 kHz-normalised).
+    freqs, left = load_fr_csv(out / "measurement_left.csv")
+    inj_on_grid = np.interp(np.log10(freqs), np.log10(inj_f), inj_g, left=inj_g[0], right=inj_g[-1])
+    band = (freqs >= 120) & (freqs <= 7000)
+    recovered = _normalize_at_1k(freqs, left)[band]
+    injected = _normalize_at_1k(freqs, inj_on_grid)[band]
+    rms = float(np.sqrt(np.mean((recovered - injected) ** 2)))
+    assert rms < 4.0, f"recovered response deviates {rms:.2f} dB RMS from injected HD650 curve"
+
+    # (b) The EQ corrects the real headphone toward the (flat) target.
+    errs = _predicted_errors(out, spec.sample_rate)
+    assert errs["left_after"] < errs["left_before"]
+    assert errs["right_after"] < errs["right_before"]
+    assert "left_bands" in report and report["left_bands"]
+
+
+# A representative middle-aged (presbycusis) audiogram: gentle low-frequency
+# loss sloping to a moderate high-frequency loss (dB above the normal reference).
+_PRESBYCUSIS_LOSS_DB = {500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
+
+
+def _presbycusis_profile() -> HearingProfile:
+    side = {
+        f: FrequencyThreshold(
+            freq_hz=f,
+            level_dbfs=NORMAL_HEARING_REFERENCE[f] + _PRESBYCUSIS_LOSS_DB[f],
+            ascending_runs=3,
+            determined=True,
+        )
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(left=dict(side), right=dict(side), tested_at="2026-01-01T00:00:00+00:00", asymmetric_freqs=[])
+
+
+def test_hearing_fit_e2e_presbycusis_boosts_high_frequencies(tmp_path):
+    profile = _presbycusis_profile()
+    report = run_hearing_fit(profile, tmp_path, sample_rate=48000)
+
+    assert report["mode"] == "hearing_only"
+    for name in ("equalizer_apo.txt", "equalizer_apo_graphiceq.txt", "hearing_fit_report.json", "README.txt"):
+        assert (tmp_path / name).exists(), f"missing {name}"
+
+    bands = report["left_bands"]
+    assert bands, "expected compensation bands for presbycusis"
+    by_freq = {round(b["freq"]): b["gain_db"] for b in bands}
+    # High-frequency boost must exceed low-frequency boost (sloping loss).
+    assert max(by_freq) >= 6000
+    assert by_freq[max(by_freq)] > by_freq[min(by_freq)]
+    # Gains respect the compensation cap.
+    assert all(b["gain_db"] <= MAX_COMPENSATION_DB + 1e-6 for b in bands)
+
+    # Compact GraphicEQ (measured points + anchors), not a dense grid.
+    gq = [ln for ln in (tmp_path / "equalizer_apo_graphiceq.txt").read_text().splitlines() if ln.startswith("GraphicEQ:")]
+    assert gq and len(gq[0].split(":", 1)[1].split(";")) <= 12

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -495,6 +495,86 @@ def test_create_app_builds_shell_on_fake_root(tmp_path, fake_tk, monkeypatch):
 
 
 
+def _make_saved_hearing_profile():
+    from headmatch.hearing_test import (
+        HearingProfile, FrequencyThreshold, TEST_FREQUENCIES, NORMAL_HEARING_REFERENCE,
+    )
+    side = {
+        f: FrequencyThreshold(f, NORMAL_HEARING_REFERENCE[f] + 15.0, 3, True)
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(
+        left=dict(side), right=dict(side),
+        tested_at="2026-06-01T12:00:00+00:00", asymmetric_freqs=[],
+    )
+
+
+def _track_buttons(monkeypatch):
+    created = []
+
+    class TrackingButton(DummyWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    monkeypatch.setattr(DummyTtk, 'Button', TrackingButton)
+    return created
+
+
+def _hearing_app(fake_tk, tmp_path):
+    return fake_tk.create_app(
+        root=DummyRoot(),
+        config_loader=lambda _path=None: (
+            FrontendConfig(default_output_dir=str(tmp_path / 'out' / 'session_01')),
+            tmp_path / 'config.json', False,
+        ),
+    )
+
+
+def test_hearing_test_offers_saved_profile_reuse(tmp_path, fake_tk, monkeypatch):
+    profile = _make_saved_hearing_profile()
+    monkeypatch.setattr('headmatch.hearing_test.load_hearing_profile', lambda: profile)
+    created = _track_buttons(monkeypatch)
+    app = _hearing_app(fake_tk, tmp_path)
+
+    app.show_view('hearing-test')
+
+    texts = [b.kwargs.get('text') for b in created]
+    assert 'Use Saved Profile' in texts
+    assert 'Run New Test' in texts
+
+
+def test_hearing_test_use_saved_profile_goes_to_followup(tmp_path, fake_tk, monkeypatch):
+    profile = _make_saved_hearing_profile()
+    monkeypatch.setattr('headmatch.hearing_test.load_hearing_profile', lambda: profile)
+    created = _track_buttons(monkeypatch)
+    app = _hearing_app(fake_tk, tmp_path)
+    app.show_view('hearing-test')
+
+    use_btn = next(b for b in created if b.kwargs.get('text') == 'Use Saved Profile')
+    use_btn.command()
+
+    assert app.hearing_profile is profile
+    assert 'Generate EQ Preset Now' in [b.kwargs.get('text') for b in created]
+
+
+def test_hearing_test_without_saved_profile_runs_test(tmp_path, fake_tk, monkeypatch):
+    monkeypatch.setattr('headmatch.hearing_test.load_hearing_profile', lambda: None)
+    monkeypatch.setattr('headmatch.audio_backend.get_audio_backend', lambda: object())
+    rendered = {}
+    monkeypatch.setattr(
+        'headmatch.gui.shell.render_hearing_test',
+        lambda *a, **k: rendered.setdefault('called', True),
+    )
+    created = _track_buttons(monkeypatch)
+    app = _hearing_app(fake_tk, tmp_path)
+
+    app.show_view('hearing-test')
+
+    assert rendered.get('called') is True
+    assert 'Use Saved Profile' not in [b.kwargs.get('text') for b in created]
+
+
 def test_create_app_includes_setup_check_view_and_refreshes_doctor_report(tmp_path, fake_tk):
     calls = {}
     root = DummyRoot()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -575,6 +575,34 @@ def test_hearing_test_without_saved_profile_runs_test(tmp_path, fake_tk, monkeyp
     assert 'Use Saved Profile' not in [b.kwargs.get('text') for b in created]
 
 
+def test_resolve_hearing_target_path_modes(tmp_path, fake_tk):
+    from headmatch.targets import load_curve
+    app = _hearing_app(fake_tk, tmp_path)
+    out = tmp_path / "hearing_fit"
+
+    # Basic mode -> always flat (None).
+    app.mode_var.set("basic")
+    app.hearing_target_var.set("Harman")
+    assert app._resolve_hearing_target_path(str(out)) is None
+
+    # Advanced + Flat -> None.
+    app.mode_var.set("advanced")
+    app.hearing_target_var.set("Flat (default)")
+    assert app._resolve_hearing_target_path(str(out)) is None
+
+    # Advanced + Harman -> a materialised Harman target CSV.
+    app.hearing_target_var.set("Harman")
+    path = app._resolve_hearing_target_path(str(out))
+    assert path is not None
+    curve = load_curve(path)
+    assert len(curve.freqs_hz) == 12
+
+    # Advanced + Custom CSV -> the chosen target_csv_var path.
+    app.hearing_target_var.set("Custom CSV…")
+    app.target_csv_var.set("/tmp/my_target.csv")
+    assert app._resolve_hearing_target_path(str(out)) == "/tmp/my_target.csv"
+
+
 def test_create_app_includes_setup_check_view_and_refreshes_doctor_report(tmp_path, fake_tk):
     calls = {}
     root = DummyRoot()
@@ -1238,6 +1266,9 @@ def test_show_hearing_followup_renders_two_buttons():
         content=content,
         _ttk=ttk,
         state=SimpleNamespace(default_output_dir="/tmp/hm/session_01"),
+        mode_var=DummyVar(value="basic"),
+        hearing_target_var=DummyVar(value="Flat (default)"),
+        _resolve_hearing_target_path=lambda out: None,
         show_view=lambda key: commands.setdefault("show_view", key),
         _start_hearing_fit=lambda p, out: commands.update({"start_fit": out}),
     )
@@ -1263,8 +1294,11 @@ def test_show_hearing_followup_generate_button_calls_start_hearing_fit():
         content=content,
         _ttk=ttk,
         state=SimpleNamespace(default_output_dir="/tmp/hm/session_01"),
+        mode_var=DummyVar(value="basic"),
+        hearing_target_var=DummyVar(value="Flat (default)"),
+        _resolve_hearing_target_path=lambda out: None,
         show_view=lambda key: None,
-        _start_hearing_fit=lambda p, out: calls.update({"profile": p, "out": out}),
+        _start_hearing_fit=lambda p, out, target_path=None: calls.update({"profile": p, "out": out, "target": target_path}),
     )
 
     HeadMatchGuiApp._show_hearing_followup(app, profile)
@@ -1293,6 +1327,9 @@ def test_show_hearing_followup_measure_button_navigates_to_measure_online():
         content=content,
         _ttk=ttk,
         state=SimpleNamespace(default_output_dir="/tmp/hm/session_01"),
+        mode_var=DummyVar(value="basic"),
+        hearing_target_var=DummyVar(value="Flat (default)"),
+        _resolve_hearing_target_path=lambda out: None,
         show_view=lambda key: navigated.update({"key": key}),
         _start_hearing_fit=lambda *a: None,
     )

--- a/tests/test_gui_hearing_render.py
+++ b/tests/test_gui_hearing_render.py
@@ -1,0 +1,255 @@
+"""Smoke tests for the hearing-test GUI render path.
+
+`render_hearing_test` had **4% coverage** and was where the macOS
+`unknown option "-background"` crash lived. These tests drive the whole
+INTRO -> TEST_L -> TEST_R -> RESULTS flow with a fake toolkit and a fake
+threshold engine (the real engine is covered in test_hearing_test.py), and
+guard against the aqua `cget("background")` regression.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from headmatch.gui.views import hearing_test as ht
+from headmatch.hearing_test import HearingProfile
+
+
+# ── fake toolkit ──────────────────────────────────────────────────────────────
+
+class _FakeVar:
+    def __init__(self, master=None, value=""):
+        self._v = value
+
+    def get(self):
+        return self._v
+
+    def set(self, value):
+        self._v = value
+
+
+class _FakeTkWidget:
+    """Permissive stand-in for tk.Text / tk.Canvas."""
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+
+    def grid(self, *a, **k):
+        return self
+
+    def insert(self, *a, **k):
+        return None
+
+    def configure(self, *a, **k):
+        return None
+
+    config = configure
+
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+
+
+_FAKE_TK = types.SimpleNamespace(StringVar=_FakeVar, Text=_FakeTkWidget, Canvas=_FakeTkWidget)
+
+
+class _FakeTtkWidget:
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+        self.command = kwargs.get("command")
+        self.text = kwargs.get("text")
+        self.style = kwargs.get("style")
+
+    def grid(self, *a, **k):
+        return self
+
+    def columnconfigure(self, *a, **k):
+        return None
+
+    def configure(self, *a, **k):
+        return None
+
+    config = configure
+
+
+class _FakeTtk:
+    """Records every widget created so tests can find buttons by label."""
+    def __init__(self):
+        self.created: list[_FakeTtkWidget] = []
+
+    def _make(self, *a, **k):
+        w = _FakeTtkWidget(*a, **k)
+        self.created.append(w)
+        return w
+
+    def Frame(self, *a, **k):
+        return self._make(*a, **k)
+
+    def Label(self, *a, **k):
+        return self._make(*a, **k)
+
+    def Button(self, *a, **k):
+        return self._make(*a, **k)
+
+
+class _FakeFrame:
+    """Content frame with a synchronous-drainable `after` queue.
+
+    `cget` always raises, mimicking macOS aqua's `unknown option "-background"`
+    — if the render path ever touches `frame.cget` again, these tests fail.
+    """
+    def __init__(self):
+        self._after: dict[str, object] = {}
+        self._counter = 0
+
+    def after(self, _ms, callback):
+        self._counter += 1
+        tid = f"after#{self._counter}"
+        self._after[tid] = callback
+        return tid
+
+    def after_cancel(self, tid):
+        self._after.pop(tid, None)
+
+    def winfo_children(self):
+        return []
+
+    def columnconfigure(self, *a, **k):
+        return None
+
+    def rowconfigure(self, *a, **k):
+        return None
+
+    def cget(self, _key):
+        raise RuntimeError('unknown option "-background"')
+
+    def configure(self, *a, **k):
+        return None
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.calls = 0
+
+    def play_tone(self, *a, **k):
+        self.calls += 1
+
+
+class _FakeEngine:
+    """Converges after a single response — decouples the view test from the
+    real Hughson-Westlake staircase (which never terminates on all-misses)."""
+    def __init__(self, freq_hz, start_level_dbfs=-20.0):
+        self.freq_hz = freq_hz
+        self.current_level_dbfs = start_level_dbfs
+        self.threshold = -45.0
+        self.ascending_run_count = 3
+        self.done = False
+
+    def record_response(self, _heard):
+        self.done = True
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+def _drain(frame, limit=10000):
+    n = 0
+    while frame._after:
+        n += 1
+        if n > limit:  # pragma: no cover - guard against a runaway flow
+            raise RuntimeError("after-queue did not drain")
+        tid = next(iter(frame._after))
+        frame._after.pop(tid)()
+
+
+def _find_last(ttk, text):
+    for w in reversed(ttk.created):
+        if w.text == text and w.command is not None:
+            return w
+    return None
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    monkeypatch.setitem(sys.modules, "tkinter", _FAKE_TK)
+    monkeypatch.setattr(ht, "ThresholdEngine", _FakeEngine)
+    saved = {}
+    monkeypatch.setattr(ht, "save_hearing_profile", lambda p: saved.__setitem__("profile", p))
+    events = {"complete": [], "cancel": 0}
+    ttk = _FakeTtk()
+    frame = _FakeFrame()
+
+    def render():
+        ht.render_hearing_test(
+            ttk, frame,
+            backend=_FakeBackend(),
+            output_device=None,
+            sample_rate=48000,
+            on_complete=lambda p: events["complete"].append(p),
+            on_cancel=lambda: events.__setitem__("cancel", events["cancel"] + 1),
+        )
+
+    return types.SimpleNamespace(ttk=ttk, frame=frame, render=render, events=events, saved=saved)
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+def test_intro_renders_without_touching_frame_cget(harness):
+    # The macOS regression: building the intro must not query frame.cget.
+    harness.render()
+    assert _find_last(harness.ttk, "Start Test") is not None
+    assert _find_last(harness.ttk, "Cancel") is not None
+
+
+def test_full_flow_timeout_path_reaches_results_and_completes(harness):
+    harness.render()
+    _find_last(harness.ttk, "Start Test").command()        # -> left ear intro
+    for _ in range(2):                                      # left, then right ear
+        _find_last(harness.ttk, "Ready — Start").command()
+        _drain(harness.frame)
+    save = _find_last(harness.ttk, "Save & Use for EQ")
+    assert save is not None, "results screen never rendered"
+    save.command()
+    _drain(harness.frame)
+
+    assert "profile" in harness.saved
+    assert len(harness.events["complete"]) == 1
+    profile = harness.events["complete"][0]
+    assert isinstance(profile, HearingProfile)
+    # Both ears measured across all seven unique frequencies.
+    assert len(profile.left) == 7 and len(profile.right) == 7
+
+
+def test_heard_response_path(harness):
+    harness.render()
+    _find_last(harness.ttk, "Start Test").command()
+    _find_last(harness.ttk, "Ready — Start").command()     # first tone scheduled
+    hear = _find_last(harness.ttk, "I hear it")
+    assert hear is not None
+    hear.command()                                         # _on_heard branch
+    _drain(harness.frame)                                  # finish left via timeouts
+    _find_last(harness.ttk, "Ready — Start").command()     # right ear
+    _drain(harness.frame)
+    _find_last(harness.ttk, "Save & Use for EQ").command()
+    _drain(harness.frame)
+    assert isinstance(harness.events["complete"][0], HearingProfile)
+
+
+def test_stop_test_invokes_cancel(harness):
+    harness.render()
+    _find_last(harness.ttk, "Cancel").command()
+    assert harness.events["cancel"] == 1
+
+
+def test_save_without_applying_uses_cancel(harness):
+    harness.render()
+    _find_last(harness.ttk, "Start Test").command()
+    for _ in range(2):
+        _find_last(harness.ttk, "Ready — Start").command()
+        _drain(harness.frame)
+    _find_last(harness.ttk, "Save Without Applying").command()
+    _drain(harness.frame)
+    assert "profile" in harness.saved
+    assert harness.events["cancel"] == 1
+    assert harness.events["complete"] == []

--- a/tests/test_gui_theme.py
+++ b/tests/test_gui_theme.py
@@ -1,0 +1,78 @@
+"""Tests for headmatch.gui.theme.apply_theme."""
+from __future__ import annotations
+
+from headmatch.gui.theme import apply_theme, PALETTE
+
+
+class _RecordingStyle:
+    def __init__(self, master=None, *, theme_use_raises=False):
+        self.master = master
+        self._theme = "default"
+        self._theme_use_raises = theme_use_raises
+        self.configured: dict = {}
+        self.mapped: dict = {}
+        self.theme_calls: list = []
+
+    def theme_use(self, name=None):
+        if name is None:
+            return self._theme
+        if self._theme_use_raises and name == "clam":
+            raise RuntimeError("no such theme")
+        self.theme_calls.append(name)
+        self._theme = name
+
+    def configure(self, style, **kwargs):
+        self.configured.setdefault(style, {}).update(kwargs)
+
+    def map(self, style, **kwargs):
+        self.mapped.setdefault(style, {}).update(kwargs)
+
+
+class _Root:
+    def __init__(self):
+        self.background = None
+
+    def configure(self, **kwargs):
+        self.background = kwargs.get("background", self.background)
+
+
+class _Ttk:
+    def __init__(self, style):
+        self._style = style
+
+    def Style(self, master=None):
+        self._style.master = master
+        return self._style
+
+
+def test_returns_false_without_style_factory():
+    class NoStyle:
+        pass
+
+    assert apply_theme(NoStyle()) is False
+
+
+def test_applies_clam_theme_and_core_styles():
+    style = _RecordingStyle()
+    root = _Root()
+    assert apply_theme(_Ttk(style), root) is True
+    assert "clam" in style.theme_calls
+    # Core styles configured with the palette
+    assert style.configured["TFrame"]["background"] == PALETTE["bg"]
+    assert style.configured["Accent.TButton"]["background"] == PALETTE["accent"]
+    assert "Accent.TButton" in style.mapped
+    assert root.background == PALETTE["bg"]
+
+
+def test_falls_back_when_clam_unavailable():
+    # Must not raise even if 'clam' is rejected; styling still applied.
+    style = _RecordingStyle(theme_use_raises=True)
+    assert apply_theme(_Ttk(style), _Root()) is True
+    assert "clam" not in style.theme_calls
+    assert style.configured["TLabel"]["foreground"] == PALETTE["text"]
+
+
+def test_custom_palette_override():
+    style = _RecordingStyle()
+    apply_theme(_Ttk(style), _Root(), palette={"accent": "#ff0000"})
+    assert style.configured["Accent.TButton"]["background"] == "#ff0000"

--- a/tests/test_gui_views_common.py
+++ b/tests/test_gui_views_common.py
@@ -8,7 +8,7 @@ from tests.test_gui import DummyVar, DummyWidget, RecordingTtk
 
 def test_confidence_display_helpers():
     assert _confidence_display("very_high") == "Very High"
-    assert _confidence_badge("high").startswith("✓")
+    assert _confidence_badge("high").startswith("[OK]")
     assert _confidence_badge("unknown") == "Unknown"
 
 

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -115,6 +115,21 @@ class TestFitFromHearingProfile:
         assert isinstance(left_bands, list)
         assert isinstance(report["target"], str)
 
+    def test_target_curve_applied_even_with_no_hearing_loss(self, tmp_path):
+        # Regression: a tonal target (e.g. Harman) must still produce an EQ when
+        # the listener shows no measurable hearing loss — the target is known
+        # independently of the hearing test.
+        from headmatch.builtin_targets import materialize_builtin_target
+        # Thresholds exactly at the reference -> zero compensation.
+        side = {
+            f: FrequencyThreshold(f, NORMAL_HEARING_REFERENCE[f], 3, True)
+            for f in TEST_FREQUENCIES
+        }
+        profile = HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
+        harman = materialize_builtin_target("harman", tmp_path)
+        left_bands, _, _ = fit_from_hearing_profile(profile, sample_rate=48000, target_path=harman)
+        assert left_bands, "Harman target should yield EQ bands even with no hearing loss"
+
     def test_filter_budget_respected(self):
         from headmatch.peq import FilterBudget
         profile = _make_profile(loss_db=20.0)
@@ -139,6 +154,15 @@ class TestRunHearingFit:
         assert (tmp_path / "camilladsp_filters_only.yaml").exists()
         assert (tmp_path / "hearing_fit_report.json").exists()
         assert (tmp_path / "README.txt").exists()
+
+    def test_writes_profile_copy_to_results_dir(self, tmp_path):
+        profile = self._profile(loss_db=20.0)
+        run_hearing_fit(profile, tmp_path, sample_rate=48000)
+        prof_path = tmp_path / "hearing_profile.json"
+        assert prof_path.exists()
+        data = json.loads(prof_path.read_text(encoding="utf-8"))
+        assert set(data["left"]) == {str(f) for f in TEST_FREQUENCIES}
+        assert data["tested_at"] == profile.tested_at
 
     def test_report_json_valid(self, tmp_path):
         profile = self._profile()

--- a/tests/test_hearing_test_bugfixes.py
+++ b/tests/test_hearing_test_bugfixes.py
@@ -82,6 +82,44 @@ def test_engine_still_converges_normally_within_cap():
         n += 1
     assert eng.done
     assert eng.threshold == -45.0
-    # Genuine convergence happens before the safety cap kicks in.
+    # Terminates within the safety cap (which doubles as a max-length bound).
     from headmatch.hearing_test import MAX_PRESENTATIONS
-    assert n < MAX_PRESENTATIONS
+    assert n <= MAX_PRESENTATIONS
+
+
+def test_hearing_fit_graphiceq_point_count_is_sane(tmp_path):
+    # Regression: run_hearing_fit used geometric_log_grid(20, 20000, 512) where
+    # 512 is points-per-octave -> ~5103 points, which crashed EasyEffects.
+    from headmatch.hearing_test import HearingProfile, FrequencyThreshold, TEST_FREQUENCIES
+    from headmatch.pipeline import run_hearing_fit
+
+    left = {f: FrequencyThreshold(f, -30.0, 3, True) for f in TEST_FREQUENCIES}
+    right = {f: FrequencyThreshold(f, -30.0, 3, True) for f in TEST_FREQUENCIES}
+    profile = HearingProfile(left=left, right=right, tested_at="2026-01-01T00:00:00Z", asymmetric_freqs=[])
+
+    run_hearing_fit(profile, str(tmp_path), sample_rate=48000)
+    text = (tmp_path / "equalizer_apo_graphiceq.txt").read_text()
+    gq_lines = [ln for ln in text.splitlines() if ln.startswith("GraphicEQ:")]
+    assert gq_lines, "no GraphicEQ line written"
+    n_points = len(gq_lines[0].split(":", 1)[1].split(";"))
+    # Compact: the 7 audiometric points + 20 Hz / 20 kHz anchors, never a
+    # dense grid manufactured from a 7-frequency measurement.
+    assert n_points <= 12, f"GraphicEQ should be compact, got {n_points} points"
+
+
+def test_parametric_bands_placed_at_audiometric_frequencies(tmp_path):
+    # Direct 7-frequency EQ: peaking filters sit AT the measured frequencies,
+    # not at greedy-fit positions on an interpolated grid.
+    from headmatch.hearing_test import (
+        HearingProfile, FrequencyThreshold, TEST_FREQUENCIES, NORMAL_HEARING_REFERENCE,
+        eq_bands_from_gain_points, compute_compensation_points,
+    )
+    side = {f: FrequencyThreshold(f, NORMAL_HEARING_REFERENCE[f] + 20.0, 3, True) for f in TEST_FREQUENCIES}
+    profile = HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
+    bands = eq_bands_from_gain_points(compute_compensation_points(profile))
+    assert bands, "expected boost bands for 20 dB loss"
+    assert all(b.kind == "peaking" for b in bands)
+    assert all(round(b.freq) in TEST_FREQUENCIES for b in bands)
+    # Wider spacing -> lower Q; narrower spacing -> higher Q.
+    qs = {round(b.freq): b.q for b in bands}
+    assert qs[1000] < qs[4000]

--- a/tests/test_hearing_test_bugfixes.py
+++ b/tests/test_hearing_test_bugfixes.py
@@ -42,6 +42,12 @@ def test_speaker_status_strings_are_ascii():
         assert s.isascii(), f"status string must be ASCII-renderable: {s!r}"
 
 
+def test_intro_instructions_are_ascii_and_cover_volume():
+    text = "\n".join(ht_view._INTRO_INSTRUCTIONS)
+    assert text.isascii(), "intro instructions must be ASCII-renderable"
+    assert "volume" in text.lower(), "intro must guide the user on volume level"
+
+
 # ── Bug 3: engine always terminates ───────────────────────────────────────────
 
 def test_engine_terminates_when_listener_hears_everything():
@@ -76,3 +82,6 @@ def test_engine_still_converges_normally_within_cap():
         n += 1
     assert eng.done
     assert eng.threshold == -45.0
+    # Genuine convergence happens before the safety cap kicks in.
+    from headmatch.hearing_test import MAX_PRESENTATIONS
+    assert n < MAX_PRESENTATIONS

--- a/tests/test_hearing_test_bugfixes.py
+++ b/tests/test_hearing_test_bugfixes.py
@@ -102,9 +102,42 @@ def test_hearing_fit_graphiceq_point_count_is_sane(tmp_path):
     gq_lines = [ln for ln in text.splitlines() if ln.startswith("GraphicEQ:")]
     assert gq_lines, "no GraphicEQ line written"
     n_points = len(gq_lines[0].split(":", 1)[1].split(";"))
-    # Compact: the 7 audiometric points + 20 Hz / 20 kHz anchors, never a
-    # dense grid manufactured from a 7-frequency measurement.
-    assert n_points <= 12, f"GraphicEQ should be compact, got {n_points} points"
+    # Standard 127-point grid (AutoEq de-facto), never the ~5103-point grid that
+    # crashed EasyEffects.
+    assert n_points <= 130, f"GraphicEQ should use the standard grid, got {n_points} points"
+
+
+def test_deadband_ignores_sub_threshold_losses():
+    # Losses below the ~10 dB self-test noise deadband must not produce EQ.
+    from headmatch.hearing_test import (
+        HearingProfile, FrequencyThreshold, TEST_FREQUENCIES, NORMAL_HEARING_REFERENCE,
+        compute_compensation_points,
+    )
+    side = {f: FrequencyThreshold(f, NORMAL_HEARING_REFERENCE[f] + 8.0, 3, True) for f in TEST_FREQUENCIES}
+    profile = HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
+    assert compute_compensation_points(profile) == {}
+
+
+def test_lsq_band_gains_realize_target_accounting_for_interaction():
+    # The least-squares solve must make the realized chain hit the target gains
+    # at the measured frequencies despite overlapping (summing) bands.
+    import numpy as np
+    from headmatch.hearing_test import (
+        HearingProfile, FrequencyThreshold, TEST_FREQUENCIES, NORMAL_HEARING_REFERENCE,
+        compute_compensation_points, eq_bands_from_gain_points,
+    )
+    from headmatch.peq import peq_chain_response_db
+
+    loss = {500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
+    side = {f: FrequencyThreshold(f, NORMAL_HEARING_REFERENCE[f] + loss[f], 3, True) for f in TEST_FREQUENCIES}
+    profile = HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
+    points = compute_compensation_points(profile)
+    bands = eq_bands_from_gain_points(points, sample_rate=48000)
+
+    freqs = np.array(sorted(points), dtype=float)
+    realized = peq_chain_response_db(freqs, 48000, bands)
+    for f, r in zip(freqs, realized):
+        assert abs(r - points[int(f)]) < 1.0, f"{int(f)} Hz: realized {r:.2f} vs target {points[int(f)]}"
 
 
 def test_parametric_bands_placed_at_audiometric_frequencies(tmp_path):

--- a/tests/test_hearing_test_bugfixes.py
+++ b/tests/test_hearing_test_bugfixes.py
@@ -1,0 +1,78 @@
+"""Regression tests for three hearing-test bugs reported against 0.8.2.
+
+1. Tone played in both ears while testing a single ear (generate_tone always
+   duplicated the mono signal into both channels).
+2. Non-ASCII status glyphs (♪ ✓ — …) failed to render in the user's Tk font.
+3. The threshold engine never terminated when the listener heard (or missed)
+   every presentation — the test got stuck on the first frequency.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from headmatch.hearing_test import ThresholdEngine, generate_tone
+from headmatch.gui.views import hearing_test as ht_view
+
+
+# ── Bug 1: per-ear channel routing ────────────────────────────────────────────
+
+def test_generate_tone_left_silences_right_channel():
+    buf = generate_tone(1000, -20.0, 48000, ear="left")
+    assert buf.shape[1] == 2
+    assert np.any(buf[:, 0] != 0.0), "left channel should carry the tone"
+    assert np.all(buf[:, 1] == 0.0), "right channel must be silent for left ear"
+
+
+def test_generate_tone_right_silences_left_channel():
+    buf = generate_tone(1000, -20.0, 48000, ear="right")
+    assert np.all(buf[:, 0] == 0.0), "left channel must be silent for right ear"
+    assert np.any(buf[:, 1] != 0.0), "right channel should carry the tone"
+
+
+def test_generate_tone_both_ears_is_default():
+    buf = generate_tone(1000, -20.0, 48000)
+    assert np.array_equal(buf[:, 0], buf[:, 1])
+    assert np.any(buf[:, 0] != 0.0)
+
+
+# ── Bug 2: ASCII-only status strings ──────────────────────────────────────────
+
+def test_speaker_status_strings_are_ascii():
+    for s in (ht_view._STATUS_PLAYING, ht_view._STATUS_HEARD, ht_view._STATUS_NOT_HEARD):
+        assert s.isascii(), f"status string must be ASCII-renderable: {s!r}"
+
+
+# ── Bug 3: engine always terminates ───────────────────────────────────────────
+
+def test_engine_terminates_when_listener_hears_everything():
+    eng = ThresholdEngine(1000)
+    for _ in range(500):
+        if eng.done:
+            break
+        eng.record_response(True)
+    assert eng.done, "engine must terminate even if every tone is heard"
+    # Heard even the quietest tone -> threshold determined at/near the floor.
+    assert eng.threshold is not None
+
+
+def test_engine_terminates_when_listener_misses_everything():
+    eng = ThresholdEngine(1000)
+    for _ in range(500):
+        if eng.done:
+            break
+        eng.record_response(False)
+    assert eng.done, "engine must terminate even if every tone is missed"
+    # Never heard anything -> threshold genuinely undetermined.
+    assert eng.threshold is None
+
+
+def test_engine_still_converges_normally_within_cap():
+    # A realistic responder (heard at/above -45 dBFS) must converge well before
+    # the safety cap and not be cut short by it.
+    eng = ThresholdEngine(1000)
+    n = 0
+    while not eng.done and n < 500:
+        eng.record_response(eng.current_level_dbfs >= -45.0)
+        n += 1
+    assert eng.done
+    assert eng.threshold == -45.0

--- a/tests/test_hearing_test_runner.py
+++ b/tests/test_hearing_test_runner.py
@@ -1,0 +1,70 @@
+"""Tests for the headless CLI hearing-test runner (run_cli_hearing_test).
+
+This is the `headmatch hearing-test` driver and was previously uncovered. The
+real Hughson-Westlake staircase is exercised in test_hearing_test.py; here a
+fake engine that converges after a fixed number of responses keeps the I/O
+orchestration test deterministic (the real engine never terminates on
+all-misses).
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+from headmatch import hearing_test as ht_mod
+from headmatch.hearing_test import HearingProfile, TEST_FREQUENCIES, run_cli_hearing_test
+
+
+class _FakeEngine:
+    def __init__(self, freq_hz, start_level_dbfs=-20.0):
+        self.freq_hz = freq_hz
+        self.current_level_dbfs = start_level_dbfs
+        self._n = 0
+        self.done = False
+        self.threshold = -45.0
+        self.ascending_run_count = 2
+
+    def record_response(self, _heard):
+        self._n += 1
+        if self._n >= 2:
+            self.done = True
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.calls = 0
+
+    def play_tone(self, *a, **k):
+        self.calls += 1
+
+
+def _patch_fast(monkeypatch):
+    monkeypatch.setattr(ht_mod, "ThresholdEngine", _FakeEngine)
+    monkeypatch.setattr(ht_mod, "RESPONSE_WINDOW_S", 0.01)
+    monkeypatch.setattr(ht_mod, "generate_tone", lambda *a, **k: [0.0])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+
+def test_returns_complete_profile_for_both_ears(monkeypatch):
+    _patch_fast(monkeypatch)
+    backend = _FakeBackend()
+    statuses: list[str] = []
+
+    profile = run_cli_hearing_test(backend, None, 48000, on_status=statuses.append)
+
+    assert isinstance(profile, HearingProfile)
+    assert set(profile.left) == set(TEST_FREQUENCIES)
+    assert set(profile.right) == set(TEST_FREQUENCIES)
+    assert all(t.determined for t in profile.left.values())
+    assert backend.calls > 0          # tones were actually played
+    assert statuses                   # on_status callback path exercised
+    assert isinstance(profile.asymmetric_freqs, list)
+
+
+def test_default_status_prints_to_stdout(monkeypatch, capsys):
+    _patch_fast(monkeypatch)
+    # No on_status -> the runner prints instructions itself.
+    run_cli_hearing_test(_FakeBackend(), None)
+    out = capsys.readouterr().out
+    assert "Hearing Threshold Test" in out

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -113,15 +113,15 @@ from headmatch.history import confidence_icon, format_run_entry, format_comparis
 
 
 def test_confidence_icon_returns_checkmark_for_high():
-    assert confidence_icon("high") == "\u2713"
+    assert confidence_icon("high") == "[OK]"
 
 
 def test_confidence_icon_returns_warning_for_medium():
-    assert confidence_icon("medium") == "\u26A0"
+    assert confidence_icon("medium") == "[!]"
 
 
 def test_confidence_icon_returns_cross_for_low():
-    assert confidence_icon("low") == "\u2717"
+    assert confidence_icon("low") == "[X]"
 
 
 def test_confidence_icon_returns_question_for_unknown():
@@ -148,7 +148,7 @@ def test_format_run_entry(tmp_path):
     from headmatch.history import RunHistoryEntry
     entry = RunHistoryEntry(summary_path=tmp_path / "run_summary.json", summary=summary, guide_path=tmp_path / "README.txt")
     text = format_run_entry(entry, 1)
-    assert "✓" in text
+    assert "[OK]" in text
     assert "HIGH" in text
     assert "Good run" in text
     assert "L rms=1.20" in text

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -423,6 +423,9 @@ def test_process_single_measurement_relative_target_exports_effective_per_channe
         '1000.0,0.0,0.0',
         '20000.0,-3.0,-4.0',
     ]
-    # Dense GraphicEQ now exports the fitted PEQ response, not the raw target.
-    # With max_filters=0, no bands are placed, so the GraphicEQ should be ~0 dB.
-    assert 'GraphicEQ: 20.00 0.00; 1000.00 0.00; 20000.00 0.00' in graphiceq
+    # GraphicEQ now renders the fitted PEQ response on the standard 127-point
+    # grid. With max_filters=0 no bands are placed, so every point is 0 dB.
+    gq_line = next(l for l in graphiceq.splitlines() if l.startswith('GraphicEQ:'))
+    pts = gq_line.split(':', 1)[1].split(';')
+    assert len(pts) == 127
+    assert all(float(p.split()[1]) == 0.0 for p in pts)


### PR DESCRIPTION
Quality follow-up to the 0.8.1 macOS hearing-test crash fix (already merged). No functional behaviour changes.

## Test hardening — close the gap that let 0.8.1's crash ship

0.8.1 slipped through "100% coverage" because the GUI render path was never invoked by a test and the GUI tests mock the toolkit (so the crashing branch never ran). This covers those paths directly:

- **`tests/test_gui_hearing_render.py`** — drives the full hearing-test render flow (intro → both ears → results → save) with a fake toolkit + fake threshold engine, asserts completion, and **guards that the render path never touches `frame.cget`** (the exact macOS regression).
- **`tests/test_hearing_test_runner.py`** — covers the headless `run_cli_hearing_test` CLI driver, previously untested.
- **`tests/test_gui_theme.py`** — covers `apply_theme` (clam selection, fallback, palette override).

| Module | Before | After |
|---|---|---|
| `gui/views/hearing_test.py` (render path) | 4% | 93% |
| `hearing_test.py` (engine + CLI runner) | 75% | 98% |
| `gui/theme.py` (new) | — | 89% |
| `gui/widgets.py` | — | 100% |

**697 tests passing** (up from 686).

## Prettier, consistent cross-platform GUI theme

New `headmatch/gui/theme.py` standardises on Tk's bundled **`clam`** theme on every platform instead of each OS's native theme. `clam` honours `background`/`foreground`/`style.map` customisation, whereas macOS's `aqua` ignores most of it and rejects options like `-background` (the root cause of the 0.8.1 crash). So this is **both** prettier (cohesive palette, typography scale, accent-coloured primary buttons via `Accent.TButton`) **and** structurally safer (the aqua styling-quirk class cannot recur).

**Visible change:** Windows/Linux users previously saw their native ttk theme; they now see the `clam`-based HeadMatch theme. All workflows unchanged.

Release notes: `docs/releases/0.8.2.md`.