### PR TITLE
Add 250 Hz, PTA4/WHO summary, and false-positive handling to hearing test

### DIFF
--- a/docs/designs/hearing-personalization.md
+++ b/docs/designs/hearing-personalization.md
@@ -42,8 +42,14 @@ no proprietary algorithm is used.
 Frequencies follow **ISO 8253-1** (Pure tone audiometry — basic pure-tone
 air and bone conduction threshold audiometry; public international standard):
 
-- **Test frequencies**: 500, 1000, 2000, 3000, 4000, 6000, 8000 Hz
-- **Test order**: 1000 → 2000 → 3000 → 4000 → 6000 → 8000 → 1000 → 500 Hz
+- **Test frequencies**: 250, 500, 1000, 2000, 3000, 4000, 6000, 8000 Hz
+- **Test order**: 1000 → 2000 → 3000 → 4000 → 6000 → 8000 → 1000 → 500 → 250 Hz
+
+250 Hz is included for a fuller low-frequency audiogram and low-end EQ coverage;
+it is **not** part of the PTA4 average (§3a). The ceiling stays at 8 kHz: above
+~8 kHz, headphone FR and seat/seal variance dominate the measurement and our
+public reference data (ISO 389-8 HDA200) stops at 8 kHz, so extending would
+equalize headphone coloration rather than hearing.
 
 The 1 kHz frequency is visited twice to provide an inter-run reliability check.
 Both measurements are reconciled by using only the first visit in the threshold
@@ -82,6 +88,28 @@ NORMAL_HEARING_REFERENCE = {
 **Reference:**
 > ISO 7029:2017. *Acoustics — Statistical distribution of hearing thresholds
 > related to age and gender.* International Organization for Standardization.
+
+### 2.4 False-Positive Control (Catch Trials + Jitter)
+
+Self-administered tests are prone to *false-positive* ("phantom") responses —
+the listener expects a tone and responds without actually hearing one. Two
+standard countermeasures are applied at the **runner** level (the
+`ThresholdEngine` staircase stays pure detection logic):
+
+1. **Silent catch trials** — before a real tone, with probability
+   `CATCH_TRIAL_PROB` (0.2, capped at `MAX_CATCH_TRIALS_PER_FREQ`=4 per
+   frequency), a *silent* buffer is presented with the same response window. A
+   response to silence is a measured false positive. Catch trials do **not**
+   advance the staircase.
+2. **Timing jitter** — the pre-tone interval is drawn uniformly from
+   `[JITTER_MIN_S, JITTER_MAX_S]` = [0.5, 2.0] s so the listener cannot
+   anticipate a predictable rhythm.
+
+Per ear, `catch` and `false_positive` counts are accumulated. An ear is flagged
+**unreliable** when `is_unreliable(catch, fp)` — at least 3 catch trials and a
+false-positive rate above `FP_RATE_WARN` (1/3). Flagged results are surfaced to
+the user with a retest suggestion but are **not** auto-discarded. The counts are
+persisted on the profile (`catch_stats`, `unreliable_ears`).
 
 ---
 
@@ -140,6 +168,30 @@ curve on the analysis frequency grid:
    function. This eliminates sharp EQ peaks that could arise from noisy threshold
    estimates at individual frequencies.
 3. Gain values are clamped to [0, MAX_COMPENSATION_DB] after smoothing.
+
+---
+
+## 3a. Hearing Summary (PTA4 + WHO Grade)
+
+For a legible, user-facing result, `compute_hearing_summary(profile)` derives a
+**pure-tone average** and a **WHO 2021 hearing grade**.
+
+```
+est_HL(f)  = threshold_dbfs(f) − NORMAL_HEARING_REFERENCE[f]   # positive = worse
+PTA4(ear)  = mean( est_HL(f) for f in {500, 1000, 2000, 4000} )
+```
+
+- PTA4 requires ≥ 3 of the 4 frequencies determined, else `None`.
+- The **better-ear** PTA (`min(left, right)`) selects the WHO grade band
+  (`WHO_GRADE_BANDS`): < 20 No impairment, 20–35 Mild, 35–50 Moderate, 50–65
+  Moderately severe, 65–80 Severe, 80–95 Profound, ≥ 95 Complete.
+
+This is an **estimate** — our scale is uncalibrated relative dBFS, not clinical
+dB HL — and is always surfaced with a "not a medical diagnosis" disclaimer. The
+summary appears in `hearing_fit_report.json`, the CLI output, and the GUI
+results screen.
+
+**Reference:** World Health Organization (2021). *World Report on Hearing.*
 
 ---
 

--- a/docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
+++ b/docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
@@ -46,13 +46,22 @@ NORMAL_HEARING_REFERENCE[250]   # provisional ≈ -45.0  dBFS
 NORMAL_RELATIVE_SHAPE_DB[250]   # provisional ≈ +11.0  dB relative to 1 kHz
 ```
 
-> **⚠ VERIFY BEFORE MERGE:** these two values are provisional. Confirm them
-> against the actual standard tables during implementation:
-> - `NORMAL_HEARING_REFERENCE[250]` — derive from ISO 7029:2017 median (young
->   adult) mapped to the project's relative dBFS scale, consistent with the
->   existing 500 Hz value (−48.0).
-> - `NORMAL_RELATIVE_SHAPE_DB[250]` — derive from the ISO 389-8 (HDA200) RETSPL
->   table, expressed relative to the 1 kHz value (consistent with 500 Hz = +5.5).
+> **✓ VERIFIED against ISO 389-8:2004 Table 1 (HDA 200):**
+> - `NORMAL_RELATIVE_SHAPE_DB[250] = 12.5` — **exact**. ISO Table 1 gives
+>   RETSPL(250) = 18.0 dB and RETSPL(1000) = 5.5 dB, so the relative-to-1 kHz
+>   shape is 18.0 − 5.5 = 12.5 dB. (The 500/2000/3000/4000/8000 entries also
+>   match the standard exactly.)
+> - `NORMAL_HEARING_REFERENCE[250] = −45.0` — this table is a *softened* dBFS
+>   heuristic (not raw RETSPL), so there is no single "correct" ISO value. −45.0
+>   is ~3 dB less sensitive than 500 Hz, matching the curve's own LF compression
+>   (to within ~0.5 dB). It is **not** used by PTA4 (250 Hz is excluded), so it
+>   only affects the legacy absolute-compensation path.
+>
+> **Incidental finding (pre-existing, NOT changed here):** `NORMAL_RELATIVE_SHAPE_DB[6000]`
+> is 8.7 in the code, but ISO 389-8 Table 1 lists RETSPL(6000) = 17.0 → 11.5 dB.
+> The code comment incorrectly claims 6 kHz is absent from the table. Left as-is
+> because it predates this work and changing it would shift existing EQ output;
+> worth a follow-up.
 
 **Decoupling note:** 250 Hz is *not* used by PTA4 (which is 500/1k/2k/4k), so
 Parts A and B stay independent. 250 Hz participates in the EQ compensation curve

--- a/docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
+++ b/docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
@@ -1,0 +1,239 @@
+# Hearing Test: 250 Hz, PTA4/WHO Summary, and False-Positive Handling — Design
+
+**Date:** 2026-06-14
+**Status:** Approved design, pending spec review
+
+## 1. Overview
+
+Three independent, standards-based additions to the hearing test. All use
+public-domain / published methods only; nothing here reuses any proprietary or
+patented technique.
+
+| # | Addition | Purpose |
+|---|----------|---------|
+| A | Add 250 Hz to the test protocol | Low-frequency hearing info + fuller audiogram + better low-end EQ coverage |
+| B | PTA4 average + WHO-2021 hearing grade | Legible, user-facing summary of the result |
+| C | Catch trials + timing jitter | Suppress and *measure* false-positive ("phantom") responses |
+
+**Explicitly out of scope** (decided during brainstorming):
+- **No extension above 8 kHz.** Above ~8 kHz, headphone FR + seat/seal variance
+  dominate the measurement and our public reference data (ISO 389-8 HDA200) stops
+  at 8 kHz; extending would equalize headphone coloration rather than hearing.
+- Forced-choice / ear-localization paradigm (corrupts near-threshold readings).
+- RETSPL per-device calibration; per-ear PEQ; NAL-NL2 prescription.
+
+All changes are centered on `headmatch/hearing_test.py`, with runner changes in
+both `run_cli_hearing_test` (CLI) and `gui/views/hearing_test.py` (GUI event loop).
+
+---
+
+## 2. Part A — Add 250 Hz
+
+Pure-parameter change. Touches four module constants plus tests; no engine logic
+changes — 250 Hz flows through the existing per-frequency staircase loop.
+
+```python
+TEST_FREQUENCIES = (250, 500, 1000, 2000, 3000, 4000, 6000, 8000)
+
+# ISO 8253-1 order: 1 kHz first, ascend, re-verify 1 kHz, descend to lowest last.
+TEST_ORDER = (1000, 2000, 3000, 4000, 6000, 8000, 1000, 500, 250)
+```
+
+Two new reference entries are required:
+
+```python
+NORMAL_HEARING_REFERENCE[250]   # provisional ≈ -45.0  dBFS
+NORMAL_RELATIVE_SHAPE_DB[250]   # provisional ≈ +11.0  dB relative to 1 kHz
+```
+
+> **⚠ VERIFY BEFORE MERGE:** these two values are provisional. Confirm them
+> against the actual standard tables during implementation:
+> - `NORMAL_HEARING_REFERENCE[250]` — derive from ISO 7029:2017 median (young
+>   adult) mapped to the project's relative dBFS scale, consistent with the
+>   existing 500 Hz value (−48.0).
+> - `NORMAL_RELATIVE_SHAPE_DB[250]` — derive from the ISO 389-8 (HDA200) RETSPL
+>   table, expressed relative to the 1 kHz value (consistent with 500 Hz = +5.5).
+
+**Decoupling note:** 250 Hz is *not* used by PTA4 (which is 500/1k/2k/4k), so
+Parts A and B stay independent. 250 Hz participates in the EQ compensation curve
+through the existing `compute_compensation_points` / `compute_relative_compensation`
+paths with no special-casing.
+
+---
+
+## 3. Part B — PTA4 + WHO Grade Summary
+
+### 3.1 Estimated hearing level
+
+Reuses the existing "loss" computation (already in `compute_compensation_points`):
+
+```
+est_HL(ear, f) = threshold_dbfs(ear, f) − NORMAL_HEARING_REFERENCE[f]
+                  # positive = worse than the normal reference
+```
+
+This is an *estimate* of dB HL, not calibrated clinical dB HL (we operate in
+relative dBFS). All reporting must carry this caveat.
+
+### 3.2 PTA4 and better-ear grade
+
+```
+PTA4(ear) = mean( est_HL(ear, f) for f in {500, 1000, 2000, 4000} )
+```
+
+- Require **≥ 3 of the 4** frequencies *determined* for that ear; otherwise
+  `PTA4(ear) = None`.
+- Better-ear PTA = `min(PTA4_left, PTA4_right)` (lower dB = better hearing).
+- If both ears are `None`, no grade is produced.
+
+WHO 2021 better-ear grade bands (`WHO_GRADE_BANDS` constant):
+
+| Better-ear PTA (dB) | Grade label |
+|---------------------|-------------|
+| < 20  | No impairment |
+| 20 – <35 | Mild |
+| 35 – <50 | Moderate |
+| 50 – <65 | Moderately severe |
+| 65 – <80 | Severe |
+| 80 – <95 | Profound |
+| ≥ 95 | Complete |
+
+Negative est_HL (better than reference) is left as-is (grades to "No impairment");
+no clamping.
+
+### 3.3 API and surfacing
+
+New pure function in `hearing_test.py`:
+
+```python
+def compute_hearing_summary(profile: HearingProfile) -> dict:
+    # returns:
+    # {
+    #   "pta4_left_db": float | None,
+    #   "pta4_right_db": float | None,
+    #   "better_ear_pta_db": float | None,
+    #   "who_grade": str | None,           # None when insufficient data
+    #   "estimated": True,                  # always True — uncalibrated
+    # }
+```
+
+Surfaced in:
+- `hearing_fit_report.json` — new `"hearing_summary"` block.
+- GUI results screen (`_show_results`) — PTA + grade line.
+
+Both surfaces show a clear disclaimer:
+> *Estimated from an uncalibrated self-test — not a medical diagnosis. See an
+> audiologist for clinical assessment.*
+
+---
+
+## 4. Part C — Catch Trials + Jitter
+
+Targets the expectation/criterion bias behind "phantom" responses, using the
+standard clinical countermeasure (silent catch trials) plus de-rhythming (jitter).
+Single-button UX is unchanged.
+
+### 4.1 New constants
+
+```python
+CATCH_TRIAL_PROB        = 0.2    # chance of inserting a catch before a real tone
+MAX_CATCH_TRIALS_PER_FREQ = 4    # bound runtime
+FP_RATE_WARN            = 0.34   # > 1/3 false positives -> unreliable
+JITTER_MIN_S            = 0.5
+JITTER_MAX_S            = 2.0
+```
+
+### 4.2 Shared, testable policy helper
+
+Because the CLI runner and the GUI event loop are separate implementations, the
+*policy* is extracted into small pure helpers in `hearing_test.py` so both call
+the same logic and tests can drive it deterministically:
+
+```python
+def should_insert_catch(rng: random.Random, n_inserted_this_freq: int) -> bool:
+    return (n_inserted_this_freq < MAX_CATCH_TRIALS_PER_FREQ
+            and rng.random() < CATCH_TRIAL_PROB)
+
+def jittered_delay(rng: random.Random) -> float:
+    return rng.uniform(JITTER_MIN_S, JITTER_MAX_S)
+
+def is_unreliable(catch_count: int, false_positive_count: int) -> bool:
+    return catch_count >= 3 and (false_positive_count / catch_count) > FP_RATE_WARN
+```
+
+Both runners accept an optional injected `rng` (default a fresh `random.Random()`)
+for deterministic tests.
+
+A truly-silent buffer is needed for catch trials (a small helper or
+`np.zeros((n, 2))` matching tone duration).
+
+### 4.3 Mechanics
+
+- **Catch trial:** before a real presentation, if `should_insert_catch(...)`,
+  play a silent buffer for the same duration and open the same response window.
+  A response = false positive. **A catch trial does NOT call
+  `engine.record_response()`** — the `ThresholdEngine` staircase stays pure.
+  Per ear, accumulate `catch_count` and `false_positive_count`.
+- **Jitter:** replace the fixed pre-tone gap with `jittered_delay(rng)`. (In the
+  CLI runner this is a pre-tone sleep; in the GUI it is a pre-tone timer delay.)
+- **Reliability flag:** after each ear, if `is_unreliable(...)`, mark that ear
+  unreliable, warn the user, and suggest a retest. **Data is not auto-discarded.**
+
+### 4.4 Data model changes
+
+`HearingProfile` gains optional, backward-compatible fields:
+
+```python
+@dataclass
+class HearingProfile:
+    ...
+    catch_stats: dict[str, dict[str, int]] | None = None
+    # e.g. {"left": {"catch": 6, "false_positive": 1}, "right": {...}}
+    unreliable_ears: list[str] | None = None    # subset of ["left", "right"]
+```
+
+`to_dict` / `from_dict` updated with defaults so **old saved profiles still load**
+(missing fields → `None` / `[]`).
+
+---
+
+## 5. Testing
+
+New / extended tests (extending the existing `tests/test_hearing_*.py` suite):
+
+- **`compute_hearing_summary`**: PTA math; better-ear selection; each WHO band
+  boundary (19/20/34/35/.../94/95); `< 3 of 4` determined → `None`; both ears
+  missing → no grade.
+- **250 Hz**: constants present and mutually consistent; simulated listener
+  converges at 250 Hz; 250 excluded from PTA4 but present in compensation points.
+- **Catch / jitter helpers** (seeded `random.Random`): catch insertion respects
+  prob and per-freq cap; false-positive accounting; `is_unreliable` trips exactly
+  at the boundary; `jittered_delay` within `[MIN, MAX]`; engine staircase result
+  unaffected by interleaved catch trials.
+- **Profile round-trip** with new fields, plus **back-compat load** of a profile
+  JSON lacking `catch_stats` / `unreliable_ears`.
+
+---
+
+## 6. Files touched
+
+- `headmatch/hearing_test.py` — constants, `compute_hearing_summary`,
+  `WHO_GRADE_BANDS`, catch/jitter helpers, `HearingProfile` fields + serialisation,
+  `run_cli_hearing_test` runner.
+- `headmatch/gui/views/hearing_test.py` — catch/jitter in the event loop;
+  PTA/WHO + reliability warning on the results screen.
+- Report writer (hearing fit report JSON) — `hearing_summary` block.
+- `docs/designs/hearing-personalization.md` — update frequency set, add PTA/WHO and
+  reliability sections.
+- `tests/test_hearing_*.py` — new coverage above.
+
+---
+
+## 7. References (all public / public-domain)
+
+- ISO 8253-1 — pure-tone audiometry method & test order.
+- ISO 7029:2017 — age-related normal threshold statistics (250 Hz reference).
+- ISO 389-8 — HDA200 RETSPL (relative shape; 250 Hz–8 kHz).
+- WHO (2021) — *World Report on Hearing*, grades of hearing loss (better-ear PTA).
+- Carhart & Jerger (1959) — Modified Hughson-Westlake (already implemented).
+- Standard clinical practice — silent/catch trials for false-positive control.

--- a/docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
+++ b/docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
@@ -57,11 +57,12 @@ NORMAL_RELATIVE_SHAPE_DB[250]   # provisional ≈ +11.0  dB relative to 1 kHz
 >   (to within ~0.5 dB). It is **not** used by PTA4 (250 Hz is excluded), so it
 >   only affects the legacy absolute-compensation path.
 >
-> **Incidental finding (pre-existing, NOT changed here):** `NORMAL_RELATIVE_SHAPE_DB[6000]`
-> is 8.7 in the code, but ISO 389-8 Table 1 lists RETSPL(6000) = 17.0 → 11.5 dB.
-> The code comment incorrectly claims 6 kHz is absent from the table. Left as-is
-> because it predates this work and changing it would shift existing EQ output;
-> worth a follow-up.
+> **Incidental fix (pre-existing bug, corrected here):** `NORMAL_RELATIVE_SHAPE_DB[6000]`
+> was 8.7, but ISO 389-8 Table 1 lists RETSPL(6000) = 17.0 → 11.5 dB (the old code
+> comment wrongly claimed 6 kHz was absent from the table). Corrected to 11.5. The
+> higher normal-shape value means a gentle HF slope at 6 kHz is correctly treated as
+> mostly the ear's natural rise, yielding slightly less 6 kHz boost; one relative-
+> compensation test fixture was re-calibrated to a genuine moderate deviation.
 
 **Decoupling note:** 250 Hz is *not* used by PTA4 (which is 500/1k/2k/4k), so
 Parts A and B stay independent. 250 Hz participates in the EQ compensation curve

--- a/headmatch/cli.py
+++ b/headmatch/cli.py
@@ -169,7 +169,7 @@ def build_parser(config) -> argparse.ArgumentParser:
         "hearing-test",
         help="Run a pure-tone hearing threshold test and save a personalised hearing profile.",
         description=(
-            "Sweeps 7 frequencies per ear using the Modified Hughson-Westlake procedure "
+            "Sweeps 8 frequencies per ear using the Modified Hughson-Westlake procedure "
             "(Carhart & Jerger 1959). Saves a hearing profile to the config directory. "
             "Use 'headmatch fit --with-hearing-compensation' to apply the profile to a fit."
         ),
@@ -599,6 +599,7 @@ def main(argv: list[str] | None = None) -> None:
             analyze_measurement(args.recording, spec_from_args(args), out_dir=args.out_dir)
         elif args.cmd == "hearing-test":
             from .hearing_test import (
+                compute_hearing_summary,
                 load_hearing_profile,
                 run_cli_hearing_test,
                 save_hearing_profile,
@@ -610,9 +611,22 @@ def main(argv: list[str] | None = None) -> None:
             profile = run_cli_hearing_test(backend, output_device, sample_rate=args.sample_rate)
             path = save_hearing_profile(profile)
             if getattr(args, "json", False):
-                print(json.dumps(profile.to_dict(), indent=2))
+                out = profile.to_dict()
+                out["hearing_summary"] = compute_hearing_summary(profile)
+                print(json.dumps(out, indent=2))
             else:
                 print(f"\nHearing profile saved to {path}")
+                summary = compute_hearing_summary(profile)
+                if summary["who_grade"] is not None:
+                    print(
+                        f"Estimated hearing: {summary['who_grade']} "
+                        f"(better-ear average {summary['better_ear_pta_db']:.0f} dB). "
+                        "Estimate from an uncalibrated self-test — not a medical diagnosis."
+                    )
+                if profile.unreliable_ears:
+                    ears = ", ".join(profile.unreliable_ears)
+                    print(f"Warning: high false-positive rate on the {ears} ear(s) — results may be "
+                          "unreliable; consider retesting in a quiet room.")
                 if profile.asymmetric_freqs:
                     freq_strs = ", ".join(str(f) for f in profile.asymmetric_freqs)
                     print(f"Warning: large L/R difference at {freq_strs} Hz — consider consulting an audiologist.")

--- a/headmatch/cli.py
+++ b/headmatch/cli.py
@@ -611,16 +611,16 @@ def main(argv: list[str] | None = None) -> None:
             profile = run_cli_hearing_test(backend, output_device, sample_rate=args.sample_rate)
             path = save_hearing_profile(profile)
             if getattr(args, "json", False):
-                out = profile.to_dict()
-                out["hearing_summary"] = compute_hearing_summary(profile)
-                print(json.dumps(out, indent=2))
+                profile_json = profile.to_dict()
+                profile_json["hearing_summary"] = compute_hearing_summary(profile)
+                print(json.dumps(profile_json, indent=2))
             else:
                 print(f"\nHearing profile saved to {path}")
-                summary = compute_hearing_summary(profile)
-                if summary["who_grade"] is not None:
+                hearing_summary = compute_hearing_summary(profile)
+                if hearing_summary["who_grade"] is not None:
                     print(
-                        f"Estimated hearing: {summary['who_grade']} "
-                        f"(better-ear average {summary['better_ear_pta_db']:.0f} dB). "
+                        f"Estimated hearing: {hearing_summary['who_grade']} "
+                        f"(better-ear average {hearing_summary['better_ear_pta_db']:.0f} dB). "
                         "Estimate from an uncalibrated self-test — not a medical diagnosis."
                     )
                 if profile.unreliable_ears:

--- a/headmatch/gui/views/hearing_test.py
+++ b/headmatch/gui/views/hearing_test.py
@@ -1,6 +1,7 @@
 """GUI view for the hearing threshold test workflow."""
 from __future__ import annotations
 
+import random
 import threading
 from typing import Callable, Optional
 
@@ -18,6 +19,11 @@ from ...hearing_test import (
     FrequencyThreshold,
     adaptive_needs_more_passes,
     averaged_frequency_threshold,
+    compute_hearing_summary,
+    generate_silence,
+    is_unreliable,
+    jittered_delay,
+    should_insert_catch,
     HearingProfile,
     ThresholdEngine,
     detect_asymmetric_frequencies,
@@ -49,7 +55,7 @@ _INTRO_INSTRUCTIONS = (
     "    is too high - turn it down, otherwise no hearing",
     "    threshold can be measured.",
     "  - Go to a quiet room and minimise background noise.",
-    "  - The test takes about 5 minutes total.",
+    "  - The test takes about 6-7 minutes total.",
     "",
     "During the test:",
     "  - Click 'I hear it' each time you hear a tone.",
@@ -60,6 +66,7 @@ _INTRO_INSTRUCTIONS = (
 
 
 _FREQ_LABELS = {
+    250: "250 Hz",
     500: "500 Hz",
     1000: "1 kHz",
     2000: "2 kHz",
@@ -99,6 +106,12 @@ def render_hearing_test(
         "response_timer": None,
         "tone_thread": None,
         "responded": False,
+        # False-positive control: per-ear catch-trial accounting + jitter RNG.
+        "rng": random.Random(),
+        "catch": {"left": {"catch": 0, "false_positive": 0},
+                  "right": {"catch": 0, "false_positive": 0}},
+        "catch_this_freq": 0,
+        "in_catch": False,
     }
 
     # ── helpers ──────────────────────────────────────────────────────────────
@@ -128,6 +141,17 @@ def render_hearing_test(
         t.start()
         _state["tone_thread"] = t
 
+    def _play_silence_async():
+        """Play a silent catch-trial buffer in a background thread."""
+        def _worker():
+            try:
+                backend.play_tone(generate_silence(sample_rate), sample_rate, output_device)
+            except Exception:
+                pass
+        t = threading.Thread(target=_worker, daemon=True)
+        t.start()
+        _state["tone_thread"] = t
+
     # ── view transitions ─────────────────────────────────────────────────────
 
     def _show_intro():
@@ -140,7 +164,7 @@ def render_hearing_test(
         ttk.Label(
             frame,
             text=(
-                "This test sweeps pure tones across 7 frequencies in each ear "
+                "This test sweeps pure tones across 8 frequencies in each ear "
                 "and estimates where your hearing thresholds are. "
                 "The result is used to personalise the EQ compensation applied "
                 "to your headphone fit."
@@ -301,6 +325,7 @@ def render_hearing_test(
         _state["freq_levels"] = []
         _state["freq_floored"] = False
         _state["repeat"] = 0
+        _state["catch_this_freq"] = 0  # catch-trial cap is per frequency (across passes)
         _state["engine"] = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
         _show_test_screen(freq_hz, idx)
         _next_tone()
@@ -341,8 +366,40 @@ def render_hearing_test(
         ttk.Button(frame, text="Stop Test", command=_stop_test).grid(row=4, column=0, sticky="w", pady=(4, 0))
 
     def _next_tone():
+        """Either present a silent catch trial, or schedule the next real tone."""
+        _cancel_timer()
+        engine: ThresholdEngine = _state["engine"]
+        if engine.done:
+            _on_freq_done()
+            return
+
+        # Optionally insert a silent catch trial first. A response to silence is a
+        # false positive; it does NOT advance the staircase.
+        if should_insert_catch(_state["rng"], _state["catch_this_freq"]):
+            _state["catch_this_freq"] += 1
+            _state["catch"][_state["ear"]]["catch"] += 1
+            _state["in_catch"] = True
+            _state["responded"] = False
+            speaker_var = _state.get("speaker_label_var")
+            if speaker_var:
+                speaker_var.set(_STATUS_PLAYING)
+            _play_silence_async()
+            _state["response_timer"] = frame.after(int(RESPONSE_WINDOW_S * 1000), _on_timeout)
+            return
+
+        _schedule_real_tone()
+
+    def _schedule_real_tone():
+        """Wait a jittered interval (breaking the rhythm), then play the real tone."""
+        _state["in_catch"] = False
+        _state["responded"] = True  # ignore clicks during the silent pre-tone gap
+        delay_ms = max(1, int(jittered_delay(_state["rng"]) * 1000))
+        _state["response_timer"] = frame.after(delay_ms, _present_real_tone)
+
+    def _present_real_tone():
         """Play the current tone and start the response window timer."""
         _cancel_timer()
+        _state["in_catch"] = False
         _state["responded"] = False
 
         engine: ThresholdEngine = _state["engine"]
@@ -372,6 +429,12 @@ def render_hearing_test(
             return
         _state["responded"] = True
         _cancel_timer()
+        if _state.get("in_catch"):
+            # Responded to silence -> false positive. Do not touch the staircase.
+            _state["catch"][_state["ear"]]["false_positive"] += 1
+            _state["in_catch"] = False
+            frame.after(300, _schedule_real_tone)
+            return
         engine: ThresholdEngine = _state["engine"]
         engine.record_response(True)
         speaker_var = _state.get("speaker_label_var")
@@ -387,6 +450,11 @@ def render_hearing_test(
             return
         _state["responded"] = True
         _state["response_timer"] = None
+        if _state.get("in_catch"):
+            # Correctly silent on a catch trial -> proceed to the real tone.
+            _state["in_catch"] = False
+            frame.after(300, _schedule_real_tone)
+            return
         engine: ThresholdEngine = _state["engine"]
         engine.record_response(False)
         speaker_var = _state.get("speaker_label_var")
@@ -447,6 +515,21 @@ def render_hearing_test(
         left_thresholds: dict[int, FrequencyThreshold] = _state["left"]
         right_thresholds: dict[int, FrequencyThreshold] = _state["right"]
         asymmetric = detect_asymmetric_frequencies(left_thresholds, right_thresholds)
+        catch_stats = _state["catch"]
+        unreliable_ears = [
+            ear for ear, s in catch_stats.items()
+            if is_unreliable(s["catch"], s["false_positive"])
+        ]
+
+        def _build_profile() -> HearingProfile:
+            return HearingProfile(
+                left=left_thresholds,
+                right=right_thresholds,
+                tested_at=datetime.now(timezone.utc).isoformat(),
+                asymmetric_freqs=asymmetric,
+                catch_stats=catch_stats,
+                unreliable_ears=unreliable_ears,
+            )
 
         ttk.Label(frame, text="Hearing Test Results", style="Title.TLabel").grid(
             row=0, column=0, sticky="w", pady=(0, 8)
@@ -492,12 +575,24 @@ def render_hearing_test(
         import numpy as np
         from ...signals import geometric_log_grid
 
-        profile_for_preview = HearingProfile(
-            left=left_thresholds,
-            right=right_thresholds,
-            tested_at=datetime.now(timezone.utc).isoformat(),
-            asymmetric_freqs=asymmetric,
-        )
+        profile_for_preview = _build_profile()
+
+        # Estimated hearing summary (PTA4 + WHO 2021 grade). Uncalibrated estimate.
+        hearing_summary = compute_hearing_summary(profile_for_preview)
+        if hearing_summary["who_grade"] is not None:
+            summary_parts.append(
+                f"Estimated hearing: {hearing_summary['who_grade']} "
+                f"(better-ear average {hearing_summary['better_ear_pta_db']:.0f} dB). "
+                "Estimate from an uncalibrated self-test — not a medical diagnosis."
+            )
+        if unreliable_ears:
+            summary_parts.append(
+                f"High false-positive rate on the {', '.join(unreliable_ears)} ear(s): "
+                "responses were registered when no tone played. Results may be "
+                "unreliable — retest in a quiet room and respond only to tones you "
+                "are sure you hear."
+            )
+
         grid = geometric_log_grid(500.0, 8000.0, 48)
         comp = compute_compensation_curve(profile_for_preview, grid)
         avg_boost = float(np.mean(comp[comp > 0])) if np.any(comp > 0) else 0.0
@@ -521,22 +616,12 @@ def render_hearing_test(
         btn_frame.grid(row=row_offset, column=0, sticky="w", pady=(8, 0))
 
         def _save_and_apply():
-            profile = HearingProfile(
-                left=left_thresholds,
-                right=right_thresholds,
-                tested_at=datetime.now(timezone.utc).isoformat(),
-                asymmetric_freqs=asymmetric,
-            )
+            profile = _build_profile()
             save_hearing_profile(profile)
             on_complete(profile)
 
         def _save_only():
-            profile = HearingProfile(
-                left=left_thresholds,
-                right=right_thresholds,
-                tested_at=datetime.now(timezone.utc).isoformat(),
-                asymmetric_freqs=asymmetric,
-            )
+            profile = _build_profile()
             save_hearing_profile(profile)
             on_cancel()
 

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -120,7 +120,10 @@ NOISE_GATE_THRESHOLD_DBFS: float = -30.0
 # about 30 dB above the expected threshold for a normal-hearing listener.
 
 NORMAL_HEARING_REFERENCE: dict[int, float] = {
-    250:  -45.0,   # 250 Hz: less sensitive than 500 Hz (ISO 7029 median trend)
+    250:  -45.0,   # heuristic dBFS mapping (this whole table is softened, not raw
+                   # RETSPL); ~3 dB less sensitive than 500 Hz, matching the curve's
+                   # own LF compression. Not used by PTA4 (250 is excluded), so it
+                   # only affects the legacy absolute compensation path.
     500:  -48.0,
     1000: -50.0,
     2000: -50.0,
@@ -142,8 +145,11 @@ HEARING_PROFILE_FILENAME = "hearing_profile.json"
 NORMAL_RELATIVE_SHAPE_DB: dict[int, float] = {
     250: 12.5, 500: 5.5, 1000: 0.0, 2000: -1.0, 3000: -3.0, 4000: 4.0, 6000: 8.7, 8000: 12.0,
 }
-# 250 Hz value = ISO 389-8 (HDA200) RETSPL(250) − RETSPL(1000) ≈ 18.0 − 5.5 dB,
-# consistent with the 500 Hz entry's derivation.
+# 250 Hz value verified against ISO 389-8:2004 Table 1 (HDA 200): RETSPL(250) −
+# RETSPL(1000) = 18.0 − 5.5 = 12.5 dB exactly. (Likewise 500/2000/3000/4000/8000
+# match the standard exactly. NOTE: the pre-existing 6000 Hz entry, 8.7, disagrees
+# with ISO 389-8 Table 1, which lists RETSPL(6000)=17.0 → 11.5 dB; left unchanged
+# here as it predates this work and changing it would shift existing EQ output.)
 
 # WHO 2021 grades of hearing loss, keyed by better-ear pure-tone average (dB).
 # Each entry is (exclusive upper bound, label); the last bound is +inf.
@@ -699,7 +705,8 @@ def eq_bands_from_gain_points(
 
     target = [float(points[f]) for f in freqs]
     if sample_rate:
-        gains = solve_band_gains_lsq(freqs, target, sample_rate, freqs, qs, max_gain_db=max_gain_db)
+        freqs_f = [float(f) for f in freqs]
+        gains = solve_band_gains_lsq(freqs_f, target, sample_rate, freqs_f, qs, max_gain_db=max_gain_db)
     else:
         gains = [float(np.clip(g, -max_gain_db, max_gain_db)) for g in target]
 

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -140,16 +140,14 @@ HEARING_PROFILE_FILENAME = "hearing_profile.json"
 # threshold-of-hearing levels, i.e. the *threshold* shape appropriate for a
 # threshold-based test (not ISO 226 supra-threshold loudness contours). Subtracting
 # this isolates the listener's deviation from a normal ear's natural frequency
-# response so we don't over-correct the extremes. 6 kHz is log-f interpolated (not
-# in the ISO 389-8 table). See docs/designs/calibration-robust-hearing.md.
+# response so we don't over-correct the extremes.
+# See docs/designs/calibration-robust-hearing.md.
 NORMAL_RELATIVE_SHAPE_DB: dict[int, float] = {
-    250: 12.5, 500: 5.5, 1000: 0.0, 2000: -1.0, 3000: -3.0, 4000: 4.0, 6000: 8.7, 8000: 12.0,
+    250: 12.5, 500: 5.5, 1000: 0.0, 2000: -1.0, 3000: -3.0, 4000: 4.0, 6000: 11.5, 8000: 12.0,
 }
-# 250 Hz value verified against ISO 389-8:2004 Table 1 (HDA 200): RETSPL(250) −
-# RETSPL(1000) = 18.0 − 5.5 = 12.5 dB exactly. (Likewise 500/2000/3000/4000/8000
-# match the standard exactly. NOTE: the pre-existing 6000 Hz entry, 8.7, disagrees
-# with ISO 389-8 Table 1, which lists RETSPL(6000)=17.0 → 11.5 dB; left unchanged
-# here as it predates this work and changing it would shift existing EQ output.)
+# Every entry = ISO 389-8:2004 Table 1 RETSPL(f) − RETSPL(1000), where
+# RETSPL(1000) = 5.5 dB. Verified against the standard:
+#   250→18.0  500→11.0  2000→4.5  3000→2.5  4000→9.5  6000→17.0  8000→17.5 dB SPL.
 
 # WHO 2021 grades of hearing loss, keyed by better-ear pure-tone average (dB).
 # Each entry is (exclusive upper bound, label); the last bound is +inf.

--- a/headmatch/hearing_test.py
+++ b/headmatch/hearing_test.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import math
+import random
+import time
 from collections import Counter
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -25,17 +27,30 @@ from .signals import fractional_octave_smoothing
 
 # ── Frequency protocol ────────────────────────────────────────────────────────
 
-TEST_FREQUENCIES: tuple[int, ...] = (500, 1000, 2000, 3000, 4000, 6000, 8000)
+TEST_FREQUENCIES: tuple[int, ...] = (250, 500, 1000, 2000, 3000, 4000, 6000, 8000)
 
-# ISO 8253-1 test order: start at 1 kHz, ascend, re-verify 1 kHz, descend.
-# The duplicate 1000 Hz entry allows reliability verification.
-TEST_ORDER: tuple[int, ...] = (1000, 2000, 3000, 4000, 6000, 8000, 1000, 500)
+# ISO 8253-1 test order: start at 1 kHz, ascend, re-verify 1 kHz, descend to the
+# lowest frequency last. The duplicate 1000 Hz entry allows reliability verification.
+TEST_ORDER: tuple[int, ...] = (1000, 2000, 3000, 4000, 6000, 8000, 1000, 500, 250)
+
+# Pure-tone average frequencies (WHO/clinical PTA4 — the standard four-frequency
+# average). 250 Hz is measured for the audiogram and EQ but is NOT part of PTA4.
+PTA4_FREQS: tuple[int, ...] = (500, 1000, 2000, 4000)
 
 # ── Tone stimulus parameters ──────────────────────────────────────────────────
 
 TONE_DURATION_S: float = 0.8
 INTER_TONE_SILENCE_S: float = 0.5
 RAMP_DURATION_S: float = 0.03       # 30 ms raised-cosine onset/offset
+
+# False-positive control: silent catch trials measure how often the listener
+# responds when no tone is present, and jittered timing breaks the predictable
+# rhythm that drives expectation-based "phantom" responses.
+CATCH_TRIAL_PROB: float = 0.2           # chance of a silent catch before a real tone
+MAX_CATCH_TRIALS_PER_FREQ: int = 4      # bound the extra presentations per frequency
+FP_RATE_WARN: float = 0.34              # > 1/3 false positives -> ear flagged unreliable
+JITTER_MIN_S: float = 0.5               # pre-tone silence is drawn uniformly from
+JITTER_MAX_S: float = 2.0               # [JITTER_MIN_S, JITTER_MAX_S]
 
 # ── Threshold engine parameters ───────────────────────────────────────────────
 
@@ -105,6 +120,7 @@ NOISE_GATE_THRESHOLD_DBFS: float = -30.0
 # about 30 dB above the expected threshold for a normal-hearing listener.
 
 NORMAL_HEARING_REFERENCE: dict[int, float] = {
+    250:  -45.0,   # 250 Hz: less sensitive than 500 Hz (ISO 7029 median trend)
     500:  -48.0,
     1000: -50.0,
     2000: -50.0,
@@ -124,8 +140,22 @@ HEARING_PROFILE_FILENAME = "hearing_profile.json"
 # response so we don't over-correct the extremes. 6 kHz is log-f interpolated (not
 # in the ISO 389-8 table). See docs/designs/calibration-robust-hearing.md.
 NORMAL_RELATIVE_SHAPE_DB: dict[int, float] = {
-    500: 5.5, 1000: 0.0, 2000: -1.0, 3000: -3.0, 4000: 4.0, 6000: 8.7, 8000: 12.0,
+    250: 12.5, 500: 5.5, 1000: 0.0, 2000: -1.0, 3000: -3.0, 4000: 4.0, 6000: 8.7, 8000: 12.0,
 }
+# 250 Hz value = ISO 389-8 (HDA200) RETSPL(250) − RETSPL(1000) ≈ 18.0 − 5.5 dB,
+# consistent with the 500 Hz entry's derivation.
+
+# WHO 2021 grades of hearing loss, keyed by better-ear pure-tone average (dB).
+# Each entry is (exclusive upper bound, label); the last bound is +inf.
+WHO_GRADE_BANDS: tuple[tuple[float, str], ...] = (
+    (20.0, "No impairment"),
+    (35.0, "Mild"),
+    (50.0, "Moderate"),
+    (65.0, "Moderately severe"),
+    (80.0, "Severe"),
+    (95.0, "Profound"),
+    (float("inf"), "Complete"),
+)
 
 
 # ── Data structures ───────────────────────────────────────────────────────────
@@ -146,11 +176,18 @@ class HearingProfile:
     right: dict[int, FrequencyThreshold]
     tested_at: str                  # ISO 8601
     asymmetric_freqs: list[int]     # freqs where L/R gap > ASYMMETRY_WARNING_DB
+    # False-positive (catch-trial) accounting, e.g.
+    # {"left": {"catch": 6, "false_positive": 1}, "right": {...}}. Optional so
+    # older saved profiles (written before this field existed) still load.
+    catch_stats: Optional[dict] = None
+    unreliable_ears: Optional[list] = None  # subset of ["left", "right"]
 
     def to_dict(self) -> dict:
         return {
             "tested_at": self.tested_at,
             "asymmetric_freqs": self.asymmetric_freqs,
+            "catch_stats": self.catch_stats,
+            "unreliable_ears": self.unreliable_ears,
             "left": {str(k): asdict(v) for k, v in self.left.items()},
             "right": {str(k): asdict(v) for k, v in self.right.items()},
         }
@@ -167,6 +204,8 @@ class HearingProfile:
             right=_parse_side(data["right"]),
             tested_at=data["tested_at"],
             asymmetric_freqs=data.get("asymmetric_freqs", []),
+            catch_stats=data.get("catch_stats"),
+            unreliable_ears=data.get("unreliable_ears"),
         )
 
 
@@ -326,6 +365,84 @@ def generate_tone(freq_hz: int, level_dbfs: float, sample_rate: int = 48000,
     if side == "right":
         return np.column_stack([silent, mono])
     return np.column_stack([mono, mono])
+
+
+def generate_silence(sample_rate: int = 48000) -> np.ndarray:
+    """Return a silent stereo (N, 2) buffer the same length as a test tone.
+
+    Used for catch trials: the listener is presented with nothing during the
+    normal response window, so any response is a measurable false positive.
+    """
+    n_total = int(round(TONE_DURATION_S * sample_rate))
+    return np.zeros((n_total, 2), dtype=np.float64)
+
+
+# ── False-positive control (catch trials + jitter) ─────────────────────────────
+
+def should_insert_catch(rng: random.Random, n_inserted_this_freq: int) -> bool:
+    """Whether to present a silent catch trial before the next real tone."""
+    return (n_inserted_this_freq < MAX_CATCH_TRIALS_PER_FREQ
+            and rng.random() < CATCH_TRIAL_PROB)
+
+
+def jittered_delay(rng: random.Random) -> float:
+    """Pre-tone silence (seconds) drawn uniformly from [JITTER_MIN_S, JITTER_MAX_S]."""
+    return rng.uniform(JITTER_MIN_S, JITTER_MAX_S)
+
+
+def is_unreliable(catch_count: int, false_positive_count: int) -> bool:
+    """True when an ear's false-positive rate is high enough to distrust it.
+
+    Requires a minimum number of catch trials so a single early false positive
+    doesn't flag the whole ear.
+    """
+    return catch_count >= 3 and (false_positive_count / catch_count) > FP_RATE_WARN
+
+
+# ── Hearing summary (PTA4 + WHO grade) ─────────────────────────────────────────
+
+def who_grade(better_ear_pta_db: float) -> str:
+    """WHO 2021 hearing-loss grade for a better-ear pure-tone average (dB)."""
+    for upper, label in WHO_GRADE_BANDS:
+        if better_ear_pta_db < upper:
+            return label
+    return WHO_GRADE_BANDS[-1][1]
+
+
+def _pta4(side: dict[int, "FrequencyThreshold"]) -> Optional[float]:
+    """Estimated better-than-reference pure-tone average (dB) for one ear.
+
+    est_HL(f) = threshold(f) − NORMAL_HEARING_REFERENCE[f] (positive = worse than
+    normal). Requires at least 3 of the 4 PTA frequencies determined.
+    """
+    losses: list[float] = []
+    for freq_hz in PTA4_FREQS:
+        t = side.get(freq_hz)
+        if t is not None and t.determined and t.level_dbfs is not None:
+            losses.append(t.level_dbfs - NORMAL_HEARING_REFERENCE[freq_hz])
+    if len(losses) < 3:
+        return None
+    return round(sum(losses) / len(losses), 1)
+
+
+def compute_hearing_summary(profile: "HearingProfile") -> dict:
+    """User-facing summary: per-ear PTA4, better-ear PTA, and WHO 2021 grade.
+
+    Values are *estimates* from an uncalibrated self-test (relative dBFS, not
+    clinical dB HL) — not a medical diagnosis. ``who_grade`` is None when fewer
+    than 3 of the 4 PTA frequencies were determined in both ears.
+    """
+    pta_left = _pta4(profile.left)
+    pta_right = _pta4(profile.right)
+    present = [p for p in (pta_left, pta_right) if p is not None]
+    better = min(present) if present else None
+    return {
+        "pta4_left_db": pta_left,
+        "pta4_right_db": pta_right,
+        "better_ear_pta_db": better,
+        "who_grade": who_grade(better) if better is not None else None,
+        "estimated": True,
+    }
 
 
 # ── Compensation curve ────────────────────────────────────────────────────────
@@ -678,16 +795,20 @@ def run_cli_hearing_test(
     sample_rate: int = 48000,
     *,
     on_status=None,
+    rng: random.Random | None = None,
 ) -> HearingProfile:
     """
     Headless hearing test runner for CLI / TUI use.
 
     Plays each tone via backend.play_tone(). The user presses Enter to
     indicate they heard the tone; a response window timer handles silence.
-    Returns a completed HearingProfile.
+    Silent catch trials and jittered timing suppress and measure false-positive
+    ("phantom") responses. Returns a completed HearingProfile.
     """
     import sys
     import threading
+
+    rng = rng or random.Random()
 
     def _status(msg: str) -> None:
         if on_status:
@@ -710,10 +831,12 @@ def run_cli_hearing_test(
         t.start()
         return heard_event.wait(timeout=timeout_s)
 
-    def _test_ear(ear_label: str) -> dict[int, FrequencyThreshold]:
+    def _test_ear(ear_label: str) -> tuple[dict[int, FrequencyThreshold], int, int]:
         thresholds: dict[int, FrequencyThreshold] = {}
         processed: set[int] = set()
         reference: Optional[float] = None  # this ear's 1 kHz, for adaptive depth
+        catch_count = 0          # silent trials presented for this ear
+        false_positive_count = 0  # responses during a silent trial
 
         for freq_hz in TEST_ORDER:
             if freq_hz in processed:
@@ -725,10 +848,20 @@ def run_cli_hearing_test(
             floored = False
             runs = 0
             attempts = 0
+            catch_this_freq = 0
             min_passes = 2 if freq_hz == 1000 else 1
             while True:
                 engine = ThresholdEngine(freq_hz, start_level_dbfs=START_LEVEL_DBFS)
                 while not engine.done:
+                    # Optional silent catch trial before the real tone: a response
+                    # to silence is a false positive (does NOT advance the staircase).
+                    if should_insert_catch(rng, catch_this_freq):
+                        catch_this_freq += 1
+                        catch_count += 1
+                        backend.play_tone(generate_silence(sample_rate), sample_rate, output_device)
+                        if _ask_heard(RESPONSE_WINDOW_S):
+                            false_positive_count += 1
+                    time.sleep(jittered_delay(rng))  # break the predictable rhythm
                     level = engine.current_level_dbfs
                     samples = generate_tone(freq_hz, level, sample_rate, ear=ear_label.lower())
                     backend.play_tone(samples, sample_rate, output_device)
@@ -755,7 +888,7 @@ def run_cli_hearing_test(
             else:
                 _status(f"    threshold undetermined after {runs} runs")
 
-        return thresholds
+        return thresholds, catch_count, false_positive_count
 
     _status("\n=== Hearing Threshold Test ===")
     _status("Instructions:")
@@ -765,19 +898,37 @@ def run_cli_hearing_test(
     _status("\nStarting left ear. Cover or plug your right ear.")
     input("  Press Enter to begin...")
 
-    left = _test_ear("Left")
+    left, left_catch, left_fp = _test_ear("Left")
 
     _status("\nRight ear. Cover or plug your left ear.")
     input("  Press Enter to continue...")
 
-    right = _test_ear("Right")
+    right, right_catch, right_fp = _test_ear("Right")
 
     asymmetric = detect_asymmetric_frequencies(left, right)
+
+    catch_stats = {
+        "left": {"catch": left_catch, "false_positive": left_fp},
+        "right": {"catch": right_catch, "false_positive": right_fp},
+    }
+    unreliable_ears = [
+        ear for ear, s in catch_stats.items()
+        if is_unreliable(s["catch"], s["false_positive"])
+    ]
+    if unreliable_ears:
+        _status(
+            "\n⚠ High false-positive rate detected for "
+            f"{', '.join(unreliable_ears)} ear(s). Results may be unreliable — "
+            "consider retesting in a quieter setting and responding only to tones "
+            "you are sure you hear."
+        )
 
     profile = HearingProfile(
         left=left,
         right=right,
         tested_at=datetime.now(timezone.utc).isoformat(),
         asymmetric_freqs=asymmetric,
+        catch_stats=catch_stats,
+        unreliable_ears=unreliable_ears,
     )
     return profile

--- a/headmatch/pipeline.py
+++ b/headmatch/pipeline.py
@@ -202,7 +202,11 @@ def fit_from_hearing_profile(
         eq_target(f) = target(f) + hearing_compensation(f)
     where compensation comes from the half-gain rule (Lybarger 1944).
     """
-    from .hearing_test import compute_relative_compensation, eq_bands_from_gain_points
+    from .hearing_test import (
+        compute_hearing_summary,
+        compute_relative_compensation,
+        eq_bands_from_gain_points,
+    )
     from .signals import geometric_log_grid
 
     filter_budget = (filter_budget or FilterBudget(max_filters=max_filters)).normalized()
@@ -261,7 +265,10 @@ def fit_from_hearing_profile(
         'hearing_profile_summary': {
             'tested_at': profile.tested_at,
             'asymmetric_freqs': profile.asymmetric_freqs,
+            'catch_stats': getattr(profile, 'catch_stats', None),
+            'unreliable_ears': getattr(profile, 'unreliable_ears', None),
         },
+        'hearing_summary': compute_hearing_summary(profile),
         'filter_budget': {
             'family': filter_budget.family,
             'max_filters': filter_budget.max_filters,

--- a/tests/test_e2e_fitting.py
+++ b/tests/test_e2e_fitting.py
@@ -177,7 +177,7 @@ def test_iterative_measure_and_fit_e2e_independent_mode(monkeypatch, tmp_path):
 
 # A representative middle-aged (presbycusis) audiogram: gentle low-frequency
 # loss sloping to a moderate high-frequency loss (dB above the normal reference).
-_PRESBYCUSIS_LOSS_DB = {500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
+_PRESBYCUSIS_LOSS_DB = {250: 4, 500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
 
 
 def _presbycusis_profile() -> HearingProfile:

--- a/tests/test_gui_hearing_render.py
+++ b/tests/test_gui_hearing_render.py
@@ -221,8 +221,8 @@ def test_full_flow_timeout_path_reaches_results_and_completes(harness):
     assert len(harness.events["complete"]) == 1
     profile = harness.events["complete"][0]
     assert isinstance(profile, HearingProfile)
-    # Both ears measured across all seven unique frequencies.
-    assert len(profile.left) == 7 and len(profile.right) == 7
+    # Both ears measured across all eight unique frequencies.
+    assert len(profile.left) == 8 and len(profile.right) == 8
 
 
 def test_heard_response_path(harness):

--- a/tests/test_hearing_fit.py
+++ b/tests/test_hearing_fit.py
@@ -37,7 +37,7 @@ def _make_profile(loss_db: float = 0.0) -> HearingProfile:
 def _sloping_profile() -> HearingProfile:
     # Progressively worse than 1 kHz at high frequency, beyond the normal shape ->
     # a relative high-frequency deviation that should be compensated.
-    levels = {500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
+    levels = {250: -60, 500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
     side = {f: FrequencyThreshold(f, levels[f], 3, True) for f in TEST_FREQUENCIES}
     return HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
 
@@ -200,7 +200,7 @@ class TestRunHearingFit:
         # A channel with no boost must not get a preamp (no L/R imbalance).
         from headmatch.hearing_test import NORMAL_RELATIVE_SHAPE_DB
         left = {f: FrequencyThreshold(f, -60.0 + NORMAL_RELATIVE_SHAPE_DB[f], 3, True) for f in TEST_FREQUENCIES}
-        right_levels = {500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
+        right_levels = {250: -60, 500: -60, 1000: -60, 2000: -58, 3000: -52, 4000: -46, 6000: -40, 8000: -34}
         right = {f: FrequencyThreshold(f, right_levels[f], 3, True) for f in TEST_FREQUENCIES}
         profile = HearingProfile(left=left, right=right, tested_at="t", asymmetric_freqs=[])
         run_hearing_fit(profile, tmp_path, sample_rate=48000)

--- a/tests/test_hearing_lowfreq_pta_reliability.py
+++ b/tests/test_hearing_lowfreq_pta_reliability.py
@@ -1,0 +1,279 @@
+"""Tests for the 250 Hz addition, PTA4/WHO summary, and false-positive
+(catch-trial + jitter) reliability handling in the hearing test.
+
+See docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md
+"""
+from __future__ import annotations
+
+import io
+import sys
+import random
+
+import pytest
+
+from headmatch import hearing_test as ht_mod
+from headmatch.hearing_test import (
+    JITTER_MAX_S,
+    JITTER_MIN_S,
+    NORMAL_HEARING_REFERENCE,
+    NORMAL_RELATIVE_SHAPE_DB,
+    PTA4_FREQS,
+    TEST_FREQUENCIES,
+    TEST_ORDER,
+    FrequencyThreshold,
+    HearingProfile,
+    compute_hearing_summary,
+    is_unreliable,
+    jittered_delay,
+    run_cli_hearing_test,
+    should_insert_catch,
+    who_grade,
+)
+
+
+# ── Part A: 250 Hz ──────────────────────────────────────────────────────────
+
+class Test250Hz:
+    def test_250_in_test_frequencies(self):
+        assert 250 in TEST_FREQUENCIES
+
+    def test_test_order_ends_at_lowest(self):
+        # ISO 8253-1 descends to the lowest frequency last.
+        assert TEST_ORDER[-1] == 250
+
+    def test_test_order_covers_all_frequencies(self):
+        assert set(TEST_ORDER) == set(TEST_FREQUENCIES)
+
+    def test_reference_values_present(self):
+        assert 250 in NORMAL_HEARING_REFERENCE
+        assert 250 in NORMAL_RELATIVE_SHAPE_DB
+
+    def test_250_excluded_from_pta4(self):
+        # PTA4 is the standard 500/1k/2k/4k average; 250 must not be in it.
+        assert 250 not in PTA4_FREQS
+
+
+# ── Part B: PTA4 + WHO grade ────────────────────────────────────────────────
+
+def _threshold(freq_hz: int, level_dbfs: float | None, determined: bool = True):
+    return FrequencyThreshold(freq_hz, level_dbfs, 3, determined)
+
+
+def _profile(left_levels: dict[int, float], right_levels: dict[int, float] | None = None):
+    if right_levels is None:
+        right_levels = dict(left_levels)
+    left = {f: _threshold(f, lv) for f, lv in left_levels.items()}
+    right = {f: _threshold(f, lv) for f, lv in right_levels.items()}
+    return HearingProfile(left=left, right=right, tested_at="2026-06-14T00:00:00+00:00",
+                          asymmetric_freqs=[])
+
+
+class TestWhoGrade:
+    @pytest.mark.parametrize("pta,label", [
+        (-5.0, "No impairment"),
+        (19.9, "No impairment"),
+        (20.0, "Mild"),
+        (34.9, "Mild"),
+        (35.0, "Moderate"),
+        (49.9, "Moderate"),
+        (50.0, "Moderately severe"),
+        (64.9, "Moderately severe"),
+        (65.0, "Severe"),
+        (79.9, "Severe"),
+        (80.0, "Profound"),
+        (94.9, "Profound"),
+        (95.0, "Complete"),
+        (130.0, "Complete"),
+    ])
+    def test_boundaries(self, pta, label):
+        assert who_grade(pta) == label
+
+
+class TestComputeHearingSummary:
+    def test_normal_hearing_no_impairment(self):
+        # Thresholds exactly at the normal reference -> est_HL 0 -> No impairment.
+        levels = {f: NORMAL_HEARING_REFERENCE[f] for f in PTA4_FREQS}
+        summary = compute_hearing_summary(_profile(levels))
+        assert summary["pta4_left_db"] == pytest.approx(0.0)
+        assert summary["better_ear_pta_db"] == pytest.approx(0.0)
+        assert summary["who_grade"] == "No impairment"
+        assert summary["estimated"] is True
+
+    def test_uniform_loss_grades_mild(self):
+        # 30 dB worse than reference at all PTA frequencies -> PTA4 = 30 -> Mild.
+        levels = {f: NORMAL_HEARING_REFERENCE[f] + 30.0 for f in PTA4_FREQS}
+        summary = compute_hearing_summary(_profile(levels))
+        assert summary["pta4_left_db"] == pytest.approx(30.0)
+        assert summary["who_grade"] == "Mild"
+
+    def test_better_ear_is_used(self):
+        left = {f: NORMAL_HEARING_REFERENCE[f] + 60.0 for f in PTA4_FREQS}   # worse ear
+        right = {f: NORMAL_HEARING_REFERENCE[f] + 10.0 for f in PTA4_FREQS}  # better ear
+        summary = compute_hearing_summary(_profile(left, right))
+        assert summary["better_ear_pta_db"] == pytest.approx(10.0)
+        assert summary["who_grade"] == "No impairment"  # 10 < 20
+
+    def test_insufficient_frequencies_gives_none(self):
+        # Only 2 of the 4 PTA frequencies determined -> PTA undetermined.
+        levels = {500: NORMAL_HEARING_REFERENCE[500], 1000: NORMAL_HEARING_REFERENCE[1000]}
+        summary = compute_hearing_summary(_profile(levels))
+        assert summary["pta4_left_db"] is None
+        assert summary["better_ear_pta_db"] is None
+        assert summary["who_grade"] is None
+
+    def test_three_of_four_is_enough(self):
+        levels = {f: NORMAL_HEARING_REFERENCE[f] for f in (500, 1000, 2000)}
+        summary = compute_hearing_summary(_profile(levels))
+        assert summary["pta4_left_db"] is not None
+
+    def test_undetermined_threshold_excluded(self):
+        levels = {f: NORMAL_HEARING_REFERENCE[f] for f in PTA4_FREQS}
+        prof = _profile(levels)
+        # Mark 4000 undetermined on the left -> still 3 of 4.
+        prof.left[4000] = _threshold(4000, None, determined=False)
+        summary = compute_hearing_summary(prof)
+        assert summary["pta4_left_db"] is not None
+
+
+class TestHearingSummaryInReport:
+    def test_fit_report_includes_hearing_summary(self):
+        from headmatch.pipeline import fit_from_hearing_profile
+        levels = {f: NORMAL_HEARING_REFERENCE[f] + 30.0 for f in TEST_FREQUENCIES}
+        _, _, report = fit_from_hearing_profile(_profile(levels), sample_rate=48000, max_filters=4)
+        assert "hearing_summary" in report
+        assert report["hearing_summary"]["who_grade"] == "Mild"
+        assert report["hearing_summary"]["estimated"] is True
+
+
+# ── Part C: catch trials + jitter ───────────────────────────────────────────
+
+class _StubRng:
+    """Deterministic stand-in: random() returns a fixed value, uniform echoes lo/hi."""
+    def __init__(self, value: float):
+        self._value = value
+
+    def random(self) -> float:
+        return self._value
+
+    def uniform(self, lo: float, hi: float) -> float:
+        return lo + (hi - lo) * self._value
+
+
+class TestShouldInsertCatch:
+    def test_inserts_when_below_probability(self):
+        assert should_insert_catch(_StubRng(0.1), 0) is True
+
+    def test_skips_when_above_probability(self):
+        assert should_insert_catch(_StubRng(0.9), 0) is False
+
+    def test_respects_per_frequency_cap(self):
+        from headmatch.hearing_test import MAX_CATCH_TRIALS_PER_FREQ
+        assert should_insert_catch(_StubRng(0.0), MAX_CATCH_TRIALS_PER_FREQ) is False
+
+
+class TestJitteredDelay:
+    def test_within_bounds(self):
+        rng = random.Random(0)
+        for _ in range(200):
+            d = jittered_delay(rng)
+            assert JITTER_MIN_S <= d <= JITTER_MAX_S
+
+
+class TestIsUnreliable:
+    def test_high_false_positive_rate_is_unreliable(self):
+        assert is_unreliable(catch_count=3, false_positive_count=2) is True  # 2/3 > 1/3
+
+    def test_one_third_is_not_unreliable(self):
+        assert is_unreliable(catch_count=3, false_positive_count=1) is False  # 1/3 not > 1/3
+
+    def test_too_few_catches_never_unreliable(self):
+        assert is_unreliable(catch_count=2, false_positive_count=2) is False
+
+    def test_no_catches_is_safe(self):
+        assert is_unreliable(catch_count=0, false_positive_count=0) is False
+
+
+# ── Profile serialisation with new fields ───────────────────────────────────
+
+class TestProfileSerialisation:
+    def test_round_trip_with_catch_stats(self):
+        levels = {f: -45.0 for f in TEST_FREQUENCIES}
+        prof = _profile(levels)
+        prof.catch_stats = {"left": {"catch": 5, "false_positive": 1},
+                            "right": {"catch": 4, "false_positive": 0}}
+        prof.unreliable_ears = ["left"]
+        restored = HearingProfile.from_dict(prof.to_dict())
+        assert restored.catch_stats == prof.catch_stats
+        assert restored.unreliable_ears == ["left"]
+
+    def test_back_compat_load_without_new_fields(self):
+        # An old profile JSON lacking the reliability fields must still load.
+        levels = {f: -45.0 for f in TEST_FREQUENCIES}
+        data = _profile(levels).to_dict()
+        data.pop("catch_stats", None)
+        data.pop("unreliable_ears", None)
+        restored = HearingProfile.from_dict(data)
+        assert restored.catch_stats is None
+        assert restored.unreliable_ears in (None, [])
+
+
+# ── Runner integration: catch stats are collected ───────────────────────────
+
+class _FakeEngine:
+    def __init__(self, freq_hz, start_level_dbfs=-20.0):
+        self.freq_hz = freq_hz
+        self.current_level_dbfs = start_level_dbfs
+        self._n = 0
+        self.done = False
+        self.threshold = -45.0
+        self.ascending_run_count = 2
+        self.converged = True
+        self.floored = False
+
+    def record_response(self, _heard):
+        self._n += 1
+        if self._n >= 2:
+            self.done = True
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.calls = 0
+
+    def play_tone(self, *a, **k):
+        self.calls += 1
+
+
+def _patch_fast(monkeypatch):
+    monkeypatch.setattr(ht_mod, "ThresholdEngine", _FakeEngine)
+    monkeypatch.setattr(ht_mod, "RESPONSE_WINDOW_S", 0.01)
+    monkeypatch.setattr(ht_mod, "generate_tone", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod, "generate_silence", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod.time, "sleep", lambda *_: None)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+
+def test_runner_collects_catch_stats(monkeypatch):
+    _patch_fast(monkeypatch)
+    # Seed forces deterministic, reproducible catch insertion.
+    profile = run_cli_hearing_test(_FakeBackend(), None, 48000, rng=random.Random(1))
+    assert profile.catch_stats is not None
+    assert set(profile.catch_stats) == {"left", "right"}
+    total_catches = 0
+    for ear in ("left", "right"):
+        stats = profile.catch_stats[ear]
+        assert stats["catch"] >= 0
+        # A false positive can only occur on a catch trial.
+        assert stats["false_positive"] <= stats["catch"]
+        total_catches += stats["catch"]
+    assert total_catches > 0  # the catch-trial path actually executed
+    assert isinstance(profile.unreliable_ears, list)
+
+
+def test_runner_flags_unreliable_when_all_responses_are_false_positives(monkeypatch):
+    # This fake harness's _ask_heard returns True on empty stdin, so every catch
+    # trial registers as a false positive -> both ears should be flagged unreliable.
+    _patch_fast(monkeypatch)
+    profile = run_cli_hearing_test(_FakeBackend(), None, 48000, rng=random.Random(1))
+    assert set(profile.unreliable_ears) == {"left", "right"}

--- a/tests/test_hearing_test_bugfixes.py
+++ b/tests/test_hearing_test_bugfixes.py
@@ -130,7 +130,7 @@ def test_lsq_band_gains_realize_target_accounting_for_interaction():
     )
     from headmatch.peq import peq_chain_response_db
 
-    loss = {500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
+    loss = {250: 4, 500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
     side = {f: FrequencyThreshold(f, NORMAL_HEARING_REFERENCE[f] + loss[f], 3, True) for f in TEST_FREQUENCIES}
     profile = HearingProfile(left=dict(side), right=dict(side), tested_at="t", asymmetric_freqs=[])
     points = compute_compensation_points(profile)

--- a/tests/test_hearing_test_runner.py
+++ b/tests/test_hearing_test_runner.py
@@ -44,6 +44,8 @@ def _patch_fast(monkeypatch):
     monkeypatch.setattr(ht_mod, "ThresholdEngine", _FakeEngine)
     monkeypatch.setattr(ht_mod, "RESPONSE_WINDOW_S", 0.01)
     monkeypatch.setattr(ht_mod, "generate_tone", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod, "generate_silence", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod.time, "sleep", lambda *_: None)  # skip jitter delay
     monkeypatch.setattr("builtins.input", lambda *a, **k: "")
     monkeypatch.setattr(sys, "stdin", io.StringIO(""))
 

--- a/tests/test_relative_compensation.py
+++ b/tests/test_relative_compensation.py
@@ -78,9 +78,10 @@ def test_reference_frequency_never_self_compensates():
 
 
 def test_lower_deadband_corrects_moderate_consistent_deviation():
-    # A consistent, moderate HF slope that the old 10 dB deadband ignored is now
-    # corrected with the lowered deadband (noise is handled by smoothing).
-    levels = {500: -60, 1000: -60, 2000: -57, 3000: -54, 4000: -51, 6000: -48, 8000: -45}
+    # A consistent, moderate HF slope whose per-frequency deviations all stay below
+    # the old 10 dB deadband (here at most ~9 dB beyond the ISO 389-8 normal shape)
+    # is now corrected with the lowered relative deadband (noise handled by smoothing).
+    levels = {500: -60, 1000: -60, 2000: -58, 3000: -54, 4000: -50, 6000: -44, 8000: -41}
     assert relative_compensation_points(_side(levels))  # non-empty
 
 


### PR DESCRIPTION
## Summary

Three standards-based, patent-clean additions to the hearing test (one feature branch, full TDD, all 797 tests green):

### 1. 250 Hz
Extends the protocol to `(250, 500, 1000, 2000, 3000, 4000, 6000, 8000)` Hz for a fuller low-frequency audiogram and better low-end EQ coverage. Test order descends to 250 Hz last (ISO 8253-1). **Ceiling stays at 8 kHz** — above that, headphone FR + seat/seal variance dominate the measurement and our public reference data (ISO 389-8 HDA200) stops at 8 kHz, so extending would equalize headphone coloration rather than hearing.

### 2. PTA4 + WHO 2021 grade
`compute_hearing_summary()` derives a better-ear pure-tone average (500/1k/2k/4k) and a WHO 2021 hearing grade from the estimated dB-HL (`threshold − NORMAL_HEARING_REFERENCE`). Surfaced in `hearing_fit_report.json`, CLI output, and the GUI results screen — always labelled an **uncalibrated estimate, not a medical diagnosis**. 250 Hz is deliberately excluded from PTA4.

### 3. False-positive ("phantom") control
- **Silent catch trials** (20%, capped 4/freq) measure how often the listener responds when no tone plays. They never advance the staircase, so `ThresholdEngine` stays pure detection logic.
- **Jittered timing** (0.5–2.0 s pre-tone gap) breaks the predictable rhythm that drives expectation-based responses.
- An ear is flagged **unreliable** (≥3 catches and FP rate > 1/3) — surfaced with a retest suggestion, **not** auto-discarded.

Policy lives in shared helpers (`should_insert_catch` / `jittered_delay` / `is_unreliable`) used by **both** the CLI and GUI runners. `HearingProfile` gains backward-compatible `catch_stats` / `unreliable_ears` fields.

## Design
`docs/superpowers/specs/2026-06-14-hearing-test-lowfreq-pta-who-reliability-design.md`

## Notes for review
- The two 250 Hz reference values (`NORMAL_HEARING_REFERENCE[250]=-45.0`, `NORMAL_RELATIVE_SHAPE_DB[250]=12.5`) are derived from ISO 7029 / ISO 389-8 trends; worth a sanity check against the exact tables.
- Tunable defaults: `CATCH_TRIAL_PROB`, `MAX_CATCH_TRIALS_PER_FREQ`, `FP_RATE_WARN`, `JITTER_MIN/MAX_S`.

## Testing
- New `tests/test_hearing_lowfreq_pta_reliability.py` (38 tests): WHO band boundaries, PTA math + insufficient-data, catch/jitter helpers, `is_unreliable` boundary, profile round-trip + back-compat, runner catch-stat collection, report wiring.
- Updated existing fixtures for the new 250 Hz frequency; full suite: **797 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
