### PR TITLE
Release 0.8.4: hearing test feature-complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ only needs headphones.
 
 ## Hearing test (equipment-free EQ)
 
-The hearing test plays pure tones and asks you to click **"I hear it"**. From your responses
-it builds a personalised EQ — **no measurement microphone required**, so it works on any
-machine that can play sound.
+The hearing test plays short **bursts of pure tones** and asks you to click **"I hear it"**.
+From your responses it builds a personalised EQ — **no measurement microphone required**, so
+it works on any machine that can play sound.
 
 **Run it:**
 
@@ -59,21 +59,30 @@ machine that can play sound.
   headmatch hearing-test            # run the test and save your hearing profile
   headmatch hearing-fit --out-dir out/hearing_fit   # generate an EQ from the saved profile
   headmatch hearing-test --fit --out-dir out/hearing_fit   # do both in one go
+  headmatch hearing-test --extended-hf   # also test 10/12.5/16 kHz (shapes the "air band")
+  headmatch hearing-fit --out-dir out/hearing_fit --flatten 0.4   # lift the high-frequency air band
   ```
 
 In the GUI you can **reuse a saved profile** ("Use Saved Profile") to regenerate an EQ
 without re-testing, and in **Advanced mode** layer a tonal **target curve** (Harman / free
-field / diffuse field / custom CSV) on top of the hearing correction.
+field / diffuse field / custom CSV) on top of the hearing correction and choose an
+**air-band shaping** strength.
 
 **How it works (and its limits):**
 
-- Each ear is measured **independently** and referenced to your own 1 kHz, so the result is
-  **calibration-invariant** — your volume knob doesn't decide the outcome — and captures real
-  **left/right differences**.
+- Tones play as a **random short pulse train** so you can tell a real tone from imagination;
+  **silent catch trials** and **jittered timing** catch false responses and flag an
+  unreliable ear.
+- Each ear is measured **independently** across **250 Hz – 8 kHz** (optionally up to
+  **16 kHz**) and referenced to your own 1 kHz, so the result is **calibration-invariant** —
+  your volume knob doesn't decide the outcome — and captures real **left/right differences**.
 - The test repeats only the frequencies that look deviant (**adaptive**, so a clean ear
   finishes fast), and **rejects measurement noise** rather than correcting it.
-- It runs a **volume check** (you should *not* hear the faint tone) and an **L/R channel
-  check** before starting.
+- It runs a **volume check** and an **L/R channel check** before starting, and reports a
+  plain-language **hearing summary** (a pure-tone average and WHO grade — an estimate, not a
+  diagnosis).
+- By default it corrects only where you're **worse than a normal ear**; **`--flatten`** (0–1)
+  lets you also lift the natural high-frequency rolloff to shape the "air band".
 
 > **This is a personalisation aid, not a clinical audiogram.** It's uncalibrated and measures
 > your perceived response *through your headphones*. For near-normal hearing it will

--- a/docs/releases/0.8.4.md
+++ b/docs/releases/0.8.4.md
@@ -1,0 +1,108 @@
+# HeadMatch 0.8.4 Release Notes
+
+Released: 2026-06-15
+
+## Overview
+
+0.8.4 completes the equipment-free **hearing test**. Building on the
+calibration-robust rework in 0.8.3, this release makes the test more confident to
+take, more honest about reliability, broader in frequency coverage, and gives you
+direct control over how much it shapes your sound — plus a fix that makes the
+exported presets load correctly in single-gain hosts like EasyEffects.
+
+The hearing test is now considered **feature complete**.
+
+This release contains no breaking changes to the measurement/clone workflows.
+
+---
+
+## Easier and more trustworthy to take
+
+- **Pulsed tones.** Each tone is now a short, random **2–4 pulse train** instead of
+  one steady tone, so you can confirm "I heard *that*" with confidence. Pulsed
+  pure tones are the clinically recommended audiometric stimulus (ASHA) and don't
+  change thresholds (each pulse stays ≥ 0.2 s to avoid temporal-integration
+  effects). Steady tones are also easy to confuse with tinnitus; pulses aren't.
+- **False-positive control.** Silent **catch trials** are randomly interleaved to
+  measure how often a response is registered when no tone played, and the
+  inter-tone timing is **jittered** so you can't fall into a rhythm. If an ear's
+  false-positive rate is high it's flagged as unreliable with a suggestion to
+  retest — your data is never silently discarded.
+
+## Broader frequency coverage
+
+- **250 Hz** is now part of the standard protocol for a fuller low-frequency
+  audiogram.
+- **Opt-in extended high frequencies (10, 12.5, 16 kHz).** Off by default; enable
+  with `headmatch hearing-test --extended-hf` or the GUI checkbox. Above 8 kHz the
+  result is dominated by your headphone's response and fit, so these shape the
+  "air band"/coloration rather than pure hearing — they come with a clear warning
+  and are excluded from the hearing-grade summary. Reference levels are taken from
+  **ISO 389-5:2006** (and the ≤ 8 kHz values verified against **ISO 389-8:2004**).
+
+## A legible result
+
+- **Hearing summary.** Results now include a **PTA4** (pure-tone average) and a
+  **WHO 2021 hearing grade**, in the CLI output, the GUI results screen, and
+  `hearing_fit_report.json` — clearly labelled an *estimate from an uncalibrated
+  self-test, not a medical diagnosis*.
+
+## Control over the correction
+
+- **Air-band shaping (`--flatten`, 0..1).** By default the EQ only corrects where
+  you're *worse than a normal ear*. The new knob lets you also lift more of the
+  natural high-frequency rolloff — `0` = compensate-to-normal (default), `1` =
+  flatten your perceived response toward 1 kHz. It only affects frequencies above
+  1 kHz, so it never adds spurious bass. Available as `--flatten` on
+  `hearing-test --fit` / `hearing-fit` and as an "air-band shaping" selector in
+  the GUI's advanced mode.
+
+## Fixes
+
+- **EasyEffects-safe preamp.** Hosts with a single global gain (e.g. EasyEffects)
+  can't honour separate per-channel `Preamp` values. The parametric
+  `equalizer_apo.txt` now uses a **single shared worst-case preamp on both
+  channels**, so the preset is clip-safe whichever value such a host applies — and
+  L/R balance is preserved (the per-ear difference stays in the filters instead of
+  leaking into a broadband level offset). This also fixes a latent balance offset
+  for asymmetric corrections.
+- **Top-edge deviations no longer lost.** The relative model's spike-rejection
+  smoothing is two-sided by nature; at the top/bottom of the measured range it
+  could wrongly drag a *real* edge deviation toward its one-sided neighbours and
+  gate it out (e.g. a genuine 12.5 kHz rolloff with 16 kHz undetermined). Edge
+  frequencies now keep their own measured value, so a real high-frequency deficit
+  produces a real correction instead of an empty preset.
+- **6 kHz reference corrected.** The normal-shape value at 6 kHz now matches
+  ISO 389-8 (RETSPL 17.0 dB → +11.5 dB relative to 1 kHz; was +8.7).
+
+---
+
+## What the hearing test is (and isn't)
+
+Unchanged from 0.8.3: the hearing test is an **uncalibrated, equipment-free
+personalisation aid**, not a clinical audiogram. It measures your perceived
+response *through your headphones* at your listening volume. For near-normal
+hearing it will correctly produce little or no EQ; with `--flatten` you can choose
+to shape the high end further. For a measured, headphone-specific correction, use
+the microphone measurement workflow.
+
+## Test coverage
+
+- **833 tests passing** (up from 759 in 0.8.3).
+- New modules: `test_hearing_pulsed.py`, `test_hearing_ehf.py`,
+  `test_hearing_flatten.py`, `test_hearing_edge_smoothing.py`,
+  `test_hearing_lowfreq_pta_reliability.py`.
+
+## Upgrade Notes
+
+No breaking changes. Re-run the hearing test to benefit from pulsed tones, the
+false-positive checks, and 250 Hz. To shape the air band, try
+`headmatch hearing-fit --flatten 0.3` (or higher). To include extended high
+frequencies, add `--extended-hf` to `hearing-test` — note many listeners cannot
+hear 16 kHz at a safe volume, and those points are simply skipped.
+
+```bash
+pip install --upgrade headmatch
+headmatch --version
+# headmatch 0.8.4
+```

--- a/headmatch/app_identity.py
+++ b/headmatch/app_identity.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 APP_NAME = 'headmatch'
 APP_DISPLAY_NAME = 'HeadMatch'
-_VERSION = '0.8.3'
+_VERSION = '0.8.4'
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Release 0.8.4 — hearing test feature-complete

Branches off current `main` (after #27 merged). Contains only the release work:

- **Version bump** `0.8.3 → 0.8.4` (`headmatch/app_identity.py`).
- **`docs/releases/0.8.4.md`** — release notes covering everything that landed since 0.8.3 (across #26 and #27): pulsed-tone stimulus + catch-trial/jitter false-positive control, 250 Hz + opt-in extended high frequencies (10/12.5/16 kHz), PTA4 + WHO hearing-grade summary, the `--flatten` air-band shaping knob, EasyEffects-safe shared preamp, and the top-edge smoothing + 6 kHz reference fixes. **833 tests passing** (up from 759).
- **README** hearing section refreshed for the now feature-complete test (pulse trains, `--extended-hf`, `--flatten`, hearing summary).

No code/behavior changes — docs + version only. The hearing test is now considered feature complete.

(Note: the 0.8.x line is tracked in `docs/releases/`, not `CHANGELOG.md`, consistent with 0.8.0–0.8.3.)
