### PR TITLE
Release 0.8.3 — calibration-robust, faster hearing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,502 +1,272 @@
 # HeadMatch
 
-HeadMatch is a beginner-friendly headphone measurement and EQ tool for Linux.
+**Personalise your headphone sound — with or without a measurement microphone.**
 
-It helps you:
-- measure headphone response with **PipeWire** or an offline recorder workflow
-- fit a conservative **parametric EQ** toward a target curve
-- export ready-to-use **CamillaDSP** configurations and **Equalizer APO** presets
-- build **clone targets** from your own measurements or published CSV curves
-- review runs with graphs, summaries, and confidence guidance
+HeadMatch helps you build a ready-to-load EQ for your headphones and apply it in
+**Equalizer APO**, **EasyEffects**, or **CamillaDSP**. You can:
 
-The design goal is simple: make headphone measurement usable for audio enthusiasts who do **not** want to fight the tooling.
+- **Tune by ear, no equipment** — take a built-in **hearing test** and get an EQ matched to
+  your own hearing.
+- **Measure your headphones** with a microphone (PipeWire, or an offline recorder) and fit
+  an EQ toward a target curve (Harman, free-field, flat, …).
+- **Clone another headphone's sound** by building a difference target between two measurements.
+- **Review every run** with graphs, a plain-language confidence score, and clipping checks.
 
----
-
-## Product strategy
-
-HeadMatch currently has three frontends, but they do not have equal product priority:
-
-- **GUI** — primary experience for most users
-- **CLI** — explicit and scriptable workflow, also the most stable troubleshooting surface
-- **TUI** — backup option, mainly for offline processing or systems without a usable desktop
-
-That means most future feature work should land in the **GUI and CLI first**. The TUI remains supported, but it is no longer a primary investment area.
+The goal: make headphone personalisation usable for enthusiasts who don't want to fight the tooling.
 
 ---
 
-## What HeadMatch supports
-
-### 1. Online measurement
-Use PipeWire playback and recording to run a guided measurement directly on Linux.
-
-### 2. Offline measurement
-Generate a sweep package, record it with an external recorder, then import the WAV and fit EQ later.
-
-### 3. EQ fitting
-Analyze the measured response and generate a conservative PEQ profile aimed at audible improvement without overfitting.
-
-### 4. EQ export
-Write both **Equalizer APO** preset files and **CamillaDSP** configs from the same fit result.
-
-### 5. Headphone cloning
-Create a target curve that moves one headphone toward the tonal balance of another.
-
-### 6. Result interpretation
-Each run can include a plain-language trust summary so users can tell whether the measurement looks believable.
-
-### 7. EQ clipping prediction
-Each fit automatically checks whether the generated EQ profile could cause digital clipping. If boosts are too aggressive, HeadMatch recommends a preamp reduction and flags potential quality concerns.
-
-The CLI `headmatch fit` command shows a clipping summary after each fit. Use `--show-clipping` for a detailed breakdown (which bands are boosted, how much headroom is lost) or `--json` to get the full run summary including `eq_clipping_assessment` as structured output.
-
----
-
-## Interaction modes
-
-### GUI
-Best for most users.
+## Quick start
 
 ```bash
-headmatch-gui
-```
+python -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip headmatch
 
-The GUI offers two modes:
-
-- **Basic Mode** — A guided 3-step wizard for beginners. Pick a target, run 3 measurement iterations, review and export. No exposed device selection, sweep parameters, or filter limits.
-- **Advanced Mode** — Full control over devices, iterations, filter limits, and export options.
-
-If you want HeadMatch to appear
-
-### CLI
-Best for explicit control, scripting, and repeatable workflows.
-
-```bash
+headmatch-gui          # graphical app (recommended)
+# or, command line:
 headmatch --version
-headmatch start --out-dir out/session_01
-headmatch list-targets
+headmatch doctor       # check your setup
 ```
 
-### TUI
-Supported as a backup option, mainly for offline processing and non-desktop setups.
-
-```bash
-headmatch tui
-```
-
-All three modes share the same saved config, run summaries, and output formats.
+No microphone? Jump straight to the **[Hearing test](#hearing-test-equipment-free-eq)** — it
+only needs headphones.
 
 ---
 
-## Installation
+## Which workflow should I use?
 
-### Recommended: install from PyPI
-
-Create a small virtualenv and install the published package:
-
-```bash
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install headmatch
-```
-
-After that, the main entry points should be available:
-
-```bash
-headmatch --version
-headmatch doctor
-headmatch-gui
-```
-
-If you are not sure your local setup is ready yet, run:
-
-```bash
-headmatch doctor
-```
-
-It gives a small readiness check for the config file, PipeWire tools, and device discovery before your first measurement.
-
-### Install from source (development)
-
-If you are working from a checkout and want the editable developer install instead:
-
-```bash
-cd headmatch
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -e .
-```
-
-For tests:
-
-```bash
-python -m pip install -r requirements-test.txt
-```
-
-### Optional: add a Linux desktop launcher
-
-For GUI-first setups, you can add HeadMatch to your desktop app menu without changing packaging:
-
-1. Find the installed GUI entry point.
-   - inside a normal virtualenv this is usually `$(pwd)/.venv/bin/headmatch-gui`
-   - otherwise use `command -v headmatch-gui`
-2. Copy `docs/examples/headmatch.desktop` to:
-   ```bash
-   mkdir -p ~/.local/share/applications
-   cp docs/examples/headmatch.desktop ~/.local/share/applications/headmatch.desktop
-   ```
-3. Edit `~/.local/share/applications/headmatch.desktop` and replace `Exec=/ABSOLUTE/PATH/TO/headmatch-gui` with the real absolute path from step 1.
-4. Optionally set a custom `Icon=` path if you want something more specific than the generic `audio-headphones` icon.
-
-After that, HeadMatch should show up in most Linux desktop launchers and app menus.
+| You want to… | Use | Needs a mic? |
+|---|---|---|
+| Get an EQ matched to **your hearing**, no gear | **Hearing test** (`headmatch hearing-test`) | No |
+| Correct your headphone toward a **target curve** | **Measurement + fit** (`headmatch start` / `fit`) | Yes |
+| Make one headphone **sound like another** | **Clone target** (`headmatch clone-target`) | Yes (both headphones) |
+| Just apply an EQ you already have | See **[Applying your EQ](#applying-your-eq)** | No |
 
 ---
 
-## Recommended first run
+## Hearing test (equipment-free EQ)
 
-If you are unsure whether your machine is ready for online measurement, start with:
+The hearing test plays pure tones and asks you to click **"I hear it"**. From your responses
+it builds a personalised EQ — **no measurement microphone required**, so it works on any
+machine that can play sound.
 
+**Run it:**
+
+- **GUI:** open **Hearing Test** (available in both Basic and Advanced mode), set a
+  comfortable volume at the pre-check, then follow the prompts.
+- **CLI:**
+  ```bash
+  headmatch hearing-test            # run the test and save your hearing profile
+  headmatch hearing-fit --out-dir out/hearing_fit   # generate an EQ from the saved profile
+  headmatch hearing-test --fit --out-dir out/hearing_fit   # do both in one go
+  ```
+
+In the GUI you can **reuse a saved profile** ("Use Saved Profile") to regenerate an EQ
+without re-testing, and in **Advanced mode** layer a tonal **target curve** (Harman / free
+field / diffuse field / custom CSV) on top of the hearing correction.
+
+**How it works (and its limits):**
+
+- Each ear is measured **independently** and referenced to your own 1 kHz, so the result is
+  **calibration-invariant** — your volume knob doesn't decide the outcome — and captures real
+  **left/right differences**.
+- The test repeats only the frequencies that look deviant (**adaptive**, so a clean ear
+  finishes fast), and **rejects measurement noise** rather than correcting it.
+- It runs a **volume check** (you should *not* hear the faint tone) and an **L/R channel
+  check** before starting.
+
+> **This is a personalisation aid, not a clinical audiogram.** It's uncalibrated and measures
+> your perceived response *through your headphones*. For near-normal hearing it will
+> correctly produce little or no EQ. For a measured, headphone-specific correction, use the
+> microphone workflow below.
+
+---
+
+## Microphone measurement & EQ fitting
+
+Measure your headphone's actual response and fit a conservative parametric EQ toward a target.
+
+**Online (PipeWire), guided:**
 ```bash
-headmatch doctor
-```
-
-If the doctor output looks good and PipeWire playback and recording are working, continue with:
-
-```bash
-headmatch list-targets
+headmatch doctor                       # confirm PipeWire + devices
+headmatch list-targets                 # find your playback/capture node names
 headmatch start --out-dir out/session_01
 ```
+`start` runs a sweep → records → analyses → fits → exports APO + CamillaDSP + graphs + a summary.
 
-This will:
-1. generate a sweep
-2. run one measurement pass
-3. analyze the recording
-4. fit EQ toward the selected target
-5. export Equalizer APO and CamillaDSP files
-6. write a human-readable `README.txt`, machine-readable `run_summary.json`, and reviewable fit graphs
-
-If `headmatch doctor` reports missing PipeWire tools or no usable devices, fix that first or use the recorder-first offline path instead.
-
-If you prefer the recorder-first path:
-
+**Offline (external recorder):**
 ```bash
-headmatch prepare-offline --out-dir out/session_01
+headmatch prepare-offline --out-dir out/session_01   # get a sweep package
+# ...record the sweep with your recorder, save recording.wav...
+headmatch fit --recording out/session_01/recording.wav --out-dir out/session_01/fit
 ```
 
-Then record the sweep externally and run:
-
+**Iterative (average several passes to cut noise):**
 ```bash
-headmatch fit-offline \
-  --recording out/session_01/recording.wav \
-  --out-dir out/session_01/fit
+headmatch iterate --out-dir out/iter --target-csv my_target.csv \
+  --output-target "your-playback-node" --input-target "your-capture-node" \
+  --iterations 3 --iteration-mode average
 ```
+
+EQ aggressiveness is controlled by `--max-filters` (filters per channel) and `--fill-policy`
+(`up_to_n`, the default, stops early when the residual is small; `exact_n` places exactly N).
+Each fit predicts **clipping** and recommends a preamp if boosts are too aggressive
+(`--show-clipping` for detail, `--json` for the structured assessment).
 
 ---
 
-## Shared configuration
+## Clone another headphone's sound
 
-HeadMatch stores shared defaults in one config file used by the GUI, CLI, and TUI.
-
-Default path:
-- `$XDG_CONFIG_HOME/headmatch/config.json`
-- fallback: `~/.config/headmatch/config.json`
-
-That config can store things like:
-- preferred output folder
-- PipeWire playback target
-- PipeWire capture target
-- preferred target CSV
-- sweep and fit defaults
-
-You can override the path with:
+Build a **difference target** that moves headphone A toward the tonal balance of headphone B.
 
 ```bash
-headmatch --config /path/to/config.json ...
-headmatch-gui --config /path/to/config.json
-headmatch-tui --config /path/to/config.json
-```
-
-An example config is included at:
-
-```text
-docs/examples/headmatch.config.json
-```
-
----
-
-## Main CLI commands
-
-### Guided online path
-```bash
-headmatch doctor
-headmatch list-targets
-headmatch start --out-dir out/session_01
-```
-
-### Manual online measurement
-```bash
-headmatch measure \
-  --out-dir out/measure_usb_01 \
-  --output-target "alsa_output.usb-..." \
-  --input-target "alsa_input.usb-..."
-```
-
-### Fit an existing recording
-```bash
-headmatch fit \
-  --recording out/measure_usb_01/recording.wav \
-  --out-dir out/fit_usb_01 \
-  --target-csv my_target.csv \
-  --max-filters 8 \
-  --fill-policy up_to_n
-```
-
-`--max-filters` sets the number of EQ filters per channel. With `--fill-policy up_to_n` (the default), the fitter uses up to that many filters, stopping early if the residual error is small. With `--fill-policy exact_n`, exactly that many filters are placed.
-
-### Offline package generation
-```bash
-headmatch prepare-offline --out-dir out/offline_session_01
-```
-
-### Offline fitting
-```bash
-headmatch fit \
-  --recording out/offline_session_01/recording.wav \
-  --out-dir out/offline_session_01/fit \
-  --target-csv my_target.csv
-```
-
-`fit-offline` is still accepted as an alias for `fit` for backward compatibility, but there is no difference between them.
-
-### Iterative online workflow
-```bash
-headmatch iterate \
-  --out-dir out/iterative_usb \
-  --target-csv my_target.csv \
-  --output-target "your-playback-node" \
-  --input-target "your-capture-node" \
-  --iterations 3 \
-  --iteration-mode average
-```
-
-`--iteration-mode average` measures N times, averages the frequency responses, and fits once. This reduces noise from head position variation and ambient sound. The default `--iteration-mode independent` fits each pass separately (useful for consistency checking).
-
-### Quick setup check
-```bash
-headmatch doctor
-```
-
-Use this when install or device setup feels uncertain. It is the fastest way to confirm the config file, PipeWire tools, and basic device discovery are in place.
-
-### Clone target generation
-```bash
+# Measure both headphones on the SAME rig, then:
 headmatch clone-target \
-  --source-csv source.csv \
-  --target-csv target.csv \
-  --out clone_target.csv
+  --source-csv out/A_measure/measurement_left.csv \
+  --target-csv out/B_measure/measurement_left.csv \
+  --out out/clone/A_to_B_left.csv
+# Fit A against the clone target:
+headmatch fit --recording out/A_measure/recording.wav \
+  --target-csv out/clone/A_to_B_left.csv --out-dir out/A_to_B_fit
 ```
 
-Use this when you want to create a **difference target** that moves one headphone toward another.
+Use **matching sides** (left-vs-left or right-vs-right) and the analysed `measurement_*.csv`
+files (not the `*_raw.csv`). Ready-made published-curve examples (e.g. HD650 → HD800S) live in
+`docs/examples/clone-targets/` for learning the flow. A clone target can also serve as a
+**mic-calibration baseline** on a binaural rig — see `docs/examples/clone-target-calibration.md`.
 
-Preferred personal workflow:
-1. measure headphone **A** on your rig
-2. measure headphone **B** on the **same rig**
-3. choose matching response CSVs from those two runs
-4. build a clone target from A -> B
-5. fit a fresh measurement of headphone A against that clone target
+---
 
-For personal measurements, the CSVs to feed into `headmatch clone-target` are the run output response files:
-- `measurement_left.csv`
-- `measurement_right.csv`
+## Applying your EQ
 
-Use the **same side from both runs**.
-Examples:
-- `A/measurement_left.csv` with `B/measurement_left.csv`
-- `A/measurement_right.csv` with `B/measurement_right.csv`
+Every fit writes presets for the common hosts — load whichever matches your setup:
 
-Do **not** mix left from one headphone with right from the other unless that is deliberately what you measured.
-The raw files (`measurement_left_raw.csv` / `measurement_right_raw.csv`) are not the preferred inputs for this workflow.
-
-Concrete personal example:
-
-```bash
-# 1) Measure headphone A (the one you want to change)
-headmatch measure \
-  --out-dir out/hd650_measure \
-  --output-target "your-playback-node" \
-  --input-target "your-capture-node"
-
-# 2) Measure headphone B (the tonal balance you want to imitate)
-headmatch measure \
-  --out-dir out/hd800s_measure \
-  --output-target "your-playback-node" \
-  --input-target "your-capture-node"
-
-# 3) Build a difference target from A -> B using matching artifacts
-headmatch clone-target \
-  --source-csv out/hd650_measure/measurement_left.csv \
-  --target-csv out/hd800s_measure/measurement_left.csv \
-  --out out/clone_targets/hd650_to_hd800s_left.csv
-
-# 4) Fit headphone A using the clone target
-headmatch fit \
-  --recording out/hd650_measure/recording.wav \
-  --target-csv out/clone_targets/hd650_to_hd800s_left.csv \
-  --out-dir out/hd650_to_hd800s_fit
-```
-
-This is different from the lightweight example workflow in `docs/examples/clone-targets/`: those shipped CSVs are small published-style examples for learning the command shape. They are useful for demos and experimentation, but the preferred path for serious personal cloning is to measure both headphones on your own rig and generate the difference target from those matching measurements.
-
-### Mic calibration via clone target
-
-If you use a binaural rig, you can also use clone targets as a practical mic calibration step.
-
-The idea is simple: measure a reference headphone with published measurements, save that run as a clone target, then use it as your calibration baseline for other headphones measured on the same rig.
-
-This does **not** remove all rig effects globally. It makes your subsequent measurements more comparable within the same head/rig/setup combination, which is often the useful part.
-
-See `docs/examples/clone-target-calibration.md` for the step-by-step workflow and limitations.
+- **Equalizer APO** — `equalizer_apo.txt` (parametric) or `equalizer_apo_graphiceq.txt` (GraphicEQ).
+- **EasyEffects** — import the APO preset. GraphicEQ exports are **clip-safe** (pure-cut, max
+  0 dB), so they won't clip; turn your system volume up slightly to compensate for the cut.
+- **CamillaDSP** — `camilladsp_full.yaml` (full config template) or `camilladsp_filters_only.yaml`
+  (to merge into an existing config).
 
 ---
 
 ## Output files
 
-A typical fit output folder contains:
-- `README.txt` — plain-language explanation of the run output
-- `run_summary.json` — stable summary used by the GUI/TUI history views, including a confidence score, plain-language interpretation, and warnings
-- `fit_report.json` — detailed fit report
-- `measurement_left.csv`
-- `measurement_right.csv`
-- `equalizer_apo.txt`
-- `equalizer_apo_graphiceq.txt`
-- `camilladsp_full.yaml`
-- `camilladsp_filters_only.yaml`
-- `fit_overview.svg`
-- `fit_left.svg`
-- `fit_right.svg`
+A fit output folder contains:
 
-The general rule is:
-- open `README.txt` if you want the human explanation
-- open `run_summary.json` if you want the stable machine-readable summary, confidence score, and warnings
-- use `equalizer_apo.txt` for Equalizer APO parametric filters, `equalizer_apo_graphiceq.txt` for Equalizer APO GraphicEQ, or one of the CamillaDSP YAML files for CamillaDSP
+| File | What it is |
+|---|---|
+| `README.txt` | Plain-language explanation of the run |
+| `run_summary.json` | Stable machine-readable summary: confidence score, warnings, predicted error |
+| `fit_report.json` | Detailed fit / band list |
+| `equalizer_apo.txt`, `equalizer_apo_graphiceq.txt` | Equalizer APO presets (parametric, GraphicEQ) |
+| `camilladsp_full.yaml`, `camilladsp_filters_only.yaml` | CamillaDSP configs |
+| `measurement_left.csv`, `measurement_right.csv` | Estimated per-channel response (measurement fits) |
+| `fit_overview.svg`, `fit_left.svg`, `fit_right.svg` | Review graphs (measurement fits) |
+| `hearing_profile.json` | Your raw hearing thresholds (hearing fits) |
+
+Hearing-test runs and measurement runs both write `run_summary.json`, so both appear in the
+GUI's **Results** view and can be A/B compared.
 
 ---
 
-## Example target curves
+## Interaction modes
 
-General-purpose example target curves live in:
+All three share the same config, run summaries, and output formats. The GUI and CLI are the
+primary, actively-developed surfaces.
 
-```text
-docs/examples/targets/
-```
-
-Included example tonal targets:
-- Harman-style
-- diffuse-field
-- free-field
-- IEF neutral / Crinacle-style
-- V-shape
-- flat / studio
-
-These are small, editable example targets for quick experimentation. They are intentionally lightweight starting points rather than claims of exact published reference datasets.
-
-## Clone-target examples
-
-Documented examples live in:
-
-```text
-docs/examples/clone-targets/
-```
-
-There are two distinct clone-target workflows:
-
-### 1. Preferred personal workflow
-Use this when you own or can measure both headphones on the same rig.
-
-- measure the **source** headphone you want to change
-- measure the **target** headphone whose tonal balance you want
-- feed matching run artifacts into `headmatch clone-target`
-- use the resulting difference target when fitting the source headphone
-
-The important input files are the analyzed response CSVs written by HeadMatch:
-- `measurement_left.csv`
-- `measurement_right.csv`
-
-Use matching sides from both runs. In practice that means either:
-- left vs left, or
-- right vs right
-
-This personal-measurement path is the most trustworthy because the source and target curves come from the same coupler, mic chain, positioning style, and analysis pipeline.
-
-### 2. Lightweight published-example workflow
-Use this when you want to learn the command flow or try a rough tonal experiment from small example CSVs.
-
-These examples are useful if you want to:
-- understand the expected CSV shape
-- see a simple published-curve clone workflow
-- inspect a prebuilt example clone target
-- try ready-to-use pairings such as:
-  - FiiO JT7 → Ananda Nano
-  - HD650 → HD800S
-
-Important: the shipped clone-target CSVs are **difference targets**, not magic “make this headphone become that headphone” files.
-Use them when measuring the matching **source** headphone, then review the graphs and confidence summary to see how close the result actually got.
+- **GUI** (`headmatch-gui`) — recommended. **Basic** mode is a guided wizard; **Advanced** mode
+  exposes devices, iterations, filter limits, and target selection.
+- **CLI** (`headmatch …`) — explicit, scriptable, and the most stable troubleshooting surface.
+- **TUI** (`headmatch tui`) — backup option for offline processing or non-desktop systems.
 
 ---
 
-## Test coverage
+## Installation
 
-The repo includes:
-- unit and functional tests
-- deterministic synthetic integration tests for the CLI workflow
-- GitHub Actions workflows for both the main test suite and integration tests
+### From PyPI (recommended)
+```bash
+python -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip headmatch
+headmatch doctor      # readiness check
+```
 
-Run locally with:
+### From source (development)
+```bash
+cd headmatch
+python -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pip install -r requirements-test.txt   # for tests
+```
+
+### Standalone binaries
+Prebuilt binaries are on the [GitHub Releases](https://github.com/EaseIT-cz/headmatch/releases) page:
+
+- **Linux x64** — `headmatch-linux-x64`, `headmatch-gui-linux-x64`
+- **macOS Apple Silicon** — `headmatch-macos-arm64`, `headmatch-gui-macos-arm64`
+
+On macOS, clear the Gatekeeper quarantine once:
+```bash
+xattr -dr com.apple.quarantine /path/to/headmatch-macos-arm64
+```
+
+### Optional: desktop launcher (Linux)
+Copy `docs/examples/headmatch.desktop` to `~/.local/share/applications/` and set its `Exec=`
+to the absolute path of `headmatch-gui` (find it with `command -v headmatch-gui`).
+
+---
+
+## Configuration
+
+Shared defaults live in one config file used by the GUI, CLI, and TUI:
+
+- `$XDG_CONFIG_HOME/headmatch/config.json` (fallback `~/.config/headmatch/config.json`)
+
+It stores the preferred output folder, PipeWire playback/capture targets, preferred target
+CSV, and sweep/fit defaults. Override the path with `--config /path/to/config.json` on any
+entry point. An example is at `docs/examples/headmatch.config.json`.
+
+Your saved **hearing profile** lives separately at `hearing_profile.json` in that same config
+directory (e.g. `~/Library/Application Support/headmatch/` on macOS) and is reused across runs.
+
+---
+
+## Target curves
+
+Editable example tonal targets are in `docs/examples/targets/`: Harman-style, diffuse-field,
+free-field, IEF-neutral/Crinacle-style, V-shape, and flat/studio. They're lightweight starting
+points, not claims of exact reference datasets. Pass one with `--target-csv`, or pick one in the
+GUI's advanced target selector.
+
+---
+
+## Troubleshooting
+
+```bash
+headmatch doctor          # checks config, PipeWire tools, and device discovery
+headmatch list-targets    # lists playback/capture node names for --output/--input-target
+```
+
+If your USB audio path is unstable, use the **offline recorder-first** workflow — it's a
+supported path, not a workaround. For the hearing test, if it warns "volume too high," lower
+your level until the faint tone in the pre-check is inaudible.
+
+---
+
+## Platform & environment
+
+- **Linux + PipeWire** for microphone measurement (or an external recorder, offline).
+- The **hearing test** needs only audio playback, so it works wherever HeadMatch runs.
+- Apply the generated EQ with **Equalizer APO**, **EasyEffects**, or **CamillaDSP**.
+- In-ear or binaural microphone setups recommended for measurement.
+
+---
+
+## Tests & docs
 
 ```bash
 python -m pytest -q
 ```
 
----
-
-## Recommended hardware / environment
-
-HeadMatch is currently designed around:
-- Linux
-- PipeWire
-- CamillaDSP or Equalizer APO for applying the generated EQ
-- in-ear or binaural microphone setups
-- optional external recorder workflows
-
-If your USB audio path is unstable, use the offline recorder-first workflow. That is a supported path, not a hack.
-
----
-
-## Project docs
-
-Current project docs live in:
-- `docs/architecture.md`
-- `docs/backlog.md`
-- `docs/examples/`
-- `docs/product_pages.md` (placeholder)
-
----
-
-## Standalone binaries
-
-Prebuilt binaries are available on the [GitHub Releases](https://github.com/EaseIT-cz/headmatch/releases) page for:
-
-- **Linux x64** — `headmatch-linux-x64`, `headmatch-gui-linux-x64`
-- **macOS Apple Silicon (M1/M2/M3)** — `headmatch-macos-arm64`, `headmatch-gui-macos-arm64`
-
-### macOS: bypass "app not signed" error
-
-On macOS, unsigned binaries will be blocked by Gatekeeper. To bypass:
-
-```bash
-xattr -dr com.apple.quarantine /path/to/headmatch-macos-arm64
-```
-
-Run this once on the extracted binary or the containing folder. After that, the binary will launch normally.
+Project docs: `docs/architecture.md`, `docs/designs/` (design notes, incl. the hearing-EQ
+methodology), `docs/backlog.md`, `docs/examples/`.

--- a/docs/designs/calibration-robust-hearing.md
+++ b/docs/designs/calibration-robust-hearing.md
@@ -1,0 +1,151 @@
+# Design: Calibration-robust hearing measurement (0.8.3)
+
+Status: **draft for review.** Targets 0.8.3. Some parts are well-grounded in the
+literature; others are explicitly flagged as needing their own focused review
+before implementation (same discipline as
+`docs/designs/measurement-resolution-eq.md`).
+
+## Problem
+
+The 0.8.2 hearing test is pure-tone threshold audiometry (Modified
+Hughson-Westlake) mapped to EQ via the half-gain rule. The half-gain rule — and
+every clinical prescriptive formula (NAL-NL2, DSL, CAM2) — is defined on
+**absolute hearing loss in dB HL relative to a normal reference**. HeadMatch has
+no SPL/RETSPL calibration: it maps thresholds through an *assumed*
+`dBFS ≈ comfortable volume` reference. So the absolute "loss" is **volume-knob
+dependent**, not ear-dependent:
+
+- A real user test (2026-06-14) measured every frequency 15–20 dB "better than
+  normal" because the playback volume was high enough to hear the test floor →
+  zero compensation, a flat EQ. The data also never converged (all frequencies
+  cap-terminated, < 3 ascending runs) yet were marked `determined: true`.
+
+The literature is explicit: uncalibrated audiogram (threshold) measures are
+sensitive to missing calibration and noise, whereas **supra-threshold tests can
+be constructed to be invariant against missing calibration**
+([medRxiv 2024.06.25.24309468](https://www.medrxiv.org/content/10.1101/2024.06.25.24309468v1.full));
+and even validated app audiometry has only 60–77% test-retest agreement within
+5 dB ([Saliba et al., AJA 2022](https://pubs.asha.org/doi/10.1044/2022_AJA-21-00191)).
+
+Self-referencing thresholds to the user's own best frequency was considered and
+**rejected**: it is not a literature-backed prescription method. The
+calibration-robust path the literature actually supports is a **supra-threshold
+(loudness) measure**.
+
+## Goals
+
+1. Produce a hearing-derived EQ that is **robust to the absolute volume setting**.
+2. Stay grounded in peer-reviewed methodology; flag every approximation.
+3. Keep — but make honest — the existing pure-tone path.
+
+## Part A — Engine guards (faithful to Hughson-Westlake; do first)
+
+These bring the *existing* pure-tone path back into conformance and make any
+measurement trustworthy. Low-risk, no new science.
+
+1. **Honest `determined`.** A `FrequencyThreshold` is `determined: true` only when
+   the staircase truly converged (≥3 ascending runs with the 2-of-last-3 rule).
+   Cap-terminated / non-converged results become `determined: false` (carried as
+   low-confidence, **excluded from EQ**). The engine exposes a `converged` flag
+   distinct from `done`.
+2. **Flooring detection.** If a frequency is still heard at `MIN_LEVEL_DBFS`
+   (the floor), flag it `floored`. Many floored frequencies ⇒ surface "volume
+   too high — lower it and retest" instead of recording fake thresholds.
+3. **Volume/level pre-check.** A short calibration step before the test: play a
+   reference tone and a near-floor tone so the user sets a level where the
+   quietest tones are *near* inaudible. Also an L/R channel check ("which ear?")
+   to confirm per-ear routing reaches the hardware.
+
+## Part B — Supra-threshold, calibration-invariant measurement (primary)
+
+**Method: cross-frequency equal-loudness matching (method of adjustment).**
+
+- Present a reference tone (1 kHz) at a fixed comfortable level.
+- For each test frequency, the user adjusts that tone's level until it sounds
+  **equally loud** as the reference.
+- The level offset needed, `match(f)` (dB relative to 1 kHz), is a **within-
+  session, fixed-volume relative comparison**, so the absolute system gain
+  cancels — it is calibration-invariant by construction.
+
+**Grounding:** equal-loudness matching and equal-loudness contours are
+established psychoacoustics (ISO 226; Fletcher–Munson), and supra-threshold
+measures are the calibration-robust option the smartphone-audiometry literature
+recommends (medRxiv 2024, above).
+
+**Isolating the hearing component (the subtle part).** `match(f)` reflects three
+things mixed together: the headphone's own FR, the user's hearing, and the
+*natural* equal-loudness contour shape (a normal ear is itself less sensitive at
+the extremes). We must not "correct" the natural contour — music is already
+mastered for normal ears. So the hearing deviation is:
+
+```
+hearing_dev(f) = match_user(f) − match_normal(f)
+```
+
+where `match_normal(f)` is the normal-listener equal-loudness offset at the same
+phon level (from ISO 226). Both terms are relative-to-1 kHz, so `hearing_dev`
+stays calibration-invariant. The EQ boosts where the user needed *more* level
+than normal to match (reduced sensitivity).
+
+> ⚠ **Needs its own literature review before implementation.** Mapping a
+> supra-threshold/loudness deviation to EQ gain is *loudness restoration*, not the
+> half-gain threshold rule. There is a body of work on loudness-based fitting
+> (LGOB, IHAFF/Contour, categorical loudness scaling) with its own gain rules and
+> caveats. Before coding Part B's prescription, run a focused research pass (like
+> the EQ rework) to choose and cite the supra→gain mapping, the right phon level,
+> and how aggressively to apply `hearing_dev`. Do **not** reuse the half-gain
+> fraction blindly here.
+
+**UX caveat.** Method-of-adjustment loudness matching is harder than "I hear it"
+threshold detection (two-tone alternation + a level slider/buttons). The flow
+must make the comparison easy and allow re-matching.
+
+## Part C — Keep the pure-tone path (guarded)
+
+Retain pure-tone threshold audiometry as a secondary/clinical-style option with
+Part A's guards. It remains useful where the user *can* establish a sensible
+level, and it is the cited Hughson-Westlake method. The supra-threshold loudness
+test becomes the **default** because it is calibration-robust.
+
+## Part D — Hearing test in basic mode
+
+Add `hearing-test` to `BASIC_NAV_ITEMS` (currently advanced-only). Small,
+parked from earlier; do once Parts A/B stabilise.
+
+## Compensation model interaction
+
+Whatever Part B produces (`hearing_dev` per frequency) flows into the same
+**measured-resolution EQ** path from `docs/designs/measurement-resolution-eq.md`
+(bands at the measured frequencies, interaction-aware least-squares gains,
+standard 127-point GraphicEQ). Only the *source* of the per-frequency gains
+changes; the realisation is unchanged. Per-ear EQ (vs the current L/R average)
+becomes natural here since loudness matching is per ear — worth doing in 0.8.3.
+
+## Open questions for the focused review (Part B)
+
+1. Supra-threshold → gain mapping: which loudness-restoration rule, and how does
+   it compare to half-gain? Is partial restoration preferred (as listeners
+   preferred softer NAL-NL2 over louder CAM2, PMID 23357807)?
+2. Reference phon level for matching, and `match_normal(f)` source (ISO 226 vs a
+   simpler anchor).
+3. Test-retest reliability of self-administered loudness matching vs the ±5 dB
+   threshold figure.
+4. Minimum frequency set for matching (the 7 audiometric points, or fewer?).
+
+## Sequencing
+
+1. Part A (guards) — independent, high value, no new science.
+2. Focused literature review for Part B's prescription mapping → update this doc.
+3. Part B (equal-loudness matching + grounded mapping + per-ear EQ).
+4. Part C wiring + Part D basic-nav.
+
+## References
+
+- ISO 226 — equal-loudness-level contours.
+- medRxiv 2024.06.25.24309468 — supra-threshold measures robust to missing
+  calibration.
+- Saliba et al., AJA 2022 (doi:10.1044/2022_AJA-21-00191) — app audiometry
+  validity and ±5 dB test-retest.
+- Carhart & Jerger 1959 — Modified Hughson-Westlake (the retained pure-tone path).
+- PMID 23357807 — listeners prefer softer HF prescription (informs Part B aggressiveness).
+- `docs/designs/measurement-resolution-eq.md` — the shared EQ realisation.

--- a/docs/designs/calibration-robust-hearing.md
+++ b/docs/designs/calibration-robust-hearing.md
@@ -1,8 +1,9 @@
 # Design: Calibration-robust hearing measurement (0.8.3)
 
-Status: Targets 0.8.3. **Part A (guards) and Part D (basic-nav) shipped; the focused
-literature review for Part B is complete (folded into Part B below); Part B + the A3
-volume pre-check are the remaining implementation.**
+Status: Targets 0.8.3. **Shipped: Part A guards, Part D basic-nav, the focused review
+(folded into Part B), Part B core (per-ear relative compensation), and the A3 pre-checks
+(L/R channel check + volume/floor check). Remaining (optional): user adjustment of the
+proposed correction before export.**
 
 ## Problem
 
@@ -173,11 +174,13 @@ worth doing in 0.8.3.
 
 ## Sequencing
 
-1. ✅ Part A (guards) — honest `determined` + flooring detection (shipped).
+1. ✅ Part A (guards) — honest `determined` + flooring detection.
 2. ✅ Focused review for `normal_rel_shape` + `dev`→gain mapping (folded in above).
-3. Part B (relative-threshold measurement at a fixed reference + ISO 389-8 normal-shape
-   subtraction + fractional/capped/deadbanded mapping + per-ear EQ + user adjustment).
-4. Part C wiring + ✅ Part D basic-nav (shipped) + A3 volume pre-check (with Part B).
+3. ✅ Part B core — per-ear relative compensation (ISO 389-8 normal-shape subtraction,
+   fractional/capped/deadbanded), feeding the measured-resolution EQ realisation.
+4. ✅ Part D basic-nav + A3 pre-checks (L/R channel check + volume/floor check).
+5. ⏳ Optional: user adjustment of the proposed per-region correction before export
+   (the comparison studies all let listeners adjust; deferred enhancement).
 
 ## References
 

--- a/docs/designs/calibration-robust-hearing.md
+++ b/docs/designs/calibration-robust-hearing.md
@@ -1,9 +1,8 @@
 # Design: Calibration-robust hearing measurement (0.8.3)
 
-Status: **draft for review.** Targets 0.8.3. Some parts are well-grounded in the
-literature; others are explicitly flagged as needing their own focused review
-before implementation (same discipline as
-`docs/designs/measurement-resolution-eq.md`).
+Status: Targets 0.8.3. **Part A (guards) and Part D (basic-nav) shipped; the focused
+literature review for Part B is complete (folded into Part B below); Part B + the A3
+volume pre-check are the remaining implementation.**
 
 ## Problem
 
@@ -102,13 +101,44 @@ hearing-only music EQ that is the right quantity. It is **not** a clinical audio
 must not be presented as one. To separate headphone from hearing, use the
 mic-measurement workflow.
 
-> ⚠ **Needs a short focused review before coding** (smaller than a full study). Two
-> things to ground and cite: (a) the source/shape of `normal_rel_shape(f)` — ISO 389-8
-> reference-equivalent thresholds vs an ISO 226 equal-loudness contour at a comfortable
-> phon level; (b) how aggressively to map `dev(f)` → gain — full correction vs a
-> fraction — given listeners prefer softer high-frequency correction (PMID 23357807)
-> and self-test thresholds carry ±5 dB spread. Reuse the EQ design doc's 12 dB cap and
-> noise deadband.
+### Focused review findings (resolved)
+
+A focused literature review (adversarially verified; see References) answered the two
+open questions. *Caveat:* the review's synthesis step hit a session limit, so these
+conclusions rest on the fully-verified claims plus the prior EQ-design research pass.
+
+**(a) `normal_rel_shape(f)` = ISO 389-8 RETSPL threshold shape, relative to 1 kHz.**
+ISO 389-8 RETSPL values are *reference threshold-of-hearing levels* for circumaural
+earphones (derived from otologically-normal listeners across five labs) — i.e. a
+**threshold** reference, which is the right match for our threshold-based test. ISO 226
+equal-loudness contours are *supra-threshold* and would only apply to a loudness measure,
+so they are **not** used. The RETSPL contour has exactly the U-shape we must not
+over-correct (≈ +30 dB @125 Hz, min ≈ 1–3 kHz, rising to +17.5 dB @8 kHz re 0 dB). Use
+its value re 1 kHz at each test frequency:
+
+```
+normal_rel_shape(f) ≈ RETSPL(f) − RETSPL(1 kHz)   (ISO 389-8, HDA 200)
+  500:+5.5  1k:0  2k:−1  3k:−3  4k:+4  6k:≈+7.5(interp)  8k:+12   dB
+```
+
+Caveat: RETSPL is earphone-specific and we measure uncalibrated through an arbitrary
+headphone, so the residual `dev(f)` still folds in this headphone's deviation — exactly
+the "hearing + headphone" quantity we acknowledged. (A claim that the transducer must be
+"flat within 10–15 dB over 250 Hz–8 kHz" was **refuted** in review, so we impose no such
+hard band limit.)
+
+**(b) Map `dev(f)` → gain with a conservative fraction, a deadband, and a cap — and let
+the user fine-tune.** Apply a **fraction** of `dev(f)` (the half-gain 0.5 is the
+established, literature-backed fraction; preferred functional gain is ≈ half the
+deviation), **deadband** small deviations (self-administered audiometry agrees within
+5 dB only 60–77% of the time per frequency), and keep the **12 dB cap** from the EQ
+design doc. High-frequency aggressiveness is **genuinely contested** in the literature —
+some listeners trim prescribed HF gain by ~4 dB and prefer the softer prescription, yet
+for mild sloping losses the higher-HF prescription is preferred, and preference depends
+on input level. So we do **not** hard-code HF reduction beyond the cap; instead keep HF
+gain moderate and **expose user adjustment of the proposed correction** (the comparison
+studies all let listeners adjust). Steep HF loss correlates with preferring *less* HF
+extension, which the cap + fraction already respect.
 
 ## Part C — Keep the absolute (clinical-style) interpretation (guarded, optional)
 
@@ -134,32 +164,35 @@ of the per-frequency gains changes; the realisation is unchanged. Per-ear EQ (vs
 current L/R average) becomes natural here since the relative-threshold test is per ear —
 worth doing in 0.8.3.
 
-## Open questions for the focused review (Part B)
+## Remaining questions (post-review)
 
-1. `normal_rel_shape(f)` source: ISO 389-8 reference-equivalent threshold shape vs an
-   ISO 226 equal-loudness contour at a comfortable phon level (and which level).
-2. `dev(f)` → gain aggressiveness: full correction vs a fraction; interaction with the
-   12 dB cap and noise deadband; listeners prefer softer HF correction (PMID 23357807).
-3. Test-retest reliability of self-administered *relative* thresholds vs the absolute
-   ±5 dB figure.
-4. Frequency set: keep the 7 audiometric points, or add a few for shape resolution?
+1. Whether to expose the per-region user adjustment in the first 0.8.3 cut or a later
+   iteration (the studies all let listeners adjust the proposed correction).
+2. Exact interpolation of `normal_rel_shape` at 6 kHz (not in the ISO 389-8 HDA 200
+   table); interpolate on log-frequency.
 
 ## Sequencing
 
-1. Part A (guards) — independent, high value, no new science.
-2. Short focused review for `normal_rel_shape` + `dev`→gain mapping → update this doc.
-3. Part B (relative-threshold measurement at a fixed reference + grounded mapping +
-   per-ear EQ).
-4. Part C wiring + Part D basic-nav.
+1. ✅ Part A (guards) — honest `determined` + flooring detection (shipped).
+2. ✅ Focused review for `normal_rel_shape` + `dev`→gain mapping (folded in above).
+3. Part B (relative-threshold measurement at a fixed reference + ISO 389-8 normal-shape
+   subtraction + fractional/capped/deadbanded mapping + per-ear EQ + user adjustment).
+4. Part C wiring + ✅ Part D basic-nav (shipped) + A3 volume pre-check (with Part B).
 
 ## References
 
-- ISO 389-8 / ISO 226 — reference-equivalent thresholds and equal-loudness contours
-  (source for the normal relative reference shape).
+- **ISO 389-8:2004** — RETSPL (reference threshold-of-hearing levels) for circumaural
+  earphones; the threshold-based normal reference shape used in (a). Verified threshold
+  (not loudness) reference with the U-shaped contour.
+- ISO 226 — equal-loudness contours (supra-threshold; *not* used for a threshold test).
 - medRxiv 2024.06.25.24309468 — relative / supra-threshold measures robust to missing
   calibration.
-- Saliba et al., AJA 2022 (doi:10.1044/2022_AJA-21-00191) — app audiometry
-  validity and ±5 dB test-retest.
+- Saliba et al., AJA 2022 (doi:10.1044/2022_AJA-21-00191) — self-test audiometry agrees
+  within 5 dB only 60–77% of the time per frequency (deadband rationale).
+- Moore & Sęk 2013 (Ear & Hearing 34(1):83–95) and PMID 23357807 / doi:10.1177/
+  1084713812465494 — CAM2 vs NAL-NL2: HF-gain preference is mixed and depends on loss
+  slope and input level (informs "moderate HF + user-adjustable, not hard-coded").
+- ResearchGate 5620852 — steep HF-loss slope correlates with preferring narrower
+  bandwidth (less HF extension).
 - Carhart & Jerger 1959 — Modified Hughson-Westlake (the retained pure-tone path).
-- PMID 23357807 — listeners prefer softer HF prescription (informs Part B aggressiveness).
 - `docs/designs/measurement-resolution-eq.md` — the shared EQ realisation.

--- a/docs/designs/calibration-robust-hearing.md
+++ b/docs/designs/calibration-robust-hearing.md
@@ -27,10 +27,13 @@ be constructed to be invariant against missing calibration**
 and even validated app audiometry has only 60–77% test-retest agreement within
 5 dB ([Saliba et al., AJA 2022](https://pubs.asha.org/doi/10.1044/2022_AJA-21-00191)).
 
-Self-referencing thresholds to the user's own best frequency was considered and
-**rejected**: it is not a literature-backed prescription method. The
-calibration-robust path the literature actually supports is a **supra-threshold
-(loudness) measure**.
+A single *absolute* reference is the wrong tool here. But measuring the **relative
+response shape at one fixed listening level** is calibration-invariant (the absolute
+system gain cancels) and is the appropriate goal for a music-EQ tool. This reframes the
+objective from *clinical hearing-loss prescription* to **perceptual response calibration
+at the listening volume** — see Part B. (Self-referencing is not a valid *clinical*
+prescription, but for perceptual calibration, referencing to the user's own fixed level
+is the standard, correct approach.)
 
 ## Goals
 
@@ -56,56 +59,66 @@ measurement trustworthy. Low-risk, no new science.
    quietest tones are *near* inaudible. Also an L/R channel check ("which ear?")
    to confirm per-ear routing reaches the hardware.
 
-## Part B — Supra-threshold, calibration-invariant measurement (primary)
+## Part B — Relative response calibration at a fixed reference (primary)
 
-**Method: cross-frequency equal-loudness matching (method of adjustment).**
+**Goal (reframed).** Instead of clinical hearing-loss prescription (which needs
+absolute dB HL we cannot calibrate), measure the listener's **perceived response
+shape at the single volume they actually listen at**, and EQ it toward flat (or a
+target). Music plays at one master volume, so this matches real use; and because
+everything is measured *relative to one fixed reference*, the absolute system gain
+cancels (calibration-invariant). It also naturally includes the **headphone's own
+tuning**, since tones are measured *through* the headphone.
 
-- Present a reference tone (1 kHz) at a fixed comfortable level.
-- For each test frequency, the user adjusts that tone's level until it sounds
-  **equally loud** as the reference.
-- The level offset needed, `match(f)` (dB relative to 1 kHz), is a **within-
-  session, fixed-volume relative comparison**, so the absolute system gain
-  cancels — it is calibration-invariant by construction.
+**Method — keeps the familiar "I hear it" flow. No loudness matching, no per-frequency
+volume knob.**
 
-**Grounding:** equal-loudness matching and equal-loudness contours are
-established psychoacoustics (ISO 226; Fletcher–Munson), and supra-threshold
-measures are the calibration-robust option the smartphone-audiometry literature
-recommends (medRxiv 2024, above).
+1. The user sets the **master volume once** so a 1 kHz reference tone is comfortable;
+   that reference level is fixed for the whole test.
+2. For each frequency, the app varies only the **tone level digitally** (master
+   untouched), using the same Hughson-Westlake staircase + "I hear it" interaction
+   (with Part A's guards), to find the audibility threshold **relative to the
+   reference** — `rel_thr(f)`, in dB below the 1 kHz reference. Only the *framing*
+   changes vs today: relative to the user's own reference, not an absolute population
+   value.
+3. Repeat per ear — per-ear EQ falls out naturally.
 
-**Isolating the hearing component (the subtle part).** `match(f)` reflects three
-things mixed together: the headphone's own FR, the user's hearing, and the
-*natural* equal-loudness contour shape (a normal ear is itself less sensitive at
-the extremes). We must not "correct" the natural contour — music is already
-mastered for normal ears. So the hearing deviation is:
+**Isolating the deviation (required, or we over-boost the extremes).** A normal ear is
+*naturally* far less sensitive at the frequency extremes, so flattening the raw
+`rel_thr(f)` would wrongly boost deep bass / high treble for everyone. Subtract the
+**normal relative reference shape** (normal threshold-in-quiet / equal-loudness contour,
+referenced to 1 kHz). This is a *relative* reference and needs no absolute calibration:
 
 ```
-hearing_dev(f) = match_user(f) − match_normal(f)
+dev(f) = [ rel_thr_user(f) − rel_thr_user(1 kHz) ] − normal_rel_shape(f)
 ```
 
-where `match_normal(f)` is the normal-listener equal-loudness offset at the same
-phon level (from ISO 226). Both terms are relative-to-1 kHz, so `hearing_dev`
-stays calibration-invariant. The EQ boosts where the user needed *more* level
-than normal to match (reduced sensitivity).
+`dev(f) > 0` ⇒ the user is less sensitive than normal at f (through this headphone) ⇒
+boost. `dev(f)` then feeds the measured-resolution EQ (bands at the measured
+frequencies, LSQ gains, 127-point GraphicEQ).
 
-> ⚠ **Needs its own literature review before implementation.** Mapping a
-> supra-threshold/loudness deviation to EQ gain is *loudness restoration*, not the
-> half-gain threshold rule. There is a body of work on loudness-based fitting
-> (LGOB, IHAFF/Contour, categorical loudness scaling) with its own gain rules and
-> caveats. Before coding Part B's prescription, run a focused research pass (like
-> the EQ rework) to choose and cite the supra→gain mapping, the right phon level,
-> and how aggressively to apply `hearing_dev`. Do **not** reuse the half-gain
-> fraction blindly here.
+**What this measures, honestly.** `dev(f)` captures **hearing + this headphone**
+combined — which is exactly what reaches the listener's perception, so for a
+hearing-only music EQ that is the right quantity. It is **not** a clinical audiogram and
+must not be presented as one. To separate headphone from hearing, use the
+mic-measurement workflow.
 
-**UX caveat.** Method-of-adjustment loudness matching is harder than "I hear it"
-threshold detection (two-tone alternation + a level slider/buttons). The flow
-must make the comparison easy and allow re-matching.
+> ⚠ **Needs a short focused review before coding** (smaller than a full study). Two
+> things to ground and cite: (a) the source/shape of `normal_rel_shape(f)` — ISO 389-8
+> reference-equivalent thresholds vs an ISO 226 equal-loudness contour at a comfortable
+> phon level; (b) how aggressively to map `dev(f)` → gain — full correction vs a
+> fraction — given listeners prefer softer high-frequency correction (PMID 23357807)
+> and self-test thresholds carry ±5 dB spread. Reuse the EQ design doc's 12 dB cap and
+> noise deadband.
 
-## Part C — Keep the pure-tone path (guarded)
+## Part C — Keep the absolute (clinical-style) interpretation (guarded, optional)
 
-Retain pure-tone threshold audiometry as a secondary/clinical-style option with
-Part A's guards. It remains useful where the user *can* establish a sensible
-level, and it is the cited Hughson-Westlake method. The supra-threshold loudness
-test becomes the **default** because it is calibration-robust.
+Part B and the legacy path share the *same* measurement (the Hughson-Westlake
+"I hear it" staircase). They differ only in interpretation: Part B reads it
+**relatively** (perceptual calibration, calibration-invariant — the **default**),
+while the legacy path reads it **absolutely** (half-gain vs the population reference)
+to produce a clinical-style audiogram + EQ. Retain the absolute interpretation as an
+optional output for users who have a calibrated level, with Part A's guards applied so
+it never emits non-converged/floored thresholds as if determined.
 
 ## Part D — Hearing test in basic mode
 
@@ -114,35 +127,36 @@ parked from earlier; do once Parts A/B stabilise.
 
 ## Compensation model interaction
 
-Whatever Part B produces (`hearing_dev` per frequency) flows into the same
-**measured-resolution EQ** path from `docs/designs/measurement-resolution-eq.md`
-(bands at the measured frequencies, interaction-aware least-squares gains,
-standard 127-point GraphicEQ). Only the *source* of the per-frequency gains
-changes; the realisation is unchanged. Per-ear EQ (vs the current L/R average)
-becomes natural here since loudness matching is per ear — worth doing in 0.8.3.
+Part B's `dev(f)` per frequency flows into the same **measured-resolution EQ** path
+from `docs/designs/measurement-resolution-eq.md` (bands at the measured frequencies,
+interaction-aware least-squares gains, standard 127-point GraphicEQ). Only the *source*
+of the per-frequency gains changes; the realisation is unchanged. Per-ear EQ (vs the
+current L/R average) becomes natural here since the relative-threshold test is per ear —
+worth doing in 0.8.3.
 
 ## Open questions for the focused review (Part B)
 
-1. Supra-threshold → gain mapping: which loudness-restoration rule, and how does
-   it compare to half-gain? Is partial restoration preferred (as listeners
-   preferred softer NAL-NL2 over louder CAM2, PMID 23357807)?
-2. Reference phon level for matching, and `match_normal(f)` source (ISO 226 vs a
-   simpler anchor).
-3. Test-retest reliability of self-administered loudness matching vs the ±5 dB
-   threshold figure.
-4. Minimum frequency set for matching (the 7 audiometric points, or fewer?).
+1. `normal_rel_shape(f)` source: ISO 389-8 reference-equivalent threshold shape vs an
+   ISO 226 equal-loudness contour at a comfortable phon level (and which level).
+2. `dev(f)` → gain aggressiveness: full correction vs a fraction; interaction with the
+   12 dB cap and noise deadband; listeners prefer softer HF correction (PMID 23357807).
+3. Test-retest reliability of self-administered *relative* thresholds vs the absolute
+   ±5 dB figure.
+4. Frequency set: keep the 7 audiometric points, or add a few for shape resolution?
 
 ## Sequencing
 
 1. Part A (guards) — independent, high value, no new science.
-2. Focused literature review for Part B's prescription mapping → update this doc.
-3. Part B (equal-loudness matching + grounded mapping + per-ear EQ).
+2. Short focused review for `normal_rel_shape` + `dev`→gain mapping → update this doc.
+3. Part B (relative-threshold measurement at a fixed reference + grounded mapping +
+   per-ear EQ).
 4. Part C wiring + Part D basic-nav.
 
 ## References
 
-- ISO 226 — equal-loudness-level contours.
-- medRxiv 2024.06.25.24309468 — supra-threshold measures robust to missing
+- ISO 389-8 / ISO 226 — reference-equivalent thresholds and equal-loudness contours
+  (source for the normal relative reference shape).
+- medRxiv 2024.06.25.24309468 — relative / supra-threshold measures robust to missing
   calibration.
 - Saliba et al., AJA 2022 (doi:10.1044/2022_AJA-21-00191) — app audiometry
   validity and ±5 dB test-retest.

--- a/docs/releases/0.8.3.md
+++ b/docs/releases/0.8.3.md
@@ -1,0 +1,105 @@
+# HeadMatch 0.8.3 Release Notes
+
+Released: 2026-06-14
+
+## Overview
+
+0.8.3 makes the equipment-free **hearing test** trustworthy and fast. The test now
+measures each ear's frequency response **relative to a fixed reference** (so it no longer
+depends on the exact volume you set), **rejects self-test noise** instead of correcting
+it, runs **adaptively** so clean frequencies finish in one pass, and exports EQ that is
+**clip-safe** and smooth. The approach is grounded in a literature review captured in
+`docs/designs/calibration-robust-hearing.md`.
+
+This release contains no breaking changes to the measurement/clone workflows.
+
+---
+
+## Calibration-robust, per-ear hearing measurement
+
+The hearing-only fit was previously volume-dependent: at a high volume you measured as
+"better than normal" and got a flat EQ, and a single noisy frequency could drive a
+spurious boost. 0.8.3 reworks it:
+
+- **Relative, calibration-invariant model.** Each ear's thresholds are referenced to its
+  own 1 kHz, and the normal threshold shape (ISO 389-8 RETSPL, relative to 1 kHz) is
+  subtracted to isolate *your* deviation. Changing the overall volume no longer changes
+  the result.
+- **Per-ear EQ.** Left and right are fit independently, so a one-sided deficit produces a
+  one-sided correction.
+- **Honest results.** A threshold is only `determined` when the staircase truly converged
+  (≥3 ascending runs); cap-terminated results are excluded from the EQ rather than
+  reported as real.
+- **Flooring detection.** If you can hear the quietest tone, the test stops that frequency
+  early and warns that the volume is too high — instead of recording a fake threshold.
+- **Pre-checks.** A short **volume check** (you must *not* hear a near-floor tone) and an
+  **L/R channel check** (confirming per-ear routing reaches your hardware) run before the
+  test.
+
+## Noise-aware compensation
+
+Self-administered thresholds vary by ~±5 dB, comparable to the deviations being corrected.
+The EQ now uses the spread of repeated measurements to tell signal from noise:
+
+- **Variance gate** — a correction must beat both the deadband *and* the point's own
+  measured noise.
+- **Noise-aware L/R pooling** — where the ears agree within noise, their data is pooled
+  (more reliable); where they reliably differ, each ear is kept separate, **preserving
+  real left/right asymmetry**.
+- **Distance- and uncertainty-weighted smoothing** — neighbouring frequencies blend by
+  log-frequency distance and reliability, so a single noisy point can't drive a boost and
+  a distant frequency can't wash out a real deviation when intervening frequencies are
+  missing.
+
+## Faster test
+
+- **Adaptive depth** — every frequency gets one pass; only frequencies that look deviant
+  are repeated (to confirm and measure their spread), and the 1 kHz reference gets ≥2.
+  A near-normal ear finishes in roughly one pass per frequency.
+- **Trimmed per-tone timing** — response window 3 → 2 s, tone 1.0 → 0.8 s.
+
+## EQ export fixes
+
+- **Shelf filters for tonal targets.** When a tonal target (e.g. Harman) is layered on,
+  smooth bass/treble tilts are realised with low/high **shelf** filters instead of a
+  ripple of peaking filters.
+- **Clip-safe GraphicEQ.** GraphicEQ exports are shifted so the maximum gain is 0 dB (a
+  pure-cut curve), so they don't clip even if the host (e.g. EasyEffects) ignores the
+  separate `Preamp` line. L/R balance is preserved.
+- **Discoverable in Results.** The hearing fit now writes `run_summary.json` (with a
+  hearing-appropriate confidence summary), so its runs appear in the Results/history view
+  and are A/B-comparable like measurement runs. It also drops a copy of the raw
+  `hearing_profile.json` into the output folder.
+
+## Hearing Test in basic mode
+
+The **Hearing Test** is now available in the basic-mode navigation, not just advanced.
+
+---
+
+## Important: what the hearing test is (and isn't)
+
+The hearing test is an **uncalibrated, equipment-free personalisation aid**, not a clinical
+audiogram. It measures your perceived response *through your headphones* at your listening
+volume and corrects consistent deviations from a normal ear. For near-normal hearing it
+will correctly produce little or no EQ. For a measured, headphone-specific correction, use
+the microphone measurement workflow.
+
+## Test coverage
+
+- **759 tests passing** (up from 715 in 0.8.2).
+- New modules: `test_hearing_guards.py`, `test_relative_compensation.py`,
+  `test_noise_aware_compensation.py`, `test_adaptive_depth.py`.
+
+## Upgrade Notes
+
+No breaking changes. If you ran the hearing test in an earlier version, re-run it: results
+are now per-ear, calibration-invariant, and noise-gated. Set a comfortable volume at the
+pre-check where the quietest tones are inaudible. GraphicEQ presets are now pure-cut
+(clip-safe) — turn your system volume up slightly to compensate.
+
+```bash
+pip install --upgrade headmatch
+headmatch --version
+# headmatch 0.8.3
+```

--- a/headmatch/app_identity.py
+++ b/headmatch/app_identity.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 APP_NAME = 'headmatch'
 APP_DISPLAY_NAME = 'HeadMatch'
-_VERSION = '0.8.2'
+_VERSION = '0.8.3'
 
 
 @dataclass(frozen=True)

--- a/headmatch/exporters.py
+++ b/headmatch/exporters.py
@@ -199,22 +199,37 @@ def export_equalizer_apo_graphiceq_txt(
     gains_right_db: Iterable[float],
     *,
     comment: str = '; Generated from the shared effective correction target on the analysis frequency grid.',
+    bake_preamp: bool = False,
 ) -> Path:
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     freqs_hz = list(freqs_hz)
     gains_left_db = list(gains_left_db)
     gains_right_db = list(gains_right_db)
+
+    if bake_preamp:
+        # Make the curve clip-safe by construction: shift BOTH channels down by the
+        # global peak so the maximum gain is 0 dB (a pure-cut EQ). This avoids
+        # clipping even when the consumer (e.g. EasyEffects) ignores the separate
+        # Preamp line, and the common shift preserves L/R balance.
+        peak = max([0.0, *gains_left_db, *gains_right_db])
+        gains_left_db = [g - peak for g in gains_left_db]
+        gains_right_db = [g - peak for g in gains_right_db]
+        left_preamp = right_preamp = 0.0
+    else:
+        left_preamp = _graphiceq_preamp_db(gains_left_db)
+        right_preamp = _graphiceq_preamp_db(gains_right_db)
+
     lines = [
         '; headmatch Equalizer APO GraphicEQ preset',
         comment,
         '',
         'Channel: L',
-        f'Preamp: {_graphiceq_preamp_db(gains_left_db):.2f} dB',
+        f'Preamp: {left_preamp:.2f} dB',
         _format_graphiceq_series(freqs_hz, gains_left_db),
         '',
         'Channel: R',
-        f'Preamp: {_graphiceq_preamp_db(gains_right_db):.2f} dB',
+        f'Preamp: {right_preamp:.2f} dB',
         _format_graphiceq_series(freqs_hz, gains_right_db),
         '',
     ]

--- a/headmatch/gui/shell.py
+++ b/headmatch/gui/shell.py
@@ -82,6 +82,7 @@ DoctorReportRunner = Callable[[Path, FrontendConfig], str]
 
 BASIC_NAV_ITEMS: tuple[NavigationItem, ...] = (
     NavigationItem("basic-mode", "Basic Workflow"),
+    NavigationItem("hearing-test", "Hearing Test"),
     NavigationItem("basic-clone-target", "Clone Target"),
     NavigationItem("history", "Results"),
 )

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -156,8 +156,55 @@ def render_hearing_test(
 
         btn_frame = ttk.Frame(frame)
         btn_frame.grid(row=3, column=0, sticky="w")
-        ttk.Button(btn_frame, text="Start Test", command=_begin_left, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btn_frame, text="Start Test", command=_show_channel_check, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
         ttk.Button(btn_frame, text="Cancel", command=on_cancel).grid(row=0, column=1)
+
+    def _show_channel_check():
+        """Confirm per-ear routing reaches the hardware before testing."""
+        _clear()
+        frame.columnconfigure(0, weight=1)
+        _state["ear"] = "left"
+        ttk.Label(frame, text="Channel Check", style="Title.TLabel").grid(row=0, column=0, sticky="w", pady=(0, 8))
+        ttk.Label(
+            frame,
+            text=(
+                "A test tone is playing in your LEFT ear only. Which ear do you hear it in? "
+                "This confirms your headphones are oriented correctly and each ear is "
+                "tested independently."
+            ),
+            wraplength=560, justify="left",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 12))
+
+        def _play_check():
+            _play_tone_async(1000, START_LEVEL_DBFS)
+
+        btns = ttk.Frame(frame)
+        btns.grid(row=2, column=0, sticky="w")
+        ttk.Button(btns, text="Left ear", command=_begin_left, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btns, text="Right ear", command=_show_channel_warning).grid(row=0, column=1, padx=(0, 8))
+        ttk.Button(btns, text="Play again", command=_play_check).grid(row=0, column=2, padx=(0, 8))
+        ttk.Button(btns, text="Stop", command=_stop_test).grid(row=0, column=3)
+        _play_check()
+
+    def _show_channel_warning():
+        _clear()
+        frame.columnconfigure(0, weight=1)
+        ttk.Label(frame, text="Check Headphone Orientation", style="Title.TLabel").grid(row=0, column=0, sticky="w", pady=(0, 8))
+        ttk.Label(
+            frame,
+            text=(
+                "You heard the LEFT-channel tone in your right ear, so your headphones may "
+                "be swapped, or your system is not routing the channels independently. "
+                "Re-seat or swap your headphones and re-check, or continue anyway "
+                "(per-ear results may be unreliable)."
+            ),
+            wraplength=560, justify="left",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 12))
+        btns = ttk.Frame(frame)
+        btns.grid(row=2, column=0, sticky="w")
+        ttk.Button(btns, text="Re-check", command=_show_channel_check, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btns, text="Continue anyway", command=_begin_left).grid(row=0, column=1, padx=(0, 8))
+        ttk.Button(btns, text="Stop", command=_stop_test).grid(row=0, column=2)
 
     def _begin_left():
         _state["ear"] = "left"

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -308,13 +308,12 @@ def render_hearing_test(
         engine: ThresholdEngine = _state["engine"]
         freq_hz = engine.freq_hz
         threshold = engine.threshold
-        determined = threshold is not None
-
         result = FrequencyThreshold(
             freq_hz=freq_hz,
             level_dbfs=threshold,
             ascending_runs=engine.ascending_run_count,
-            determined=determined,
+            determined=engine.converged,
+            floored=engine.floored,
         )
         _state[_state["ear"]][freq_hz] = result
 
@@ -364,6 +363,16 @@ def render_hearing_test(
         )
         n_total = len(left_thresholds) + len(right_thresholds)
         summary_parts = [f"Thresholds determined: {n_determined} / {n_total}"]
+
+        n_floored = sum(
+            1 for t in (list(left_thresholds.values()) + list(right_thresholds.values()))
+            if getattr(t, "floored", False)
+        )
+        if n_floored:
+            summary_parts.insert(0,
+                "Volume too high: the quietest tones were still audible, so reliable "
+                "thresholds could not be measured. Lower your headphone volume and retest."
+            )
 
         if asymmetric:
             freq_labels = ", ".join(_FREQ_LABELS.get(f, str(f)) for f in asymmetric)

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -16,6 +16,7 @@ from ...hearing_test import (
     TEST_FREQUENCIES,
     TEST_ORDER,
     FrequencyThreshold,
+    adaptive_needs_more_passes,
     averaged_frequency_threshold,
     HearingProfile,
     ThresholdEngine,
@@ -249,12 +250,14 @@ def render_hearing_test(
         _state["ear"] = "left"
         _state["processed_freqs"] = set()
         _state["freq_index"] = 0
+        _state["ref_level"] = None  # this ear's 1 kHz reference (for adaptive depth)
         _show_ear_intro("left", callback=_start_test_loop)
 
     def _begin_right():
         _state["ear"] = "right"
         _state["processed_freqs"] = set()
         _state["freq_index"] = 0
+        _state["ref_level"] = None
         _show_ear_intro("right", callback=_start_test_loop)
 
     def _show_ear_intro(ear: str, callback: Callable):
@@ -403,18 +406,24 @@ def render_hearing_test(
             _state["freq_levels"].append(engine.threshold)
         _state["repeat"] += 1
 
-        # Repeat this frequency until we have MEASUREMENT_REPEATS passes (unless
-        # it floored), then average the converged passes.
-        if _state["repeat"] < MEASUREMENT_REPEATS and not _state["freq_floored"]:
+        # Adaptive depth: 1 pass per frequency; repeat (up to MEASUREMENT_REPEATS)
+        # only deviant frequencies. The 1 kHz reference gets >=2 passes.
+        min_passes = 2 if freq_hz == 1000 else 1
+        if (not _state["freq_floored"]) and adaptive_needs_more_passes(
+            freq_hz, _state["freq_levels"], _state.get("ref_level"), _state["repeat"], min_passes=min_passes
+        ):
             _state["engine"] = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
             _next_tone()
             return
 
-        _state[_state["ear"]][freq_hz] = averaged_frequency_threshold(
+        result = averaged_frequency_threshold(
             freq_hz, _state["freq_levels"],
             floored=_state["freq_floored"],
             ascending_runs=engine.ascending_run_count,
         )
+        _state[_state["ear"]][freq_hz] = result
+        if freq_hz == 1000 and result.determined:
+            _state["ref_level"] = result.level_dbfs
         _state["freq_index"] += 1
         _advance_to_next_freq()
 

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -8,6 +8,7 @@ from ...hearing_test import (
     ASYMMETRY_WARNING_DB,
     GAIN_FRACTION,
     MAX_COMPENSATION_DB,
+    MEASUREMENT_REPEATS,
     MIN_LEVEL_DBFS,
     NORMAL_HEARING_REFERENCE,
     RESPONSE_WINDOW_S,
@@ -15,6 +16,7 @@ from ...hearing_test import (
     TEST_FREQUENCIES,
     TEST_ORDER,
     FrequencyThreshold,
+    averaged_frequency_threshold,
     HearingProfile,
     ThresholdEngine,
     detect_asymmetric_frequencies,
@@ -292,6 +294,10 @@ def render_hearing_test(
 
         freq_hz = order[idx]
         _state["processed_freqs"].add(freq_hz)
+        # Repeat-measurement state for this frequency (averaged across passes).
+        _state["freq_levels"] = []
+        _state["freq_floored"] = False
+        _state["repeat"] = 0
         _state["engine"] = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
         _show_test_screen(freq_hz, idx)
         _next_tone()
@@ -391,17 +397,24 @@ def render_hearing_test(
     def _on_freq_done():
         engine: ThresholdEngine = _state["engine"]
         freq_hz = engine.freq_hz
-        threshold = engine.threshold
-        result = FrequencyThreshold(
-            freq_hz=freq_hz,
-            level_dbfs=threshold,
-            ascending_runs=engine.ascending_run_count,
-            determined=engine.converged,
-            floored=engine.floored,
-        )
-        _state[_state["ear"]][freq_hz] = result
+        if engine.floored:
+            _state["freq_floored"] = True
+        elif engine.converged and engine.threshold is not None:
+            _state["freq_levels"].append(engine.threshold)
+        _state["repeat"] += 1
 
-        # Advance freq_index past the current entry
+        # Repeat this frequency until we have MEASUREMENT_REPEATS passes (unless
+        # it floored), then average the converged passes.
+        if _state["repeat"] < MEASUREMENT_REPEATS and not _state["freq_floored"]:
+            _state["engine"] = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
+            _next_tone()
+            return
+
+        _state[_state["ear"]][freq_hz] = averaged_frequency_threshold(
+            freq_hz, _state["freq_levels"],
+            floored=_state["freq_floored"],
+            ascending_runs=engine.ascending_run_count,
+        )
         _state["freq_index"] += 1
         _advance_to_next_freq()
 

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -8,6 +8,7 @@ from ...hearing_test import (
     ASYMMETRY_WARNING_DB,
     GAIN_FRACTION,
     MAX_COMPENSATION_DB,
+    MIN_LEVEL_DBFS,
     NORMAL_HEARING_REFERENCE,
     RESPONSE_WINDOW_S,
     START_LEVEL_DBFS,
@@ -156,8 +157,44 @@ def render_hearing_test(
 
         btn_frame = ttk.Frame(frame)
         btn_frame.grid(row=3, column=0, sticky="w")
-        ttk.Button(btn_frame, text="Start Test", command=_show_channel_check, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(btn_frame, text="Start Test", command=_show_volume_check, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
         ttk.Button(btn_frame, text="Cancel", command=on_cancel).grid(row=0, column=1)
+
+    def _show_volume_check():
+        """Set a comfortable level where the test floor is inaudible (prevents the
+        flooring that makes thresholds unmeasurable)."""
+        _clear()
+        frame.columnconfigure(0, weight=1)
+        _state["ear"] = "both"
+        ttk.Label(frame, text="Set Volume", style="Title.TLabel").grid(row=0, column=0, sticky="w", pady=(0, 8))
+        ttk.Label(
+            frame,
+            text=(
+                "A 1 kHz tone is playing. Set your system volume to a comfortable "
+                "listening level. Then play the faint tone: you should NOT be able to "
+                "hear it. If you can, your volume is too high and the test cannot "
+                "measure your thresholds — lower it and re-check."
+            ),
+            wraplength=560, justify="left",
+        ).grid(row=1, column=0, sticky="w", pady=(0, 12))
+
+        def _play_comfortable():
+            _state["ear"] = "both"
+            _play_tone_async(1000, START_LEVEL_DBFS)
+
+        def _play_faint():
+            _state["ear"] = "both"
+            _play_tone_async(1000, MIN_LEVEL_DBFS + 5.0)
+
+        row1 = ttk.Frame(frame)
+        row1.grid(row=2, column=0, sticky="w")
+        ttk.Button(row1, text="Play comfortable tone", command=_play_comfortable).grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(row1, text="Play faint tone", command=_play_faint).grid(row=0, column=1)
+        row2 = ttk.Frame(frame)
+        row2.grid(row=3, column=0, sticky="w", pady=(12, 0))
+        ttk.Button(row2, text="I can't hear the faint tone — continue", command=_show_channel_check, style="Accent.TButton").grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(row2, text="Stop", command=_stop_test).grid(row=0, column=1)
+        _play_comfortable()
 
     def _show_channel_check():
         """Confirm per-ear routing reaches the hardware before testing."""

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -94,6 +94,17 @@ NORMAL_HEARING_REFERENCE: dict[int, float] = {
 
 HEARING_PROFILE_FILENAME = "hearing_profile.json"
 
+# Normal threshold shape, relative to 1 kHz, at the audiometric test frequencies.
+# Derived from ISO 389-8:2004 RETSPL (HDA 200 circumaural earphone) — reference
+# threshold-of-hearing levels, i.e. the *threshold* shape appropriate for a
+# threshold-based test (not ISO 226 supra-threshold loudness contours). Subtracting
+# this isolates the listener's deviation from a normal ear's natural frequency
+# response so we don't over-correct the extremes. 6 kHz is log-f interpolated (not
+# in the ISO 389-8 table). See docs/designs/calibration-robust-hearing.md.
+NORMAL_RELATIVE_SHAPE_DB: dict[int, float] = {
+    500: 5.5, 1000: 0.0, 2000: -1.0, 3000: -3.0, 4000: 4.0, 6000: 8.7, 8000: 12.0,
+}
+
 
 # ── Data structures ───────────────────────────────────────────────────────────
 
@@ -295,6 +306,44 @@ def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000,
 
 
 # ── Compensation curve ────────────────────────────────────────────────────────
+
+def relative_compensation_points(
+    side: dict[int, FrequencyThreshold],
+    *,
+    fraction: float = GAIN_FRACTION,
+    deadband_db: float = HEARING_DEADBAND_DB,
+    max_gain_db: float = MAX_COMPENSATION_DB,
+) -> dict[int, float]:
+    """Per-frequency EQ gain (dB) for one ear from a RELATIVE, calibration-invariant
+    reading of its thresholds.
+
+    Each determined threshold is referenced to the ear's own 1 kHz threshold (or the
+    most sensitive determined frequency if 1 kHz is missing), the normal threshold
+    shape (``NORMAL_RELATIVE_SHAPE_DB``) is subtracted to isolate the listener's
+    deviation, and a fraction of any deviation beyond the noise deadband becomes a
+    capped boost. Adding a constant to every threshold (a volume change) leaves the
+    result unchanged — the absolute level cancels.
+    """
+    thr = {
+        f: t.level_dbfs
+        for f, t in side.items()
+        if t is not None and t.determined and t.level_dbfs is not None
+    }
+    if len(thr) < 2:
+        return {}
+    ref = thr.get(1000)
+    if ref is None:
+        ref = min(thr.values())  # most sensitive determined frequency
+
+    points: dict[int, float] = {}
+    for freq_hz, level in thr.items():
+        rel = level - ref  # how much louder than the reference the listener needed
+        dev = rel - NORMAL_RELATIVE_SHAPE_DB.get(freq_hz, 0.0)
+        if dev < deadband_db:
+            continue  # within a normal ear / within self-test noise
+        points[freq_hz] = round(float(np.clip(dev * fraction, 0.0, max_gain_db)), 2)
+    return points
+
 
 def compute_compensation_points(profile: HearingProfile) -> dict[int, float]:
     """Half-gain EQ compensation (dB) at each *determined* audiometric frequency.

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -78,6 +78,10 @@ NOISE_FLOOR_DB: float = 2.0
 # a correction must exceed GATE_SIGMA of its own (smoothed) noise to be applied.
 POOL_SIGMA: float = 1.0
 GATE_SIGMA: float = 1.0
+# Across-frequency smoothing kernel width, in octaves. Weighting by log-frequency
+# distance (not list position) keeps a real deviation from being washed out by a
+# distant frequency when intervening frequencies are missing/floored.
+SMOOTH_SIGMA_OCT: float = 0.6
 # Adaptive depth: every frequency gets 1 pass; a frequency whose deviation looks
 # like a candidate for correction is repeated (up to MEASUREMENT_REPEATS) to confirm
 # it and measure its spread. Clean/normal frequencies finish in one pass — fast where
@@ -472,18 +476,22 @@ def _smooth_and_gate(dn: dict[int, tuple[float, float]], fraction, deadband_db, 
     freqs = sorted(dn)
     devs = [dn[f][0] for f in freqs]
     noises = [dn[f][1] for f in freqs]
-    # C4: inverse-variance-weighted 3-tap smoothing across frequency.
+    # C4: smoothing weighted by log-frequency distance (Gaussian kernel) AND inverse
+    # variance — neighbours blend by how close they actually are in frequency (so a
+    # distant point doesn't wash out a real deviation) and how reliable they are.
+    two_sigma_sq = 2.0 * SMOOTH_SIGMA_OCT ** 2
     sdev: list[float] = []
     snoise: list[float] = []
-    for i in range(len(freqs)):
+    for i, fi in enumerate(freqs):
         num = 0.0
         den = 0.0
-        for off, base in ((-1, 0.25), (0, 0.5), (1, 0.25)):
-            j = i + off
-            if 0 <= j < len(freqs):
-                w = base / (noises[j] ** 2)
-                num += w * devs[j]
-                den += w
+        for j, fj in enumerate(freqs):
+            oct_dist = abs(math.log2(fi / fj))
+            if oct_dist > 1.5:
+                continue  # negligible weight beyond ~1.5 octaves
+            w = math.exp(-(oct_dist ** 2) / two_sigma_sq) / (noises[j] ** 2)
+            num += w * devs[j]
+            den += w
         sdev.append(num / den if den else devs[i])
         snoise.append((1.0 / den) ** 0.5 if den else noises[i])
 

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -33,8 +33,8 @@ TEST_ORDER: tuple[int, ...] = (1000, 2000, 3000, 4000, 6000, 8000, 1000, 500)
 
 # ── Tone stimulus parameters ──────────────────────────────────────────────────
 
-TONE_DURATION_S: float = 1.0
-INTER_TONE_SILENCE_S: float = 0.8
+TONE_DURATION_S: float = 0.8
+INTER_TONE_SILENCE_S: float = 0.5
 RAMP_DURATION_S: float = 0.03       # 30 ms raised-cosine onset/offset
 
 # ── Threshold engine parameters ───────────────────────────────────────────────
@@ -56,7 +56,7 @@ MAX_PRESENTATIONS: int = 30
 # Hearing the test floor (MIN_LEVEL_DBFS) this many times means the volume is too
 # high to bracket a threshold: terminate early and flag the frequency floored.
 FLOOR_HEARD_LIMIT: int = 2
-RESPONSE_WINDOW_S: float = 3.0
+RESPONSE_WINDOW_S: float = 2.0
 
 # ── Compensation parameters ───────────────────────────────────────────────────
 
@@ -78,10 +78,12 @@ NOISE_FLOOR_DB: float = 2.0
 # a correction must exceed GATE_SIGMA of its own (smoothed) noise to be applied.
 POOL_SIGMA: float = 1.0
 GATE_SIGMA: float = 1.0
-# Each frequency is measured this many times and the converged thresholds are
-# averaged, to cut the per-point self-test variability that makes a single pass
-# jagged (Saliba et al. 2022: within-5 dB agreement only 60-77% per frequency).
-MEASUREMENT_REPEATS: int = 2
+# Adaptive depth: every frequency gets 1 pass; a frequency whose deviation looks
+# like a candidate for correction is repeated (up to MEASUREMENT_REPEATS) to confirm
+# it and measure its spread. Clean/normal frequencies finish in one pass — fast where
+# it's easy, careful where it matters. The reference (1 kHz) always gets >=2 passes.
+MEASUREMENT_REPEATS: int = 3
+ADAPTIVE_TRIGGER_DB: float = 4.0
 ASYMMETRY_WARNING_DB: float = 15.0
 NOISE_GATE_THRESHOLD_DBFS: float = -30.0
 
@@ -323,6 +325,33 @@ def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000,
 
 
 # ── Compensation curve ────────────────────────────────────────────────────────
+
+def adaptive_needs_more_passes(
+    freq_hz: int,
+    levels: list[float],
+    reference_dbfs: Optional[float],
+    attempts: int,
+    *,
+    min_passes: int = 1,
+    max_passes: int = MEASUREMENT_REPEATS,
+    trigger_db: float = ADAPTIVE_TRIGGER_DB,
+) -> bool:
+    """Whether to spend another measurement pass on this frequency (adaptive depth).
+
+    Always do at least ``min_passes`` and never more than ``max_passes``. In between,
+    repeat only if the running estimate looks deviant vs the reference (a candidate
+    for correction worth confirming) — so clean frequencies finish in one pass.
+    """
+    if attempts >= max_passes:
+        return False
+    if attempts < min_passes:
+        return True
+    if not levels or reference_dbfs is None:
+        return False
+    mean = sum(levels) / len(levels)
+    dev = (mean - reference_dbfs) - NORMAL_RELATIVE_SHAPE_DB.get(freq_hz, 0.0)
+    return abs(dev) >= trigger_db
+
 
 def averaged_frequency_threshold(
     freq_hz: int,
@@ -676,6 +705,7 @@ def run_cli_hearing_test(
     def _test_ear(ear_label: str) -> dict[int, FrequencyThreshold]:
         thresholds: dict[int, FrequencyThreshold] = {}
         processed: set[int] = set()
+        reference: Optional[float] = None  # this ear's 1 kHz, for adaptive depth
 
         for freq_hz in TEST_ORDER:
             if freq_hz in processed:
@@ -686,7 +716,9 @@ def run_cli_hearing_test(
             levels: list[float] = []
             floored = False
             runs = 0
-            for _rep in range(MEASUREMENT_REPEATS):
+            attempts = 0
+            min_passes = 2 if freq_hz == 1000 else 1
+            while True:
                 engine = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
                 while not engine.done:
                     level = engine.current_level_dbfs
@@ -694,15 +726,20 @@ def run_cli_hearing_test(
                     backend.play_tone(samples, sample_rate, output_device)
                     heard = _ask_heard(RESPONSE_WINDOW_S)
                     engine.record_response(heard)
+                attempts += 1
                 runs = max(runs, engine.ascending_run_count)
                 if engine.floored:
                     floored = True
                     break  # volume too high — no point repeating
                 if engine.converged and engine.threshold is not None:
                     levels.append(engine.threshold)
+                if not adaptive_needs_more_passes(freq_hz, levels, reference, attempts, min_passes=min_passes):
+                    break
 
             result = averaged_frequency_threshold(freq_hz, levels, floored=floored, ascending_runs=runs)
             thresholds[freq_hz] = result
+            if freq_hz == 1000 and result.determined:
+                reference = result.level_dbfs
             if result.determined:
                 _status(f"    threshold: {result.level_dbfs:.1f} dBFS (avg of {len(levels)})")
             elif floored:

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -335,14 +335,34 @@ def relative_compensation_points(
     if ref is None:
         ref = min(thr.values())  # most sensitive determined frequency
 
+    freqs = sorted(thr)
+    raw_dev = [(thr[f] - ref) - NORMAL_RELATIVE_SHAPE_DB.get(f, 0.0) for f in freqs]
+    # Smooth across frequency (triangular 3-tap) so a single noisy self-test point
+    # can't drive a boost — real hearing loss is smooth, so only deviations
+    # corroborated by neighbouring frequencies survive.
+    dev = _smooth_over_frequency(raw_dev)
+
     points: dict[int, float] = {}
-    for freq_hz, level in thr.items():
-        rel = level - ref  # how much louder than the reference the listener needed
-        dev = rel - NORMAL_RELATIVE_SHAPE_DB.get(freq_hz, 0.0)
-        if dev < deadband_db:
+    for freq_hz, d in zip(freqs, dev):
+        if d < deadband_db:
             continue  # within a normal ear / within self-test noise
-        points[freq_hz] = round(float(np.clip(dev * fraction, 0.0, max_gain_db)), 2)
+        points[freq_hz] = round(float(np.clip(d * fraction, 0.0, max_gain_db)), 2)
     return points
+
+
+def _smooth_over_frequency(values: list[float]) -> list[float]:
+    """Triangular 3-tap moving average (weights 0.25/0.5/0.25), edges renormalised."""
+    n = len(values)
+    out: list[float] = []
+    for i in range(n):
+        acc = 0.0
+        weight = 0.0
+        for j, w in ((i - 1, 0.25), (i, 0.5), (i + 1, 0.25)):
+            if 0 <= j < n:
+                acc += w * values[j]
+                weight += w
+        out.append(acc / weight if weight else values[i])
+    return out
 
 
 def compute_compensation_points(profile: HearingProfile) -> dict[int, float]:

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -46,13 +46,15 @@ STEP_UP_DB: float = 5.0             # increase after no response
 MAX_ASCENDING_RUNS: int = 8
 THRESHOLD_RESPONSES_NEEDED: int = 2
 THRESHOLD_WINDOW: int = 3
-# Safety cap: the Hughson-Westlake staircase only completes via ascending runs,
-# which require misses. A listener who hears (or misses) every presentation
-# never produces an ascending run, so without this cap the frequency would
-# never finish and the test would hang on it. 10 keeps each frequency short
-# (it also bounds the descent for very good hearing, which otherwise feels
-# like it takes forever) while still allowing a normal staircase to resolve.
-MAX_PRESENTATIONS: int = 10
+# Safety-net cap on total presentations per frequency. High enough that a
+# legitimate staircase (~11 presentations to satisfy the 2-of-3 rule, up to
+# MAX_ASCENDING_RUNS) converges; it only ever fires on a degenerate
+# miss-everything pattern. Hearing-everything is handled earlier and faster by
+# flooring detection (below), so good hearing no longer "drags on".
+MAX_PRESENTATIONS: int = 30
+# Hearing the test floor (MIN_LEVEL_DBFS) this many times means the volume is too
+# high to bracket a threshold: terminate early and flag the frequency floored.
+FLOOR_HEARD_LIMIT: int = 2
 RESPONSE_WINDOW_S: float = 3.0
 
 # ── Compensation parameters ───────────────────────────────────────────────────
@@ -100,7 +102,8 @@ class FrequencyThreshold:
     freq_hz: int
     level_dbfs: Optional[float]  # None when UNDETERMINED
     ascending_runs: int
-    determined: bool
+    determined: bool             # True only when the staircase truly converged
+    floored: bool = False        # heard the test floor -> volume likely too high
 
 
 @dataclass
@@ -158,6 +161,9 @@ class ThresholdEngine:
         self._threshold: float | None = None
         self._presentations = 0     # total tones presented (safety cap)
         self._ever_heard = False    # any heard response at all
+        self._converged = False     # True only on real 2-of-3 convergence
+        self._floored = False       # heard the test floor (volume too high)
+        self._floor_heard = 0       # times the floor was heard
 
     @property
     def current_level_dbfs(self) -> float:
@@ -175,6 +181,17 @@ class ThresholdEngine:
     def ascending_run_count(self) -> int:
         return self._run_count
 
+    @property
+    def converged(self) -> bool:
+        """True only when a real threshold was found (>=3 ascending runs,
+        2-of-last-3). Cap-terminated / floored results are NOT converged."""
+        return self._converged
+
+    @property
+    def floored(self) -> bool:
+        """True if the listener heard the test floor — volume likely too high."""
+        return self._floored
+
     def record_response(self, heard: bool) -> None:
         """Feed one user response for the current level."""
         if self._done:
@@ -183,12 +200,23 @@ class ThresholdEngine:
         self._presentations += 1
         if heard:
             self._ever_heard = True
+            # Flooring: heard the quietest tone -> can't bracket a threshold.
+            # Terminate early and flag it (the test should tell the user to lower
+            # the volume) rather than grinding to the safety cap.
+            if self._level <= MIN_LEVEL_DBFS:
+                self._floored = True
+                self._floor_heard += 1
+                if self._floor_heard >= FLOOR_HEARD_LIMIT:
+                    self._threshold = None
+                    self._done = True
+                    return
             if self._in_ascending:
                 self._run_count += 1
                 self._ascending_hits.append(round(self._level, 2))
                 threshold = self._check_threshold()
                 if threshold is not None:
                     self._threshold = threshold
+                    self._converged = True
                     self._done = True
                     return
                 if self._run_count >= MAX_ASCENDING_RUNS:
@@ -493,15 +521,18 @@ def run_cli_hearing_test(
                 engine.record_response(heard)
 
             threshold = engine.threshold
-            determined = threshold is not None
+            determined = engine.converged
             thresholds[freq_hz] = FrequencyThreshold(
                 freq_hz=freq_hz,
                 level_dbfs=threshold,
                 ascending_runs=engine.ascending_run_count,
                 determined=determined,
+                floored=engine.floored,
             )
             if determined:
                 _status(f"    threshold: {threshold:.1f} dBFS after {engine.ascending_run_count} runs")
+            elif engine.floored:
+                _status("    floored — volume too high to measure; lower it and retest")
             else:
                 _status(f"    threshold undetermined after {engine.ascending_run_count} runs")
 

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -9,6 +9,7 @@ No proprietary algorithm or patented DSP method is used.
 from __future__ import annotations
 
 import json
+import math
 from collections import Counter
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -70,6 +71,13 @@ HEARING_DEADBAND_DB: float = 10.0
 # deviation. Lower than the absolute deadband because smoothing already rejects
 # single-point noise, so a smaller bar catches mild-but-consistent deviations.
 RELATIVE_DEADBAND_DB: float = 6.0
+# Per-point inherent uncertainty even with repeats (avoids div-by-zero and reflects
+# that no self-test point is perfectly reliable). Used by the noise-aware model.
+NOISE_FLOOR_DB: float = 2.0
+# L/R deviations within POOL_SIGMA combined std are pooled (treated as the same);
+# a correction must exceed GATE_SIGMA of its own (smoothed) noise to be applied.
+POOL_SIGMA: float = 1.0
+GATE_SIGMA: float = 1.0
 # Each frequency is measured this many times and the converged thresholds are
 # averaged, to cut the per-point self-test variability that makes a single pass
 # jagged (Saliba et al. 2022: within-5 dB agreement only 60-77% per frequency).
@@ -123,6 +131,7 @@ class FrequencyThreshold:
     ascending_runs: int
     determined: bool             # True only when the staircase truly converged
     floored: bool = False        # heard the test floor -> volume likely too high
+    spread_db: float = 0.0        # std of the repeated passes (per-point uncertainty)
 
 
 @dataclass
@@ -329,7 +338,8 @@ def averaged_frequency_threshold(
     """
     if floored or not levels:
         return FrequencyThreshold(freq_hz, None, ascending_runs, False, floored)
-    return FrequencyThreshold(freq_hz, round(float(np.mean(levels)), 2), ascending_runs, True, False)
+    spread = round(float(np.std(levels)), 2) if len(levels) > 1 else 0.0
+    return FrequencyThreshold(freq_hz, round(float(np.mean(levels)), 2), ascending_runs, True, False, spread)
 
 
 def relative_compensation_points(
@@ -349,45 +359,113 @@ def relative_compensation_points(
     capped boost. Adding a constant to every threshold (a volume change) leaves the
     result unchanged — the absolute level cancels.
     """
-    thr = {
-        f: t.level_dbfs
+    return _smooth_and_gate(_ear_deviations(side), fraction, deadband_db, max_gain_db)
+
+
+def compute_relative_compensation(
+    profile: HearingProfile,
+    *,
+    fraction: float = GAIN_FRACTION,
+    deadband_db: float = RELATIVE_DEADBAND_DB,
+    max_gain_db: float = MAX_COMPENSATION_DB,
+) -> tuple[dict[int, float], dict[int, float]]:
+    """Per-ear EQ gains using per-point uncertainty (from repeated passes):
+
+    - A1 variance gate: a correction must exceed the deadband AND the point's own
+      (smoothed) measured noise — so noisy points are not corrected.
+    - B3 noise-aware pooling: where the two ears agree within their combined noise,
+      the deviations are pooled (more data, less noise); where they reliably differ,
+      each ear is kept separate — preserving real L/R asymmetry.
+    - C4 uncertainty-weighted smoothing: neighbouring frequencies are blended with
+      inverse-variance weights, so reliable points dominate noisy ones.
+    """
+    left = _ear_deviations(profile.left)
+    right = _ear_deviations(profile.right)
+
+    pooled_left: dict[int, tuple[float, float]] = {}
+    pooled_right: dict[int, tuple[float, float]] = {}
+    for freq_hz in sorted(set(left) | set(right)):
+        dl = left.get(freq_hz)
+        dr = right.get(freq_hz)
+        if dl and dr:
+            combined = math.hypot(dl[1], dr[1])
+            if abs(dl[0] - dr[0]) <= POOL_SIGMA * combined:
+                merged = _inverse_variance_weighted([dl, dr])  # ears agree -> pool
+                pooled_left[freq_hz] = pooled_right[freq_hz] = merged
+            else:
+                pooled_left[freq_hz] = dl  # reliably differ -> per-ear
+                pooled_right[freq_hz] = dr
+        elif dl:
+            pooled_left[freq_hz] = dl
+        elif dr:
+            pooled_right[freq_hz] = dr
+
+    return (
+        _smooth_and_gate(pooled_left, fraction, deadband_db, max_gain_db),
+        _smooth_and_gate(pooled_right, fraction, deadband_db, max_gain_db),
+    )
+
+
+def _ear_deviations(side: dict[int, FrequencyThreshold]) -> dict[int, tuple[float, float]]:
+    """{freq: (deviation_db, noise_db)} for one ear — relative to its own 1 kHz,
+    normal shape subtracted, with the combined measurement noise."""
+    determined = {
+        f: (t.level_dbfs, getattr(t, 'spread_db', 0.0) or 0.0)
         for f, t in side.items()
         if t is not None and t.determined and t.level_dbfs is not None
     }
-    if len(thr) < 2:
+    if len(determined) < 2:
         return {}
-    ref = thr.get(1000)
-    if ref is None:
-        ref = min(thr.values())  # most sensitive determined frequency
+    ref_level, ref_spread = determined.get(1000, (None, 0.0))
+    if ref_level is None:
+        ref_level = min(v[0] for v in determined.values())
+        ref_spread = 0.0
+    ref_noise_sq = ref_spread ** 2 + NOISE_FLOOR_DB ** 2
 
-    freqs = sorted(thr)
-    raw_dev = [(thr[f] - ref) - NORMAL_RELATIVE_SHAPE_DB.get(f, 0.0) for f in freqs]
-    # Smooth across frequency (triangular 3-tap) so a single noisy self-test point
-    # can't drive a boost — real hearing loss is smooth, so only deviations
-    # corroborated by neighbouring frequencies survive.
-    dev = _smooth_over_frequency(raw_dev)
+    out: dict[int, tuple[float, float]] = {}
+    for freq_hz, (level, spread) in determined.items():
+        dev = (level - ref_level) - NORMAL_RELATIVE_SHAPE_DB.get(freq_hz, 0.0)
+        noise = math.sqrt(spread ** 2 + NOISE_FLOOR_DB ** 2 + ref_noise_sq)
+        out[freq_hz] = (dev, noise)
+    return out
+
+
+def _inverse_variance_weighted(items: list[tuple[float, float]]) -> tuple[float, float]:
+    weights = [1.0 / (n * n) for _, n in items]
+    total = sum(weights)
+    dev = sum(w * d for w, (d, _) in zip(weights, items)) / total
+    return dev, (1.0 / total) ** 0.5
+
+
+def _smooth_and_gate(dn: dict[int, tuple[float, float]], fraction, deadband_db, max_gain_db) -> dict[int, float]:
+    if not dn:
+        return {}
+    freqs = sorted(dn)
+    devs = [dn[f][0] for f in freqs]
+    noises = [dn[f][1] for f in freqs]
+    # C4: inverse-variance-weighted 3-tap smoothing across frequency.
+    sdev: list[float] = []
+    snoise: list[float] = []
+    for i in range(len(freqs)):
+        num = 0.0
+        den = 0.0
+        for off, base in ((-1, 0.25), (0, 0.5), (1, 0.25)):
+            j = i + off
+            if 0 <= j < len(freqs):
+                w = base / (noises[j] ** 2)
+                num += w * devs[j]
+                den += w
+        sdev.append(num / den if den else devs[i])
+        snoise.append((1.0 / den) ** 0.5 if den else noises[i])
 
     points: dict[int, float] = {}
-    for freq_hz, d in zip(freqs, dev):
+    for freq_hz, d, n in zip(freqs, sdev, snoise):
         if d < deadband_db:
             continue  # within a normal ear / within self-test noise
+        if d < GATE_SIGMA * n:
+            continue  # A1: doesn't beat its own measured noise
         points[freq_hz] = round(float(np.clip(d * fraction, 0.0, max_gain_db)), 2)
     return points
-
-
-def _smooth_over_frequency(values: list[float]) -> list[float]:
-    """Triangular 3-tap moving average (weights 0.25/0.5/0.25), edges renormalised."""
-    n = len(values)
-    out: list[float] = []
-    for i in range(n):
-        acc = 0.0
-        weight = 0.0
-        for j, w in ((i - 1, 0.25), (i, 0.5), (i + 1, 0.25)):
-            if 0 <= j < n:
-                acc += w * values[j]
-                weight += w
-        out.append(acc / weight if weight else values[i])
-    return out
 
 
 def compute_compensation_points(profile: HearingProfile) -> dict[int, float]:

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -66,6 +66,14 @@ MAX_COMPENSATION_DB: float = 12.0
 # losses (Schwartz et al. 1980). Ignore measured "loss" below this deadband so
 # we don't EQ within-noise differences. See docs/designs/measurement-resolution-eq.md.
 HEARING_DEADBAND_DB: float = 10.0
+# Deadband for the relative model: applied to the *smoothed* per-frequency
+# deviation. Lower than the absolute deadband because smoothing already rejects
+# single-point noise, so a smaller bar catches mild-but-consistent deviations.
+RELATIVE_DEADBAND_DB: float = 6.0
+# Each frequency is measured this many times and the converged thresholds are
+# averaged, to cut the per-point self-test variability that makes a single pass
+# jagged (Saliba et al. 2022: within-5 dB agreement only 60-77% per frequency).
+MEASUREMENT_REPEATS: int = 2
 ASYMMETRY_WARNING_DB: float = 15.0
 NOISE_GATE_THRESHOLD_DBFS: float = -30.0
 
@@ -307,11 +315,28 @@ def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000,
 
 # ── Compensation curve ────────────────────────────────────────────────────────
 
+def averaged_frequency_threshold(
+    freq_hz: int,
+    levels: list[float],
+    *,
+    floored: bool,
+    ascending_runs: int,
+) -> "FrequencyThreshold":
+    """Combine the converged thresholds from repeated passes at one frequency.
+
+    Determined only if at least one pass converged and none floored; the level is
+    the mean of the converged passes (finer than the 5 dB staircase grid).
+    """
+    if floored or not levels:
+        return FrequencyThreshold(freq_hz, None, ascending_runs, False, floored)
+    return FrequencyThreshold(freq_hz, round(float(np.mean(levels)), 2), ascending_runs, True, False)
+
+
 def relative_compensation_points(
     side: dict[int, FrequencyThreshold],
     *,
     fraction: float = GAIN_FRACTION,
-    deadband_db: float = HEARING_DEADBAND_DB,
+    deadband_db: float = RELATIVE_DEADBAND_DB,
     max_gain_db: float = MAX_COMPENSATION_DB,
 ) -> dict[int, float]:
     """Per-frequency EQ gain (dB) for one ear from a RELATIVE, calibration-invariant
@@ -579,31 +604,33 @@ def run_cli_hearing_test(
                 continue
             processed.add(freq_hz)
 
-            engine = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
             _status(f"\n  {ear_label} ear — {freq_hz} Hz")
+            levels: list[float] = []
+            floored = False
+            runs = 0
+            for _rep in range(MEASUREMENT_REPEATS):
+                engine = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
+                while not engine.done:
+                    level = engine.current_level_dbfs
+                    samples = generate_tone(freq_hz, level, sample_rate, ear=ear_label.lower())
+                    backend.play_tone(samples, sample_rate, output_device)
+                    heard = _ask_heard(RESPONSE_WINDOW_S)
+                    engine.record_response(heard)
+                runs = max(runs, engine.ascending_run_count)
+                if engine.floored:
+                    floored = True
+                    break  # volume too high — no point repeating
+                if engine.converged and engine.threshold is not None:
+                    levels.append(engine.threshold)
 
-            while not engine.done:
-                level = engine.current_level_dbfs
-                samples = generate_tone(freq_hz, level, sample_rate, ear=ear_label.lower())
-                backend.play_tone(samples, sample_rate, output_device)
-                heard = _ask_heard(RESPONSE_WINDOW_S)
-                engine.record_response(heard)
-
-            threshold = engine.threshold
-            determined = engine.converged
-            thresholds[freq_hz] = FrequencyThreshold(
-                freq_hz=freq_hz,
-                level_dbfs=threshold,
-                ascending_runs=engine.ascending_run_count,
-                determined=determined,
-                floored=engine.floored,
-            )
-            if determined:
-                _status(f"    threshold: {threshold:.1f} dBFS after {engine.ascending_run_count} runs")
-            elif engine.floored:
+            result = averaged_frequency_threshold(freq_hz, levels, floored=floored, ascending_runs=runs)
+            thresholds[freq_hz] = result
+            if result.determined:
+                _status(f"    threshold: {result.level_dbfs:.1f} dBFS (avg of {len(levels)})")
+            elif floored:
                 _status("    floored — volume too high to measure; lower it and retest")
             else:
-                _status(f"    threshold undetermined after {engine.ascending_run_count} runs")
+                _status(f"    threshold undetermined after {runs} runs")
 
         return thresholds
 

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -202,7 +202,7 @@ def fit_from_hearing_profile(
         eq_target(f) = target(f) + hearing_compensation(f)
     where compensation comes from the half-gain rule (Lybarger 1944).
     """
-    from .hearing_test import eq_bands_from_gain_points, relative_compensation_points
+    from .hearing_test import compute_relative_compensation, eq_bands_from_gain_points
     from .signals import geometric_log_grid
 
     filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
@@ -223,8 +223,7 @@ def fit_from_hearing_profile(
     # Per-ear, calibration-invariant relative compensation (Part B): reference each
     # ear's thresholds to its own 1 kHz and subtract the normal threshold shape.
     # See docs/designs/calibration-robust-hearing.md.
-    left_comp = relative_compensation_points(profile.left)
-    right_comp = relative_compensation_points(profile.right)
+    left_comp, right_comp = compute_relative_compensation(profile)
     target_grid = np.interp(np.log10(freqs), np.log10(tfreqs), tvals, left=float(tvals[0]), right=float(tvals[-1]))
     target_is_flat = not bool(np.any(np.abs(tvals) > 0.05))
 

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -221,35 +221,33 @@ def fit_from_hearing_profile(
     tvals = np.asarray(target.values_db, dtype=float)
 
     # Per-ear, calibration-invariant relative compensation (Part B): reference each
-    # ear's thresholds to its own 1 kHz, subtract the normal threshold shape, then
-    # combine with the (independent) target curve and place one peaking filter per
-    # control point. See docs/designs/calibration-robust-hearing.md.
-    def _combine_with_target(comp_points: dict) -> dict:
-        # Control points = the ear's measured frequencies UNION the target's own
-        # non-neutral frequencies (the target applies even with no hearing deviation).
-        control = set(comp_points)
-        control.update(int(round(f)) for f, v in zip(tfreqs, tvals) if abs(v) > 0.05)
-        return {
-            f: round(comp_points.get(f, 0.0) + float(np.interp(f, tfreqs, tvals)), 2)
-            for f in sorted(control)
-        }
+    # ear's thresholds to its own 1 kHz and subtract the normal threshold shape.
+    # See docs/designs/calibration-robust-hearing.md.
+    left_comp = relative_compensation_points(profile.left)
+    right_comp = relative_compensation_points(profile.right)
+    target_grid = np.interp(np.log10(freqs), np.log10(tfreqs), tvals, left=float(tvals[0]), right=float(tvals[-1]))
+    target_is_flat = not bool(np.any(np.abs(tvals) > 0.05))
 
-    def _grid_curve(eq_points: dict) -> np.ndarray:
-        if not eq_points:
-            return np.zeros(len(freqs))
-        fs = sorted(eq_points)
-        gs = [eq_points[f] for f in fs]
-        return np.interp(np.log10(freqs), np.log10(fs), gs, left=gs[0], right=gs[-1])
+    def _ear_bands_and_target(comp: dict):
+        # Sparse hearing compensation as peaking filters at the measured frequencies.
+        hearing_bands = eq_bands_from_gain_points(comp, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
+        if target_is_flat:
+            # Hearing only: keep the honest, sparse measured-resolution bands.
+            return hearing_bands, peq_chain_response_db(freqs, sample_rate, hearing_bands)
+        # A tonal target is layered on. Render the hearing bumps as a curve, add the
+        # (smooth, dense) target, and re-fit the combined curve with fit_peq, which
+        # places low/high SHELVES at tilted edges + peaking for mid features — so the
+        # Harman bass/treble tilt is smooth instead of rippled.
+        combined = target_grid + peq_chain_response_db(freqs, sample_rate, hearing_bands)
+        return fit_peq(freqs, combined, sample_rate, budget=filter_budget), combined
 
-    left_eq_points = _combine_with_target(relative_compensation_points(profile.left))
-    right_eq_points = _combine_with_target(relative_compensation_points(profile.right))
-    left_bands = eq_bands_from_gain_points(left_eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
-    right_bands = eq_bands_from_gain_points(right_eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
+    left_bands, left_target = _ear_bands_and_target(left_comp)
+    right_bands, right_target = _ear_bands_and_target(right_comp)
 
     left_pred = peq_chain_response_db(freqs, sample_rate, left_bands)
     right_pred = peq_chain_response_db(freqs, sample_rate, right_bands)
-    l_rms, l_max = _metrics(freqs, left_pred, _grid_curve(left_eq_points))
-    r_rms, r_max = _metrics(freqs, right_pred, _grid_curve(right_eq_points))
+    l_rms, l_max = _metrics(freqs, left_pred, left_target)
+    r_rms, r_max = _metrics(freqs, right_pred, right_target)
 
     identity = get_app_identity()
     report = {
@@ -274,8 +272,8 @@ def fit_from_hearing_profile(
         'left_bands': [asdict(b) for b in left_bands],
         'right_bands': [asdict(b) for b in right_bands],
         'hearing_eq_points': {
-            'left': {str(f): g for f, g in left_eq_points.items()},
-            'right': {str(f): g for f, g in right_eq_points.items()},
+            'left': {str(f): g for f, g in left_comp.items()},
+            'right': {str(f): g for f, g in right_comp.items()},
         },
     }
     clipping_assessment = assess_eq_clipping(freqs, sample_rate, left_bands, right_bands)

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -370,6 +370,7 @@ def run_hearing_fit(
         peq_chain_response_db(gq_freqs, sample_rate, left_bands),
         peq_chain_response_db(gq_freqs, sample_rate, right_bands),
         comment='; GraphicEQ rendered on the standard 127-point grid from the fitted bands.',
+        bake_preamp=True,
     )
 
     # Drop a copy of the raw hearing profile alongside the EQ artifacts for

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -202,11 +202,7 @@ def fit_from_hearing_profile(
         eq_target(f) = target(f) + hearing_compensation(f)
     where compensation comes from the half-gain rule (Lybarger 1944).
     """
-    from .hearing_test import (
-        compute_compensation_curve,
-        compute_compensation_points,
-        eq_bands_from_gain_points,
-    )
+    from .hearing_test import eq_bands_from_gain_points, relative_compensation_points
     from .signals import geometric_log_grid
 
     filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
@@ -215,45 +211,45 @@ def fit_from_hearing_profile(
     # ~7 measured points, so the EQ is built directly from those (see
     # docs/designs/measurement-resolution-eq.md).
     freqs = geometric_log_grid(20.0, 20000.0, 48)
-    flat = np.zeros(len(freqs))
 
     if target_path:
         target = load_curve(target_path)
     else:
         target = create_flat_target(freqs)
     target_resampled = resample_curve(target, freqs)
-    if target_resampled.semantics == 'relative':
-        target_values = flat + target_resampled.values_db
-    else:
-        target_values = target_resampled.values_db.copy()
-
-    compensation = compute_compensation_curve(profile, freqs)
-    eq_target = target_values + compensation
-
-    # Build the EQ directly from the measured audiometric frequencies: combine
-    # per-frequency hearing compensation with the target sampled at those same
-    # frequencies, then place one peaking filter per point (Q from spacing).
-    comp_points = compute_compensation_points(profile)
-    # Control points = the measured audiometric frequencies (hearing comp) UNION the
-    # target curve's own frequencies where it deviates from neutral. The target is
-    # known independently of the hearing test, so it must apply even when there is
-    # no measurable hearing loss. gain(f) = compensation(f) + target(f).
     tfreqs = np.asarray(target.freqs_hz, dtype=float)
     tvals = np.asarray(target.values_db, dtype=float)
-    control = set(comp_points)
-    control.update(int(round(f)) for f, v in zip(tfreqs, tvals) if abs(v) > 0.05)
-    eq_points = {
-        f: round(comp_points.get(f, 0.0) + float(np.interp(f, tfreqs, tvals)), 2)
-        for f in sorted(control)
-    }
-    bands = eq_bands_from_gain_points(eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
-    left_bands = bands
-    right_bands = list(bands)
 
-    left_pred = flat + peq_chain_response_db(freqs, sample_rate, left_bands)
-    right_pred = flat + peq_chain_response_db(freqs, sample_rate, right_bands)
-    l_rms, l_max = _metrics(freqs, left_pred, eq_target)
-    r_rms, r_max = _metrics(freqs, right_pred, eq_target)
+    # Per-ear, calibration-invariant relative compensation (Part B): reference each
+    # ear's thresholds to its own 1 kHz, subtract the normal threshold shape, then
+    # combine with the (independent) target curve and place one peaking filter per
+    # control point. See docs/designs/calibration-robust-hearing.md.
+    def _combine_with_target(comp_points: dict) -> dict:
+        # Control points = the ear's measured frequencies UNION the target's own
+        # non-neutral frequencies (the target applies even with no hearing deviation).
+        control = set(comp_points)
+        control.update(int(round(f)) for f, v in zip(tfreqs, tvals) if abs(v) > 0.05)
+        return {
+            f: round(comp_points.get(f, 0.0) + float(np.interp(f, tfreqs, tvals)), 2)
+            for f in sorted(control)
+        }
+
+    def _grid_curve(eq_points: dict) -> np.ndarray:
+        if not eq_points:
+            return np.zeros(len(freqs))
+        fs = sorted(eq_points)
+        gs = [eq_points[f] for f in fs]
+        return np.interp(np.log10(freqs), np.log10(fs), gs, left=gs[0], right=gs[-1])
+
+    left_eq_points = _combine_with_target(relative_compensation_points(profile.left))
+    right_eq_points = _combine_with_target(relative_compensation_points(profile.right))
+    left_bands = eq_bands_from_gain_points(left_eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
+    right_bands = eq_bands_from_gain_points(right_eq_points, sample_rate=sample_rate, max_filters=filter_budget.max_filters)
+
+    left_pred = peq_chain_response_db(freqs, sample_rate, left_bands)
+    right_pred = peq_chain_response_db(freqs, sample_rate, right_bands)
+    l_rms, l_max = _metrics(freqs, left_pred, _grid_curve(left_eq_points))
+    r_rms, r_max = _metrics(freqs, right_pred, _grid_curve(right_eq_points))
 
     identity = get_app_identity()
     report = {
@@ -277,7 +273,10 @@ def fit_from_hearing_profile(
         },
         'left_bands': [asdict(b) for b in left_bands],
         'right_bands': [asdict(b) for b in right_bands],
-        'hearing_eq_points': {str(f): g for f, g in eq_points.items()},
+        'hearing_eq_points': {
+            'left': {str(f): g for f, g in left_eq_points.items()},
+            'right': {str(f): g for f, g in right_eq_points.items()},
+        },
     }
     clipping_assessment = assess_eq_clipping(freqs, sample_rate, left_bands, right_bands)
     report['eq_clipping'] = {

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -380,9 +380,64 @@ def run_hearing_fit(
     if hasattr(profile, 'to_dict'):
         save_json(out_dir / 'hearing_profile.json', profile.to_dict())
     save_json(out_dir / 'hearing_fit_report.json', report)
+    # run_summary.json so the hearing fit is discoverable in the Results/history
+    # view and A/B-comparable, like the measurement fit.
+    save_json(out_dir / 'run_summary.json',
+              _hearing_run_summary(profile, out_dir, left_bands, right_bands, report, sample_rate, filter_budget).to_dict())
     _write_hearing_fit_readme(out_dir, report)
 
     return report
+
+
+def _hearing_run_summary(profile, out_dir, left_bands, right_bands, report, sample_rate, filter_budget):
+    from .contracts import (
+        RUN_SUMMARY_SCHEMA_VERSION, ConfidenceSummary, FrontendRunSummary,
+        RunErrorSummary, RunFilterCounts,
+    )
+    from .hearing_test import TEST_FREQUENCIES
+
+    sides = list(profile.left.values()) + list(profile.right.values())
+    total = len(sides)
+    determined = sum(1 for t in sides if getattr(t, 'determined', False))
+    floored = sum(1 for t in sides if getattr(t, 'floored', False))
+    if floored:
+        label, score, headline = "low", 30, "Some frequencies floored — volume likely too high; re-test at a lower level."
+    elif total and determined == total:
+        label, score, headline = "high", 80, "All frequencies measured (hearing-only fit; flat headphone assumed)."
+    elif total and determined >= 0.6 * total:
+        label, score, headline = "medium", 60, "Most frequencies measured (hearing-only fit)."
+    else:
+        label, score, headline = "low", 40, "Few frequencies converged — results uncertain; re-test."
+
+    confidence = ConfidenceSummary(
+        score=score, label=label, headline=headline,
+        interpretation="Equipment-free hearing-based EQ. Not a clinical audiogram (uncalibrated, relative test).",
+        reasons=(f"{determined}/{total} thresholds determined",),
+        warnings=("Volume too high during the test — re-test at a lower level.",) if floored else (),
+        metrics={"determined": float(determined), "floored": float(floored), "total": float(total)},
+    )
+    clipping = report.get('eq_clipping') if isinstance(report.get('eq_clipping'), dict) else None
+    return FrontendRunSummary(
+        schema_version=RUN_SUMMARY_SCHEMA_VERSION,
+        generated_by=get_app_identity().as_metadata(),
+        kind="fit",
+        out_dir=str(out_dir),
+        sample_rate=sample_rate,
+        frequency_points=len(TEST_FREQUENCIES),
+        target=report.get('target', 'flat'),
+        filters=RunFilterCounts(left=len(left_bands), right=len(right_bands)),
+        predicted_error_db=RunErrorSummary(
+            left_rms=report['predicted_left_rms_error_db'],
+            right_rms=report['predicted_right_rms_error_db'],
+            left_max=report['predicted_left_max_error_db'],
+            right_max=report['predicted_right_max_error_db'],
+        ),
+        confidence=confidence,
+        plots={},
+        results_guide=str(out_dir / 'README.txt'),
+        filter_budget=filter_budget,
+        eq_clipping_assessment=clipping,
+    )
 
 
 def _average_measurements(results: list[MeasurementResult]) -> MeasurementResult:

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -353,12 +353,12 @@ def run_hearing_fit(
         max_filters=max_filters, filter_budget=filter_budget,
     )
 
-    clipping = report.get('eq_clipping') if isinstance(report.get('eq_clipping'), dict) else None
+    # Per-channel preamp (preamp_db=None): a channel with no boost is not attenuated,
+    # so a one-eared correction doesn't shift L/R balance.
     export_equalizer_apo_parametric_txt(
         out_dir / 'equalizer_apo.txt',
         left_bands,
         right_bands,
-        preamp_db=(float(clipping['preamp_db']) if clipping and clipping.get('will_clip') else None),
     )
     export_camilladsp_filters_yaml(out_dir / 'camilladsp_full.yaml', left_bands, right_bands, samplerate=sample_rate)
     export_camilladsp_filter_snippet_yaml(out_dir / 'camilladsp_filters_only.yaml', left_bands, right_bands)

--- a/headmatch/pipeline_artifacts.py
+++ b/headmatch/pipeline_artifacts.py
@@ -103,6 +103,7 @@ def _write_fixed_band_graphiceq_artifact(
         [band.gain_db for band in left_bands],
         [band.gain_db for band in right_bands],
         comment='; Generated directly from the fixed-band GraphicEQ fitting backend.',
+        bake_preamp=True,
     )
 
 
@@ -219,6 +220,7 @@ def write_fit_artifacts(
         gq_freqs,
         peq_chain_response_db(gq_freqs, sample_rate, left_bands),
         peq_chain_response_db(gq_freqs, sample_rate, right_bands),
+        bake_preamp=True,
     )
     _write_fixed_band_graphiceq_artifact(
         out_dir,

--- a/tests/test_adaptive_depth.py
+++ b/tests/test_adaptive_depth.py
@@ -1,0 +1,34 @@
+"""Adaptive measurement depth (0.8.3): 1 pass per frequency, repeat only deviant
+ones (and >=2 for the reference) — fast on clean ears, careful where it matters."""
+from __future__ import annotations
+
+from headmatch.hearing_test import (
+    MEASUREMENT_REPEATS,
+    NORMAL_RELATIVE_SHAPE_DB,
+    adaptive_needs_more_passes,
+)
+
+
+def test_always_does_at_least_min_passes():
+    assert adaptive_needs_more_passes(2000, [], None, 0, min_passes=1) is True
+    assert adaptive_needs_more_passes(1000, [-60.0], -60.0, 1, min_passes=2) is True  # reference anchor
+
+
+def test_never_exceeds_max_passes():
+    assert adaptive_needs_more_passes(2000, [-50.0], -55.0, MEASUREMENT_REPEATS, min_passes=1) is False
+
+
+def test_non_deviant_frequency_stops_after_one_pass():
+    ref = -55.0
+    level = ref - NORMAL_RELATIVE_SHAPE_DB[2000]  # exactly normal-shaped -> dev 0
+    assert adaptive_needs_more_passes(2000, [level], ref, 1, min_passes=1) is False
+
+
+def test_deviant_frequency_is_repeated():
+    ref = -55.0
+    level = ref + 14.0  # 14 dB louder than reference at 2 kHz -> candidate
+    assert adaptive_needs_more_passes(2000, [level], ref, 1, min_passes=1) is True
+
+
+def test_no_reference_yet_stops_after_min():
+    assert adaptive_needs_more_passes(2000, [-50.0], None, 1, min_passes=1) is False

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -806,7 +806,7 @@ def test_basic_mode_includes_clone_target_workflow_and_runs_shared_builder(tmp_p
     )
 
     app.set_mode('basic')
-    assert [item.key for item in app._nav_items_for_mode()] == ['basic-mode', 'basic-clone-target', 'history']
+    assert [item.key for item in app._nav_items_for_mode()] == ['basic-mode', 'hearing-test', 'basic-clone-target', 'history']
 
     app.show_view('basic-clone-target')
     app.basic_clone_source_var.set(str(tmp_path / 'source.csv'))

--- a/tests/test_gui_hearing_render.py
+++ b/tests/test_gui_hearing_render.py
@@ -206,7 +206,8 @@ def test_intro_renders_without_touching_frame_cget(harness):
 
 def test_full_flow_timeout_path_reaches_results_and_completes(harness):
     harness.render()
-    _find_last(harness.ttk, "Start Test").command()        # -> left ear intro
+    _find_last(harness.ttk, "Start Test").command()        # -> channel check
+    _find_last(harness.ttk, "Left ear").command()          # -> left ear intro
     for _ in range(2):                                      # left, then right ear
         _find_last(harness.ttk, "Ready — Start").command()
         _drain(harness.frame)
@@ -226,6 +227,7 @@ def test_full_flow_timeout_path_reaches_results_and_completes(harness):
 def test_heard_response_path(harness):
     harness.render()
     _find_last(harness.ttk, "Start Test").command()
+    _find_last(harness.ttk, "Left ear").command()          # pass channel check
     _find_last(harness.ttk, "Ready — Start").command()     # first tone scheduled
     hear = _find_last(harness.ttk, "I hear it")
     assert hear is not None
@@ -238,6 +240,19 @@ def test_heard_response_path(harness):
     assert isinstance(harness.events["complete"][0], HearingProfile)
 
 
+def test_channel_check_precedes_test_and_warns_on_mismatch(harness):
+    harness.render()
+    _find_last(harness.ttk, "Start Test").command()
+    # Channel check appears before the test.
+    assert _find_last(harness.ttk, "Left ear") is not None
+    assert _find_last(harness.ttk, "Right ear") is not None
+    # Hearing the left-channel tone in the right ear warns, then can continue.
+    _find_last(harness.ttk, "Right ear").command()
+    assert _find_last(harness.ttk, "Continue anyway") is not None
+    _find_last(harness.ttk, "Continue anyway").command()
+    assert _find_last(harness.ttk, "Ready — Start") is not None
+
+
 def test_stop_test_invokes_cancel(harness):
     harness.render()
     _find_last(harness.ttk, "Cancel").command()
@@ -247,6 +262,7 @@ def test_stop_test_invokes_cancel(harness):
 def test_save_without_applying_uses_cancel(harness):
     harness.render()
     _find_last(harness.ttk, "Start Test").command()
+    _find_last(harness.ttk, "Left ear").command()          # pass channel check
     for _ in range(2):
         _find_last(harness.ttk, "Ready — Start").command()
         _drain(harness.frame)

--- a/tests/test_gui_hearing_render.py
+++ b/tests/test_gui_hearing_render.py
@@ -146,6 +146,8 @@ class _FakeEngine:
         self.threshold = -45.0
         self.ascending_run_count = 3
         self.done = False
+        self.converged = True
+        self.floored = False
 
     def record_response(self, _heard):
         self.done = True

--- a/tests/test_gui_hearing_render.py
+++ b/tests/test_gui_hearing_render.py
@@ -206,7 +206,8 @@ def test_intro_renders_without_touching_frame_cget(harness):
 
 def test_full_flow_timeout_path_reaches_results_and_completes(harness):
     harness.render()
-    _find_last(harness.ttk, "Start Test").command()        # -> channel check
+    _find_last(harness.ttk, "Start Test").command()        # -> volume check
+    _find_last(harness.ttk, "I can't hear the faint tone — continue").command()  # -> channel check
     _find_last(harness.ttk, "Left ear").command()          # -> left ear intro
     for _ in range(2):                                      # left, then right ear
         _find_last(harness.ttk, "Ready — Start").command()
@@ -227,6 +228,7 @@ def test_full_flow_timeout_path_reaches_results_and_completes(harness):
 def test_heard_response_path(harness):
     harness.render()
     _find_last(harness.ttk, "Start Test").command()
+    _find_last(harness.ttk, "I can't hear the faint tone — continue").command()
     _find_last(harness.ttk, "Left ear").command()          # pass channel check
     _find_last(harness.ttk, "Ready — Start").command()     # first tone scheduled
     hear = _find_last(harness.ttk, "I hear it")
@@ -243,6 +245,7 @@ def test_heard_response_path(harness):
 def test_channel_check_precedes_test_and_warns_on_mismatch(harness):
     harness.render()
     _find_last(harness.ttk, "Start Test").command()
+    _find_last(harness.ttk, "I can't hear the faint tone — continue").command()
     # Channel check appears before the test.
     assert _find_last(harness.ttk, "Left ear") is not None
     assert _find_last(harness.ttk, "Right ear") is not None
@@ -251,6 +254,16 @@ def test_channel_check_precedes_test_and_warns_on_mismatch(harness):
     assert _find_last(harness.ttk, "Continue anyway") is not None
     _find_last(harness.ttk, "Continue anyway").command()
     assert _find_last(harness.ttk, "Ready — Start") is not None
+
+
+def test_volume_check_precedes_channel_check(harness):
+    harness.render()
+    _find_last(harness.ttk, "Start Test").command()
+    # Volume calibration appears first.
+    assert _find_last(harness.ttk, "Play faint tone") is not None
+    _find_last(harness.ttk, "I can't hear the faint tone — continue").command()
+    # ...then the channel check.
+    assert _find_last(harness.ttk, "Left ear") is not None
 
 
 def test_stop_test_invokes_cancel(harness):
@@ -262,6 +275,7 @@ def test_stop_test_invokes_cancel(harness):
 def test_save_without_applying_uses_cancel(harness):
     harness.render()
     _find_last(harness.ttk, "Start Test").command()
+    _find_last(harness.ttk, "I can't hear the faint tone — continue").command()
     _find_last(harness.ttk, "Left ear").command()          # pass channel check
     for _ in range(2):
         _find_last(harness.ttk, "Ready — Start").command()

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -197,6 +197,16 @@ class TestRunHearingFit:
         assert "right_bands" in data
         assert "eq_clipping" in data
 
+    def test_writes_run_summary_discoverable_in_history(self, tmp_path):
+        from headmatch.ab_compare import load_run_summary
+        from headmatch.history import load_recent_runs
+        out = tmp_path / "run"
+        run_hearing_fit(self._profile(loss_db=20.0), out, sample_rate=48000)
+        assert (out / "run_summary.json").exists()
+        summary = load_run_summary(out)  # parses cleanly
+        assert summary.kind in ("fit", "iteration")
+        assert any(r.summary_path.parent == out for r in load_recent_runs(tmp_path))
+
     def test_returns_report_dict(self, tmp_path):
         profile = self._profile()
         result = run_hearing_fit(profile, tmp_path, sample_rate=48000)

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -172,6 +172,21 @@ class TestRunHearingFit:
         assert set(data["left"]) == {str(f) for f in TEST_FREQUENCIES}
         assert data["tested_at"] == profile.tested_at
 
+    def test_left_channel_not_attenuated_when_only_right_has_boost(self, tmp_path):
+        # A channel with no boost must not get a preamp (no L/R imbalance).
+        from headmatch.hearing_test import NORMAL_RELATIVE_SHAPE_DB
+        left = {f: FrequencyThreshold(f, -60.0 + NORMAL_RELATIVE_SHAPE_DB[f], 3, True) for f in TEST_FREQUENCIES}
+        right_levels = {500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
+        right = {f: FrequencyThreshold(f, right_levels[f], 3, True) for f in TEST_FREQUENCIES}
+        profile = HearingProfile(left=left, right=right, tested_at="t", asymmetric_freqs=[])
+        run_hearing_fit(profile, tmp_path, sample_rate=48000)
+
+        apo = (tmp_path / "equalizer_apo.txt").read_text()
+        left_section = apo.split("Channel: R")[0]
+        assert "Channel: L" in left_section
+        assert "Preamp: 0.00 dB" in left_section  # no boost -> no attenuation
+        assert "Filter" not in left_section
+
     def test_report_json_valid(self, tmp_path):
         profile = self._profile()
         run_hearing_fit(profile, tmp_path, sample_rate=48000)

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -34,6 +34,14 @@ def _make_profile(loss_db: float = 0.0) -> HearingProfile:
     )
 
 
+def _sloping_profile() -> HearingProfile:
+    # Progressively worse than 1 kHz at high frequency, beyond the normal shape ->
+    # a relative high-frequency deviation that should be compensated.
+    levels = {500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
+    side = {f: FrequencyThreshold(f, levels[f], 3, True) for f in TEST_FREQUENCIES}
+    return HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
+
+
 class TestFitFromHearingProfile:
     def test_returns_band_lists_and_report(self):
         profile = _make_profile(loss_db=10.0)
@@ -83,23 +91,23 @@ class TestFitFromHearingProfile:
         resp = peq_chain_response_db(grid, 48000, left_bands)
         assert float(np.max(np.abs(resp))) < 2.0  # very near flat
 
-    def test_20dB_loss_produces_boost(self):
-        """20 dB hearing loss → ~10 dB half-gain compensation → EQ bands with positive gain."""
+    def test_sloping_hf_loss_produces_hf_boost(self):
+        """A sloping HF deviation (worse than normal at high freq, relative to the
+        listener's own 1 kHz) produces a positive high-frequency boost."""
         from headmatch.peq import peq_chain_response_db
         from headmatch.signals import geometric_log_grid
-        profile = _make_profile(loss_db=20.0)
-        left_bands, _, _ = fit_from_hearing_profile(profile, sample_rate=48000, max_filters=8)
-        grid = geometric_log_grid(500.0, 8000.0, 48)
+        left_bands, _, _ = fit_from_hearing_profile(_sloping_profile(), sample_rate=48000, max_filters=8)
+        assert left_bands
+        grid = geometric_log_grid(2000.0, 8000.0, 48)
         resp = peq_chain_response_db(grid, 48000, left_bands)
         assert float(np.mean(resp)) > 1.0
 
     def test_symmetric_left_right_bands(self):
         """Symmetric hearing profile → left and right bands identical."""
-        profile = _make_profile(loss_db=15.0)
         left_bands, right_bands, _ = fit_from_hearing_profile(
-            profile, sample_rate=48000, max_filters=4
+            _sloping_profile(), sample_rate=48000, max_filters=4
         )
-        assert len(left_bands) == len(right_bands)
+        assert left_bands and len(left_bands) == len(right_bands)
         for lb, rb in zip(left_bands, right_bands):
             assert lb.freq == pytest.approx(rb.freq, abs=0.1)
             assert lb.gain_db == pytest.approx(rb.gain_db, abs=0.01)

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -133,6 +133,20 @@ class TestFitFromHearingProfile:
         kinds = {b.kind for b in left_bands}
         assert "lowshelf" in kinds or "highshelf" in kinds, f"expected shelf filters, got {kinds}"
 
+    def test_graphiceq_is_clip_safe_for_boosting_target(self, tmp_path):
+        # A Harman target boosts the bass; the GraphicEQ must be clip-safe (max gain
+        # <= 0 dB, preamp baked in) so it doesn't clip even if the consumer ignores
+        # the Preamp line.
+        from headmatch.builtin_targets import materialize_builtin_target
+        harman = materialize_builtin_target("harman", tmp_path)
+        run_hearing_fit(_make_profile(loss_db=0.0), tmp_path, sample_rate=48000, target_path=harman)
+        for line in (tmp_path / "equalizer_apo_graphiceq.txt").read_text().splitlines():
+            if line.startswith("GraphicEQ:"):
+                gains = [float(p.split()[1]) for p in line.split(":", 1)[1].split(";")]
+                assert max(gains) <= 0.01, f"GraphicEQ has positive gain (clips): {max(gains)}"
+            if line.startswith("Preamp:"):
+                assert line.strip() == "Preamp: 0.00 dB"
+
     def test_target_curve_applied_even_with_no_hearing_loss(self, tmp_path):
         # Regression: a tonal target (e.g. Harman) must still produce an EQ when
         # the listener shows no measurable hearing loss — the target is known

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -123,6 +123,16 @@ class TestFitFromHearingProfile:
         assert isinstance(left_bands, list)
         assert isinstance(report["target"], str)
 
+    def test_tonal_target_tilt_uses_shelf_filters_not_rippled_peaking(self, tmp_path):
+        # A Harman-like bass/treble tilt should be realised with shelf filters
+        # (smooth) rather than a ripple of peaking filters at the target points.
+        from headmatch.builtin_targets import materialize_builtin_target
+        harman = materialize_builtin_target("harman", tmp_path)
+        profile = _make_profile(loss_db=0.0)  # no hearing deviation -> target only
+        left_bands, _, _ = fit_from_hearing_profile(profile, sample_rate=48000, target_path=harman)
+        kinds = {b.kind for b in left_bands}
+        assert "lowshelf" in kinds or "highshelf" in kinds, f"expected shelf filters, got {kinds}"
+
     def test_target_curve_applied_even_with_no_hearing_loss(self, tmp_path):
         # Regression: a tonal target (e.g. Harman) must still produce an EQ when
         # the listener shows no measurable hearing loss — the target is known

--- a/tests/test_hearing_guards.py
+++ b/tests/test_hearing_guards.py
@@ -1,0 +1,73 @@
+"""Part A engine guards (0.8.3): honest convergence + flooring detection.
+
+A threshold is only trustworthy when the Hughson-Westlake staircase truly
+converged (>=3 ascending runs, 2-of-last-3). Cap-terminated or floored results
+must NOT be reported as determined, and hearing the test floor must terminate
+early and flag "volume too high".
+"""
+from __future__ import annotations
+
+from headmatch.hearing_test import (
+    FrequencyThreshold,
+    MAX_PRESENTATIONS,
+    MIN_LEVEL_DBFS,
+    ThresholdEngine,
+)
+
+
+def _drive(engine, responder, limit=500):
+    n = 0
+    while not engine.done and n < limit:
+        engine.record_response(responder(engine.current_level_dbfs))
+        n += 1
+    return n
+
+
+def test_converged_true_on_real_convergence():
+    eng = ThresholdEngine(1000)
+    _drive(eng, lambda level: level >= -45.0)
+    assert eng.done
+    assert eng.converged is True
+    assert eng.floored is False
+    assert eng.threshold == -45.0
+
+
+def test_hearing_everything_is_floored_not_converged():
+    eng = ThresholdEngine(1000)
+    _drive(eng, lambda _level: True)
+    assert eng.done
+    assert eng.converged is False
+    assert eng.floored is True
+    # Heard even the quietest tone -> threshold cannot be bracketed.
+    assert eng.threshold is None
+
+
+def test_flooring_terminates_early():
+    eng = ThresholdEngine(1000)
+    n = _drive(eng, lambda _level: True)
+    # Descends to the floor in ~5 steps, then bails once the floor is heard a
+    # couple of times — far short of the safety cap.
+    assert n < 12
+
+
+def test_missing_everything_is_undetermined_not_converged():
+    eng = ThresholdEngine(1000)
+    _drive(eng, lambda _level: False)
+    assert eng.done
+    assert eng.converged is False
+    assert eng.floored is False
+    assert eng.threshold is None
+
+
+def test_safety_cap_allows_real_convergence():
+    # The cap must be high enough that a legitimate staircase (~11 presentations)
+    # converges instead of being cut off.
+    assert MAX_PRESENTATIONS >= 20
+    eng = ThresholdEngine(1000)
+    n = _drive(eng, lambda level: level >= -45.0)
+    assert eng.converged is True and n < MAX_PRESENTATIONS
+
+
+def test_frequency_threshold_has_floored_field_default_false():
+    t = FrequencyThreshold(freq_hz=1000, level_dbfs=-45.0, ascending_runs=3, determined=True)
+    assert t.floored is False

--- a/tests/test_hearing_guards.py
+++ b/tests/test_hearing_guards.py
@@ -68,6 +68,27 @@ def test_safety_cap_allows_real_convergence():
     assert eng.converged is True and n < MAX_PRESENTATIONS
 
 
+def test_measurement_repeats_is_at_least_two():
+    from headmatch.hearing_test import MEASUREMENT_REPEATS
+    assert MEASUREMENT_REPEATS >= 2
+
+
+def test_averaged_threshold_averages_converged_levels():
+    from headmatch.hearing_test import averaged_frequency_threshold
+    t = averaged_frequency_threshold(1000, [-50.0, -60.0], floored=False, ascending_runs=3)
+    assert t.determined is True
+    assert t.level_dbfs == -55.0
+    assert t.floored is False
+
+
+def test_averaged_threshold_floored_is_undetermined():
+    from headmatch.hearing_test import averaged_frequency_threshold
+    t = averaged_frequency_threshold(1000, [-50.0], floored=True, ascending_runs=2)
+    assert t.determined is False
+    assert t.floored is True
+    assert t.level_dbfs is None
+
+
 def test_frequency_threshold_has_floored_field_default_false():
     t = FrequencyThreshold(freq_hz=1000, level_dbfs=-45.0, ascending_runs=3, determined=True)
     assert t.floored is False

--- a/tests/test_hearing_test_bugfixes.py
+++ b/tests/test_hearing_test_bugfixes.py
@@ -57,8 +57,10 @@ def test_engine_terminates_when_listener_hears_everything():
             break
         eng.record_response(True)
     assert eng.done, "engine must terminate even if every tone is heard"
-    # Heard even the quietest tone -> threshold determined at/near the floor.
-    assert eng.threshold is not None
+    # Hearing the floor means the volume is too high to bracket a threshold:
+    # the engine flags it floored and reports it undetermined (0.8.3 guards).
+    assert eng.floored is True
+    assert eng.threshold is None
 
 
 def test_engine_terminates_when_listener_misses_everything():

--- a/tests/test_hearing_test_runner.py
+++ b/tests/test_hearing_test_runner.py
@@ -23,6 +23,8 @@ class _FakeEngine:
         self.done = False
         self.threshold = -45.0
         self.ascending_run_count = 2
+        self.converged = True
+        self.floored = False
 
     def record_response(self, _heard):
         self._n += 1

--- a/tests/test_noise_aware_compensation.py
+++ b/tests/test_noise_aware_compensation.py
@@ -1,0 +1,73 @@
+"""Noise-aware compensation (0.8.3 issue #3): per-point variance gate (A1),
+noise-aware L/R pooling (B3), and uncertainty-weighted smoothing (C4)."""
+from __future__ import annotations
+
+from headmatch.hearing_test import (
+    HearingProfile,
+    FrequencyThreshold,
+    NORMAL_RELATIVE_SHAPE_DB,
+    TEST_FREQUENCIES,
+    compute_relative_compensation,
+)
+
+
+def _ft(f, level, spread=1.0):
+    return FrequencyThreshold(f, level, 3, True, False, spread)
+
+
+def _ear(extra_and_spread: dict[int, tuple[float, float]]):
+    """Normal-shaped base at -60 dBFS, with per-freq (extra_dev, spread) overrides."""
+    out = {}
+    for f in TEST_FREQUENCIES:
+        extra, spread = extra_and_spread.get(f, (0.0, 1.0))
+        out[f] = _ft(f, -60.0 + NORMAL_RELATIVE_SHAPE_DB[f] + extra, spread)
+    return out
+
+
+def _profile(left, right):
+    return HearingProfile(left=left, right=right, tested_at="t", asymmetric_freqs=[])
+
+
+# ── A1: per-point variance gate ───────────────────────────────────────────────
+
+def test_A1_consistent_low_noise_deviation_is_corrected():
+    ear = _ear({3000: (14, 1.0), 4000: (14, 1.0), 6000: (14, 1.0)})
+    left, _ = compute_relative_compensation(_profile(ear, dict(ear)))
+    assert any(left.get(f, 0) > 0 for f in (3000, 4000, 6000))
+
+
+def test_A1_same_deviation_but_high_noise_is_gated_out():
+    ear = _ear({3000: (14, 25.0), 4000: (14, 25.0), 6000: (14, 25.0)})
+    left, _ = compute_relative_compensation(_profile(ear, dict(ear)))
+    assert all(left.get(f, 0) == 0 for f in (3000, 4000, 6000))
+
+
+# ── B3: noise-aware L/R pooling ───────────────────────────────────────────────
+
+def test_B3_reliable_asymmetry_is_preserved_per_ear():
+    left = _ear({})  # flat
+    right = _ear({6000: (14, 1.0), 8000: (14, 1.0)})  # clear, low-noise HF deficit
+    L, R = compute_relative_compensation(_profile(left, right))
+    assert not L                                   # left untouched
+    assert any(R.get(f, 0) > 0 for f in (6000, 8000))  # right corrected
+
+
+def test_B3_within_noise_difference_is_pooled_symmetric():
+    # L vs R differ by ~4 dB at 6/8k but both noisy enough that the difference is
+    # within noise -> pooled -> the two ears get the SAME correction.
+    left = _ear({6000: (5, 4.0), 8000: (5, 4.0)})
+    right = _ear({6000: (9, 4.0), 8000: (9, 4.0)})
+    L, R = compute_relative_compensation(_profile(left, right))
+    assert L.get(6000) == R.get(6000)
+    assert L.get(8000) == R.get(8000)
+
+
+# ── C4: uncertainty-weighted smoothing ────────────────────────────────────────
+
+def test_C4_reliable_point_resists_noisy_neighbours():
+    # A reliable deviation at 3 kHz flanked by NOISY non-deviant neighbours should
+    # keep most of its value (low-noise point dominates the weighted smoothing),
+    # rather than being diluted toward the neighbours' zero.
+    ear = _ear({2000: (0, 30.0), 3000: (14, 1.0), 4000: (0, 30.0)})
+    left, _ = compute_relative_compensation(_profile(ear, dict(ear)))
+    assert left.get(3000, 0) > 5.0  # ~half of 14; uniform smoothing would give ~3.5

--- a/tests/test_relative_compensation.py
+++ b/tests/test_relative_compensation.py
@@ -39,13 +39,29 @@ def test_calibration_invariance_to_overall_volume():
     assert quiet  # and it actually produced a correction
 
 
-def test_high_frequency_deviation_boosts_only_that_region():
+def test_edge_high_frequency_deviation_is_boosted():
     levels = _normal_shaped(-60.0)
-    levels[8000] += 20.0  # 20 dB worse than normal at 8 kHz, relative to own 1 kHz
-    points = relative_compensation_points(side := _side(levels))
+    levels[8000] += 20.0  # worse than normal at the top edge
+    points = relative_compensation_points(_side(levels))
     assert set(points) == {8000}
-    # Half-gain of the 20 dB deviation, capped at 12.
-    assert points[8000] == 10.0
+    assert points[8000] > 0
+
+
+def test_isolated_midband_spike_is_smoothed_away():
+    # A single noisy frequency surrounded by opposite-sign neighbours (like a real
+    # jagged self-test) must not drive an EQ boost.
+    levels = _normal_shaped(-60.0)
+    levels[2000] += 16.0   # one bad point...
+    levels[3000] -= 10.0   # ...with neighbours deviating the other way
+    assert relative_compensation_points(_side(levels)) == {}
+
+
+def test_consistent_multiband_deviation_survives_smoothing():
+    # A coherent high-frequency slope (neighbours agree) should still be corrected.
+    levels = {500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
+    points = relative_compensation_points(_side(levels))
+    assert points and max(points) >= 6000
+    assert all(g > 0 for g in points.values())
 
 
 def test_gain_respects_cap():

--- a/tests/test_relative_compensation.py
+++ b/tests/test_relative_compensation.py
@@ -76,6 +76,13 @@ def test_reference_frequency_never_self_compensates():
     assert 1000 not in points
 
 
+def test_lower_deadband_corrects_moderate_consistent_deviation():
+    # A consistent, moderate HF slope that the old 10 dB deadband ignored is now
+    # corrected with the lowered deadband (noise is handled by smoothing).
+    levels = {500: -60, 1000: -60, 2000: -57, 3000: -54, 4000: -51, 6000: -48, 8000: -45}
+    assert relative_compensation_points(_side(levels))  # non-empty
+
+
 def test_too_few_determined_yields_nothing():
     side = {1000: FrequencyThreshold(1000, -60.0, 3, True)}
     assert relative_compensation_points(side) == {}

--- a/tests/test_relative_compensation.py
+++ b/tests/test_relative_compensation.py
@@ -1,0 +1,65 @@
+"""Part B core (0.8.3): relative, calibration-invariant hearing compensation.
+
+Each ear's thresholds are referenced to its own 1 kHz threshold, the normal
+threshold shape (ISO 389-8 RETSPL, relative to 1 kHz) is subtracted to isolate
+the listener's deviation, and a fractional/deadbanded/capped gain results.
+"""
+from __future__ import annotations
+
+from headmatch.hearing_test import (
+    FrequencyThreshold,
+    MAX_COMPENSATION_DB,
+    NORMAL_RELATIVE_SHAPE_DB,
+    TEST_FREQUENCIES,
+    relative_compensation_points,
+)
+
+
+def _side(levels: dict[int, float]) -> dict[int, FrequencyThreshold]:
+    return {f: FrequencyThreshold(f, levels[f], 3, True) for f in levels}
+
+
+def _normal_shaped(base_dbfs: float) -> dict[int, float]:
+    # A listener whose relative threshold shape equals the normal shape -> no deviation.
+    return {f: base_dbfs + NORMAL_RELATIVE_SHAPE_DB[f] for f in TEST_FREQUENCIES}
+
+
+def test_normal_shaped_listener_gets_no_compensation():
+    side = _side(_normal_shaped(-60.0))
+    assert relative_compensation_points(side) == {}
+
+
+def test_calibration_invariance_to_overall_volume():
+    # Shifting every threshold by a constant (a volume change) must not change the EQ.
+    levels = _normal_shaped(-60.0)
+    levels[8000] += 20.0  # high-frequency deviation
+    quiet = relative_compensation_points(_side(levels))
+    loud = relative_compensation_points(_side({f: v + 25.0 for f, v in levels.items()}))
+    assert quiet == loud
+    assert quiet  # and it actually produced a correction
+
+
+def test_high_frequency_deviation_boosts_only_that_region():
+    levels = _normal_shaped(-60.0)
+    levels[8000] += 20.0  # 20 dB worse than normal at 8 kHz, relative to own 1 kHz
+    points = relative_compensation_points(side := _side(levels))
+    assert set(points) == {8000}
+    # Half-gain of the 20 dB deviation, capped at 12.
+    assert points[8000] == 10.0
+
+
+def test_gain_respects_cap():
+    levels = _normal_shaped(-60.0)
+    levels[8000] += 40.0  # huge deviation
+    points = relative_compensation_points(_side(levels))
+    assert points[8000] == MAX_COMPENSATION_DB
+
+
+def test_reference_frequency_never_self_compensates():
+    points = relative_compensation_points(_side(_normal_shaped(-55.0)))
+    assert 1000 not in points
+
+
+def test_too_few_determined_yields_nothing():
+    side = {1000: FrequencyThreshold(1000, -60.0, 3, True)}
+    assert relative_compensation_points(side) == {}

--- a/tests/test_relative_compensation.py
+++ b/tests/test_relative_compensation.py
@@ -66,7 +66,8 @@ def test_consistent_multiband_deviation_survives_smoothing():
 
 def test_gain_respects_cap():
     levels = _normal_shaped(-60.0)
-    levels[8000] += 40.0  # huge deviation
+    for f in (4000, 6000, 8000):
+        levels[f] += 40.0  # huge, consistent HF deviation -> survives smoothing -> caps
     points = relative_compensation_points(_side(levels))
     assert points[8000] == MAX_COMPENSATION_DB
 
@@ -81,6 +82,15 @@ def test_lower_deadband_corrects_moderate_consistent_deviation():
     # corrected with the lowered deadband (noise is handled by smoothing).
     levels = {500: -60, 1000: -60, 2000: -57, 3000: -54, 4000: -51, 6000: -48, 8000: -45}
     assert relative_compensation_points(_side(levels))  # non-empty
+
+
+def test_deviation_survives_when_intervening_frequencies_missing():
+    # 2 kHz is +11 dB deviant; 3/4/6 kHz are missing (floored), so the next
+    # determined frequency is 8 kHz — two octaves away. The 2 kHz deficit must NOT
+    # be smoothed away by that distant point (smoothing is by log-freq distance).
+    side = _side({500: -55, 1000: -60, 2000: -50, 8000: -55})
+    points = relative_compensation_points(side)
+    assert points.get(2000, 0) > 0
 
 
 def test_too_few_determined_yields_nothing():


### PR DESCRIPTION
Makes the equipment-free **hearing test** trustworthy and fast. No breaking changes to the measurement/clone workflows. Full notes: `docs/releases/0.8.3.md`.

## Highlights
- **Calibration-robust, per-ear measurement** — thresholds referenced to each ear's own 1 kHz, normal shape subtracted (ISO 389-8), so the result no longer depends on the volume you set; real L/R asymmetry is captured. Honest `determined` (only true convergence), flooring detection, and volume + L/R pre-checks.
- **Noise-aware compensation** — per-point variance gate, noise-aware L/R pooling (preserves real asymmetry), and log-frequency-distance + uncertainty-weighted smoothing. Stops correcting self-test noise.
- **Faster** — adaptive depth (clean frequencies finish in one pass; only deviant ones repeat) + trimmed per-tone timing.
- **EQ export fixes** — shelf filters for tonal-target tilts (no bass/treble ripple); **clip-safe GraphicEQ** (baked preamp, pure-cut so it won't clip in EasyEffects); `run_summary.json` for hearing fits (now appear in Results); raw `hearing_profile.json` copied to the output folder.
- **Hearing Test in basic-mode nav.**

## Design & rigor
Grounded in a literature review folded into `docs/designs/calibration-robust-hearing.md` (ISO 389-8 reference shape; fractional/capped/deadbanded gain; HF kept moderate per CAM2-vs-NAL-NL2 evidence). The hearing test is positioned as an uncalibrated personalisation aid, not a clinical audiogram.

## Docs
- README rewritten to be task-oriented and searchable, with a first-class Hearing Test section (previously absent), a workflow chooser, and an "Applying your EQ" section.

## Tests
**759 passing** (up from 715). New: `test_hearing_guards`, `test_relative_compensation`, `test_noise_aware_compensation`, `test_adaptive_depth`.