### PR TITLE
Bring core modules to 100% test coverage + critical-path e2e tests

### DIFF
--- a/headmatch/cli.py
+++ b/headmatch/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from .contracts import FrontendRunSummary
@@ -13,6 +14,12 @@ from .settings import load_or_create_config, save_config, update_config_from_arg
 
 
 DEFAULT_START_ITERATIONS = 1
+
+
+def _desktop_shortcuts_supported() -> bool:
+    """Desktop ``.desktop`` launchers are a Linux/XDG concept; gate the
+    create-shortcut/remove-shortcut commands (and the doctor tip) accordingly."""
+    return sys.platform.startswith("linux")
 
 
 def parse_seconds(value: str) -> float:
@@ -306,6 +313,18 @@ def build_parser(config) -> argparse.ArgumentParser:
         description="Run a small beginner-friendly readiness check for config, audio tools, and device discovery.",
     )
 
+    if _desktop_shortcuts_supported():
+        sub.add_parser(
+            "create-shortcut",
+            help="Add a HeadMatch GUI entry to your desktop application launcher.",
+            description="Create a .desktop launcher in ~/.local/share/applications (Linux desktops).",
+        )
+        sub.add_parser(
+            "remove-shortcut",
+            help="Remove the HeadMatch desktop launcher entry.",
+            description="Delete the .desktop launcher created by 'headmatch create-shortcut'.",
+        )
+
     sub.add_parser(
         "tui",
         help="Launch the interactive beginner wizard.",
@@ -575,14 +594,15 @@ def main(argv: list[str] | None = None) -> None:
             else:
                 print("No desktop shortcut found.")
         elif args.cmd == "doctor":
-            from .desktop import shortcut_exists, find_gui_binary
             print(format_doctor_report(collect_doctor_checks(config_path, config), config_path=config_path))
-            gui = find_gui_binary()
-            if gui and not shortcut_exists():
-                print(f"\nTip: Run 'headmatch create-shortcut' to add HeadMatch to your desktop launcher.")
-                print(f"     (Found GUI at: {gui})")
-            elif shortcut_exists():
-                print(f"\nDesktop shortcut: installed ✓")
+            if _desktop_shortcuts_supported():
+                from .desktop import shortcut_exists, find_gui_binary
+                gui = find_gui_binary()
+                if gui and not shortcut_exists():
+                    print(f"\nTip: Run 'headmatch create-shortcut' to add HeadMatch to your desktop launcher.")
+                    print(f"     (Found GUI at: {gui})")
+                elif shortcut_exists():
+                    print(f"\nDesktop shortcut: installed ✓")
         elif args.cmd == "measure":
             out_dir = Path(args.out_dir)
             out_dir.mkdir(parents=True, exist_ok=True)
@@ -654,7 +674,7 @@ def main(argv: list[str] | None = None) -> None:
             hf_profile = load_hearing_profile()
             if hf_profile is None:
                 parser.exit(2, f"Error: no hearing profile found at {hearing_profile_path()}.\nRun 'headmatch hearing-test' first.\n")
-                raise SystemExit(2)
+                raise SystemExit(2)  # pragma: no cover  (defensive: parser.exit already raises SystemExit)
             run_hearing_fit(
                 hf_profile,
                 args.out_dir,
@@ -821,5 +841,5 @@ def main(argv: list[str] | None = None) -> None:
     print_next_steps(args.cmd, args)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/headmatch/io_utils.py
+++ b/headmatch/io_utils.py
@@ -124,7 +124,7 @@ def load_fr_csv(path: str | Path) -> Tuple[np.ndarray, np.ndarray]:
         vals = np.array([float(r[value_key]) for r in rows], dtype=np.float64)
     except KeyError as exc:
         raise ValueError(f'Missing expected column {exc.args[0]!r} in {path}') from exc
-    except ValueError as exc:
+    except (ValueError, TypeError) as exc:
         raise ValueError(f'Could not parse numeric frequency/response data from {path}') from exc
 
     if freqs.ndim != 1 or vals.ndim != 1 or len(freqs) != len(vals):

--- a/tests/test_ab_compare_coverage.py
+++ b/tests/test_ab_compare_coverage.py
@@ -1,0 +1,48 @@
+"""Coverage tests for ab_compare.py missing lines.
+
+Targets: 171 (verdict where B has lower predicted error).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from headmatch.ab_compare import build_comparison_pair, format_comparison_table
+from headmatch.contracts import (
+    ConfidenceSummary,
+    FrontendRunSummary,
+    RunErrorSummary,
+    RunFilterCounts,
+)
+
+
+def _write_run_summary(run_dir: Path, *, left_rms: float, right_rms: float):
+    run_dir.mkdir(parents=True, exist_ok=True)
+    summary = FrontendRunSummary(
+        schema_version=1,
+        kind="fit",
+        out_dir=str(run_dir),
+        sample_rate=48000,
+        frequency_points=256,
+        target="flat",
+        filters=RunFilterCounts(left=5, right=5),
+        predicted_error_db=RunErrorSummary(left_rms=left_rms, right_rms=right_rms, left_max=3.0, right_max=3.5),
+        generated_by={},
+        confidence=ConfidenceSummary(
+            score=80, label="high", headline="t", interpretation="t",
+            reasons=(), warnings=(), metrics={},
+        ),
+        plots={},
+        results_guide=str(run_dir / "README.txt"),
+    )
+    (run_dir / "run_summary.json").write_text(json.dumps(summary.to_dict()), encoding="utf-8")
+
+
+def test_verdict_b_has_lower_error(tmp_path):
+    run_a = tmp_path / "a"
+    run_b = tmp_path / "b"
+    _write_run_summary(run_a, left_rms=3.0, right_rms=3.0)
+    _write_run_summary(run_b, left_rms=1.0, right_rms=1.0)
+    pair = build_comparison_pair(run_a, run_b, label_a="A", label_b="B")
+    table = format_comparison_table(pair)
+    assert "B has lower predicted error" in table

--- a/tests/test_analysis_coverage.py
+++ b/tests/test_analysis_coverage.py
@@ -1,0 +1,165 @@
+"""Coverage tests for headmatch.analysis — drives error branches and edge cases."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from headmatch.analysis import (
+    _alignment_reference_score,
+    _align_recording_to_reference,
+    _band_mask,
+    _channel_mismatch_db,
+    _coerce_measurement_audio,
+    _roughness_db,
+    analyze_measurement,
+)
+from headmatch.io_utils import write_wav
+from headmatch.signals import SweepSpec, generate_log_sweep
+
+
+class TestCoerceMeasurementAudio:
+    def test_non_2d_raises(self):
+        with pytest.raises(ValueError, match="must be a 2D audio array"):
+            _coerce_measurement_audio(np.zeros(10), "x.wav")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="is empty"):
+            _coerce_measurement_audio(np.zeros((0, 2)), "x.wav")
+
+    def test_mono_capture_raises(self):
+        with pytest.raises(ValueError, match="mono capture"):
+            _coerce_measurement_audio(np.ones((10, 1)), "x.wav")
+
+    def test_zero_channels_raises(self):
+        # Rows present but zero columns: passes the empty/len check but trips
+        # the "at least two channels" guard (shape[1] < 2, not == 1).
+        with pytest.raises(ValueError, match="at least two channels"):
+            _coerce_measurement_audio(np.zeros((10, 0)), "x.wav")
+
+    def test_duplicated_channel_raises(self):
+        mono = np.linspace(-1, 1, 32)
+        stereo = np.column_stack([mono, mono])
+        with pytest.raises(ValueError, match="duplicated-channel"):
+            _coerce_measurement_audio(stereo, "x.wav")
+
+    def test_valid_stereo_returns_two_channels(self):
+        data = np.column_stack([
+            np.linspace(-1, 1, 16),
+            np.linspace(1, -1, 16),
+            np.zeros(16),
+        ])
+        out = _coerce_measurement_audio(data, "x.wav")
+        assert out.shape == (16, 2)
+
+
+class TestAlignmentReferenceScore:
+    def test_zero_denominator_returns_zero(self):
+        # All-constant segment -> after mean removal it is all zeros -> denom 0
+        seg = np.ones(10)
+        ref = np.ones(10)
+        assert _alignment_reference_score(seg, ref) == 0.0
+
+
+class TestAlignHelpers:
+    def _make_sweep(self, duration_s=0.3, sr=48000):
+        t = np.linspace(0, duration_s, int(sr * duration_s), endpoint=False)
+        return np.sin(2 * np.pi * (200 + 4000 * t) * t).astype(np.float64)
+
+    def test_negative_offset_truncates_head(self):
+        # Reference longer than recording forces a negative best offset path.
+        sr = 48000
+        sweep = self._make_sweep(0.3, sr)
+        # Recording is the sweep but missing its first chunk: the true alignment
+        # offset is negative, exercising lines 101-103 (truncated_head).
+        cut = 2000
+        rec_mono = sweep[cut:].copy()
+        recording = np.column_stack([rec_mono, rec_mono * 0.9 + 1e-6])
+        aligned, diag = _align_recording_to_reference(recording, sweep)
+        assert diag["alignment_head_trimmed_samples"] >= 0.0
+        assert aligned.shape[1] == 2
+
+    def test_global_max_appended_when_not_a_peak(self):
+        # A single-sample reference yields a length-1 correlation; find_peaks
+        # returns no peaks (endpoints excluded), so the global max must be
+        # appended explicitly (line 68).
+        recording = np.array([[1.0, 0.5]])
+        reference = np.array([1.0])
+        aligned, diag = _align_recording_to_reference(recording, reference)
+        assert aligned.shape == (1, 2)
+        assert diag["alignment_offset_samples"] == 0.0
+
+    def test_many_peaks_limited_to_top16(self):
+        # Construct a recording with many repeated sweep copies so find_peaks
+        # returns > 16 candidates, exercising lines 68/72-73.
+        sr = 8000
+        sweep = self._make_sweep(0.02, sr)
+        gap = len(sweep)
+        n_copies = 25
+        total = n_copies * (len(sweep) + gap) + gap
+        rec_mono = np.zeros(total)
+        for i in range(n_copies):
+            start = gap + i * (len(sweep) + gap)
+            rec_mono[start:start + len(sweep)] += sweep
+        recording = np.column_stack([rec_mono, rec_mono * 0.8 + 1e-9])
+        aligned, diag = _align_recording_to_reference(recording, sweep)
+        assert aligned.shape[1] == 2
+        assert "alignment_offset_samples" in diag
+
+
+class TestRoughnessAndMismatch:
+    def test_roughness_empty_mask_returns_zero(self):
+        mask = np.zeros(5, dtype=bool)
+        assert _roughness_db(np.ones(5), np.zeros(5), mask) == 0.0
+
+    def test_channel_mismatch_empty_mask_returns_zero(self):
+        mask = np.zeros(5, dtype=bool)
+        assert _channel_mismatch_db(np.ones(5), np.zeros(5), mask) == 0.0
+
+
+def _write_valid_recording(path, spec):
+    stereo, reference = generate_log_sweep(spec)
+    padded_len = int(round(
+        (spec.pre_silence_s + spec.duration_s + spec.post_silence_s) * spec.sample_rate
+    ))
+    rec = np.zeros((padded_len, 2))
+    start = int(round(spec.pre_silence_s * spec.sample_rate))
+    rec[start:start + len(reference), 0] = reference
+    rec[start:start + len(reference), 1] = reference * 0.95 + 1e-6
+    write_wav(path, rec, spec.sample_rate)
+
+
+class TestAnalyzeMeasurement:
+    def test_sample_rate_mismatch_raises(self, tmp_path):
+        spec = SweepSpec(sample_rate=48000, duration_s=0.3,
+                         pre_silence_s=0.1, post_silence_s=0.1)
+        wav = tmp_path / "rec.wav"
+        _write_valid_recording(wav, spec)
+        # Analyze with a spec that claims a different sample rate.
+        bad_spec = SweepSpec(sample_rate=44100, duration_s=0.3,
+                             pre_silence_s=0.1, post_silence_s=0.1)
+        with pytest.raises(ValueError, match="Sample rate mismatch"):
+            analyze_measurement(wav, bad_spec)
+
+    def test_recording_too_short_raises(self, tmp_path):
+        spec = SweepSpec(sample_rate=48000, duration_s=0.3,
+                         pre_silence_s=0.1, post_silence_s=0.1)
+        # Write a too-short but valid stereo recording.
+        short = np.column_stack([
+            np.linspace(-1, 1, 100),
+            np.linspace(1, -1, 100) * 0.9,
+        ])
+        wav = tmp_path / "short.wav"
+        write_wav(wav, short, spec.sample_rate)
+        with pytest.raises(ValueError, match="Recording too short"):
+            analyze_measurement(wav, spec)
+
+    def test_full_analysis_writes_csvs(self, tmp_path):
+        spec = SweepSpec(sample_rate=48000, duration_s=0.3,
+                         pre_silence_s=0.1, post_silence_s=0.1)
+        wav = tmp_path / "rec.wav"
+        _write_valid_recording(wav, spec)
+        out_dir = tmp_path / "out"
+        result = analyze_measurement(wav, spec, out_dir=out_dir)
+        assert (out_dir / "measurement_left.csv").exists()
+        assert (out_dir / "measurement_right.csv").exists()
+        assert result.left_db.shape == result.freqs_hz.shape

--- a/tests/test_apo_import_coverage.py
+++ b/tests/test_apo_import_coverage.py
@@ -1,0 +1,45 @@
+"""Coverage tests for headmatch.apo_import edge branches."""
+from __future__ import annotations
+
+from headmatch.apo_import import parse_apo_parametric
+
+
+class TestChannelMarkerFallback:
+    def test_unknown_channel_marker_falls_back_to_both(self):
+        """A Channel marker that is neither L nor R resets to 'both' (line 58),
+        so subsequent filters land in both channels."""
+        text = (
+            "Channel: C\n"
+            "Filter 1: ON PK Fc 1000.00 Hz Gain -2.00 dB Q 1.00\n"
+        )
+        left, right = parse_apo_parametric(text)
+        assert len(left) == 1
+        assert len(right) == 1
+        assert left[0].freq == 1000.0
+        assert right[0].freq == 1000.0
+
+    def test_unknown_channel_after_left_resets_to_both(self):
+        """An unknown channel marker resets a previously-set channel back to both."""
+        text = (
+            "Channel: L\n"
+            "Filter 1: ON PK Fc 100.00 Hz Gain 1.00 dB Q 1.00\n"
+            "Channel: X\n"
+            "Filter 2: ON PK Fc 200.00 Hz Gain 1.00 dB Q 1.00\n"
+        )
+        left, right = parse_apo_parametric(text)
+        # First filter: left only. Second filter: both.
+        assert [b.freq for b in left] == [100.0, 200.0]
+        assert [b.freq for b in right] == [200.0]
+
+
+class TestUnknownFilterType:
+    def test_unrecognized_filter_type_is_skipped(self):
+        """A filter line whose type is not in the type map is skipped (line 69)."""
+        text = (
+            "Filter 1: ON XX Fc 1000.00 Hz Gain -2.00 dB Q 1.00\n"
+            "Filter 2: ON PK Fc 2000.00 Hz Gain -1.00 dB Q 1.00\n"
+        )
+        left, right = parse_apo_parametric(text)
+        # Only the recognized PK filter should survive.
+        assert len(left) == 1
+        assert left[0].freq == 2000.0

--- a/tests/test_app_identity_coverage.py
+++ b/tests/test_app_identity_coverage.py
@@ -1,0 +1,24 @@
+"""Coverage tests for app_identity.py missing lines.
+
+Targets: 22 (version_display when a build is set).
+"""
+from __future__ import annotations
+
+from headmatch.app_identity import AppIdentity, get_app_identity
+
+
+def test_version_display_with_build():
+    identity = AppIdentity(
+        name="headmatch",
+        display_name="HeadMatch",
+        version="1.2.3",
+        package_version="1.2.3",
+        build="abc123",
+    )
+    assert identity.version_display == "1.2.3+abc123"
+
+
+def test_version_display_without_build():
+    identity = get_app_identity()
+    assert identity.build is None
+    assert identity.version_display == identity.version

--- a/tests/test_batch_coverage.py
+++ b/tests/test_batch_coverage.py
@@ -1,0 +1,46 @@
+"""Coverage tests for batch.py missing lines.
+
+Targets: 92, 105.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from headmatch.batch import load_batch_manifest
+
+
+# ── line 92: an entry that isn't a JSON object ──
+
+def test_load_manifest_entry_not_object(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"entries": ["not-a-dict"]}), encoding="utf-8")
+    with pytest.raises(ValueError, match="Entry 0 must be a JSON object"):
+        load_batch_manifest(manifest)
+
+
+# ── line 105: relative target_csv resolved against manifest parent ──
+
+def test_load_manifest_resolves_relative_target_csv(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "recording": "rec.wav",
+                        "out_dir": "out",
+                        "target_csv": "targets/harman.csv",
+                        "label": "HP",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    entries = load_batch_manifest(manifest)
+    assert len(entries) == 1
+    expected = str((tmp_path / "targets" / "harman.csv").resolve())
+    assert entries[0].target_csv == expected

--- a/tests/test_builtin_targets_coverage.py
+++ b/tests/test_builtin_targets_coverage.py
@@ -1,0 +1,18 @@
+"""Coverage tests for builtin_targets.py."""
+from __future__ import annotations
+
+import pytest
+
+from headmatch.builtin_targets import builtin_target_label, materialize_builtin_target
+
+
+def test_builtin_target_label_returns_display_name():
+    # line 37
+    assert builtin_target_label('harman') == 'Harman'
+    assert builtin_target_label('flat') == 'Flat (default)'
+
+
+def test_materialize_unknown_target_raises(tmp_path):
+    # line 51
+    with pytest.raises(KeyError, match='unknown built-in target'):
+        materialize_builtin_target('does_not_exist', tmp_path)

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,0 +1,510 @@
+"""Targeted coverage tests for headmatch.cli line-by-line branches.
+
+Every test drives the CLI via cli.main(argv) (or a helper function directly),
+mocking all heavy/hardware/pipeline/network dependencies so the suite stays
+fast and deterministic. New tests only; existing test files are untouched.
+"""
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from headmatch import cli
+from headmatch.contracts import FrontendConfig
+
+
+@pytest.fixture(autouse=True)
+def patch_config_and_sweep(monkeypatch, tmp_path):
+    """Isolate config IO and the SweepSpec so dispatch never touches real state."""
+
+    class DummySweepSpec:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr("headmatch.signals.SweepSpec", DummySweepSpec)
+    monkeypatch.setattr(
+        "headmatch.cli.load_or_create_config",
+        lambda _path=None: (FrontendConfig(), tmp_path / "config.json", False),
+    )
+    monkeypatch.setattr("headmatch.cli.save_config", lambda *_a, **_k: None)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_hearing_profile(*, unreliable_ears=None, asymmetric_freqs=None):
+    from headmatch.hearing_test import (
+        NORMAL_HEARING_REFERENCE,
+        TEST_FREQUENCIES,
+        FrequencyThreshold,
+        HearingProfile,
+    )
+
+    side = {
+        f: FrequencyThreshold(
+            freq_hz=f,
+            level_dbfs=NORMAL_HEARING_REFERENCE[f],
+            ascending_runs=3,
+            determined=True,
+        )
+        for f in TEST_FREQUENCIES
+    }
+    return HearingProfile(
+        left=dict(side),
+        right=dict(side),
+        tested_at="2026-01-01T00:00:00+00:00",
+        asymmetric_freqs=asymmetric_freqs or [],
+        unreliable_ears=unreliable_ears or [],
+    )
+
+
+class FakeBackend:
+    def play_tone(self, *a, **kw):
+        pass
+
+
+# ── _run_summary_path (line 354) ─────────────────────────────────────────────
+
+
+def test_run_summary_path_returns_none_for_non_positive_iterations():
+    # cmd in {start, iterate}, independent mode, iterations not a positive int
+    args = type("A", (), {"out_dir": "/tmp/out", "iteration_mode": "independent", "iterations": 0})()
+    assert cli._run_summary_path("start", args) is None
+
+
+# ── print_clipping_summary preamp fallback (line 416) ────────────────────────
+
+
+def test_print_clipping_summary_falls_back_to_total_preamp_db(capsys):
+    summary = type(
+        "S",
+        (),
+        {
+            "eq_clipping_assessment": {
+                "will_clip": False,
+                "total_preamp_db": -3.5,
+                "left_peak_boost_db": 1.0,
+                "right_peak_boost_db": 1.0,
+                "headroom_loss_db": 0.0,
+            }
+        },
+    )()
+    cli.print_clipping_summary(summary)
+    out = capsys.readouterr().out
+    assert "Preamp recommendation: -3.5 dB" in out
+
+
+# ── fit next-steps with corrupt summary (lines 461-462) ──────────────────────
+
+
+def test_print_next_steps_fit_with_unreadable_summary(capsys, tmp_path):
+    out_dir = tmp_path / "fit"
+    out_dir.mkdir()
+    (out_dir / "run_summary.json").write_text("{not valid json", encoding="utf-8")
+    # _run_summary_path("fit") points at run_summary.json which exists but is
+    # corrupt -> summary becomes None and clipping summary is skipped.
+    cli.print_next_steps("fit", type("A", (), {"out_dir": str(out_dir)})())
+    out = capsys.readouterr().out
+    assert "Done. Review outputs in" in out
+    assert "Preamp recommendation" not in out
+
+
+# ── format_user_error default (line 505) ─────────────────────────────────────
+
+
+def test_format_user_error_default_passthrough():
+    assert cli.format_user_error("measure", ValueError("boom")) == "boom"
+
+
+# ── render-sweep dispatch (line 559) ─────────────────────────────────────────
+
+
+def test_render_sweep_dispatches(monkeypatch, tmp_path):
+    calls = {}
+    monkeypatch.setattr(
+        "headmatch.measure.render_sweep_file",
+        lambda spec, out: calls.update({"out": out}),
+    )
+    cli.main(["render-sweep", "--out", str(tmp_path / "sweep.wav")])
+    assert calls["out"] == str(tmp_path / "sweep.wav")
+
+
+# ── doctor shortcut tips (lines 582-583, 585) ────────────────────────────────
+
+
+def _patch_doctor_report(monkeypatch):
+    monkeypatch.setattr(
+        "headmatch.measure.collect_doctor_checks", lambda path, config: []
+    )
+    monkeypatch.setattr(
+        "headmatch.measure.format_doctor_report",
+        lambda checks, config_path: "HeadMatch doctor report",
+    )
+
+
+def test_doctor_suggests_creating_shortcut_when_gui_present(monkeypatch, capsys):
+    _patch_doctor_report(monkeypatch)
+    monkeypatch.setattr("headmatch.desktop.find_gui_binary", lambda: "/usr/bin/headmatch-gui")
+    monkeypatch.setattr("headmatch.desktop.shortcut_exists", lambda: False)
+    cli.main(["doctor"])
+    out = capsys.readouterr().out
+    assert "headmatch create-shortcut" in out
+    assert "/usr/bin/headmatch-gui" in out
+
+
+def test_doctor_reports_installed_shortcut(monkeypatch, capsys):
+    _patch_doctor_report(monkeypatch)
+    monkeypatch.setattr("headmatch.desktop.find_gui_binary", lambda: "/usr/bin/headmatch-gui")
+    monkeypatch.setattr("headmatch.desktop.shortcut_exists", lambda: True)
+    cli.main(["doctor"])
+    out = capsys.readouterr().out
+    assert "Desktop shortcut: installed" in out
+
+
+# ── hearing-test branches (616, 623-625, 636-637, 640-641) ───────────────────
+
+
+def _patch_hearing_test_backend(monkeypatch, profile):
+    monkeypatch.setattr("headmatch.audio_backend.get_audio_backend", lambda: FakeBackend())
+    monkeypatch.setattr("headmatch.hearing_test.run_cli_hearing_test", lambda *a, **kw: profile)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.save_hearing_profile",
+        lambda p: Path("/tmp/hearing_profile.json"),
+    )
+
+
+def test_hearing_test_extended_hf_prints_air_band_note(monkeypatch, capsys):
+    profile = _make_hearing_profile()
+    _patch_hearing_test_backend(monkeypatch, profile)
+    cli.main(["hearing-test", "--extended-hf"])
+    out = capsys.readouterr().out
+    assert "Extended high frequencies" in out
+
+
+def test_hearing_test_json_output(monkeypatch, capsys):
+    profile = _make_hearing_profile()
+    _patch_hearing_test_backend(monkeypatch, profile)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.compute_hearing_summary",
+        lambda p: {"who_grade": "normal", "better_ear_pta_db": 5.0},
+    )
+    cli.main(["hearing-test", "--json"])
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["hearing_summary"]["who_grade"] == "normal"
+
+
+def test_hearing_test_prints_who_grade_and_warnings(monkeypatch, capsys):
+    profile = _make_hearing_profile(unreliable_ears=["left"], asymmetric_freqs=[4000])
+    _patch_hearing_test_backend(monkeypatch, profile)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.compute_hearing_summary",
+        lambda p: {"who_grade": "mild", "better_ear_pta_db": 28.4},
+    )
+    cli.main(["hearing-test"])
+    out = capsys.readouterr().out
+    assert "Estimated hearing: mild" in out
+    assert "high false-positive rate on the left ear" in out
+    assert "large L/R difference at 4000 Hz" in out
+
+
+# ── hearing-fit branches (657, 672-673) ──────────────────────────────────────
+
+
+def test_hearing_fit_exits_when_no_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr("headmatch.hearing_test.load_hearing_profile", lambda: None)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.hearing_profile_path",
+        lambda: tmp_path / "hearing_profile.json",
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["hearing-fit", "--out-dir", str(tmp_path)])
+    assert exc.value.code == 2
+
+
+def test_hearing_fit_json_swallows_read_error(monkeypatch, capsys, tmp_path):
+    profile = _make_hearing_profile()
+    monkeypatch.setattr("headmatch.hearing_test.load_hearing_profile", lambda: profile)
+    # run_hearing_fit does not write the report -> reading it raises -> except: pass
+    monkeypatch.setattr("headmatch.pipeline.run_hearing_fit", lambda *a, **kw: {})
+    cli.main(["hearing-fit", "--out-dir", str(tmp_path / "fit"), "--json"])
+    out = capsys.readouterr().out
+    # No JSON printed; next-steps message still runs.
+    assert "Hearing fit complete" in out
+
+
+# ── fit --with-hearing-compensation no profile (lines 677-680) ───────────────
+
+
+def test_fit_with_hearing_compensation_exits_without_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr("headmatch.hearing_test.load_hearing_profile", lambda: None)
+    monkeypatch.setattr(
+        "headmatch.hearing_test.hearing_profile_path",
+        lambda: tmp_path / "hearing_profile.json",
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli.main(
+            [
+                "fit",
+                "--recording",
+                str(tmp_path / "r.wav"),
+                "--out-dir",
+                str(tmp_path / "fit"),
+                "--with-hearing-compensation",
+            ]
+        )
+    assert exc.value.code == 2
+
+
+# ── fit --json swallows read error (lines 687-688) ───────────────────────────
+
+
+def test_fit_json_swallows_missing_summary(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        "headmatch.pipeline.process_single_measurement", lambda *a, **k: None
+    )
+    # No run_summary.json written -> read raises -> except: pass, returns early.
+    cli.main(
+        [
+            "fit",
+            "--recording",
+            str(tmp_path / "r.wav"),
+            "--out-dir",
+            str(tmp_path / "fit"),
+            "--json",
+        ]
+    )
+    assert capsys.readouterr().out == ""
+
+
+# ── search-headphone empty + truncated (lines 693, 702) ──────────────────────
+
+
+def test_search_headphone_no_results(monkeypatch, capsys):
+    monkeypatch.setattr("headmatch.headphone_db.search_headphone", lambda q: [])
+    cli.main(["search-headphone", "nope"])
+    out = capsys.readouterr().out
+    assert "No matches for 'nope'" in out
+
+
+def test_search_headphone_truncates_over_25(monkeypatch, capsys):
+    from headmatch.headphone_db import HeadphoneEntry
+
+    entries = [
+        HeadphoneEntry(
+            name=f"HP {i}",
+            source="src",
+            form_factor="over-ear",
+            csv_path=f"results/src/over-ear/HP {i}/HP {i}.csv",
+        )
+        for i in range(30)
+    ]
+    monkeypatch.setattr("headmatch.headphone_db.search_headphone", lambda q: entries)
+    cli.main(["search-headphone", "HP"])
+    out = capsys.readouterr().out
+    assert "Found 30 matches" in out
+    assert "... and 5 more" in out
+
+
+# ── batch-fit (lines 738-757) ────────────────────────────────────────────────
+
+
+def test_batch_fit_reports_success_and_failure(monkeypatch, capsys, tmp_path):
+    ok = types.SimpleNamespace(
+        success=True,
+        label="A",
+        predicted_left_rms_error_db=1.0,
+        predicted_right_rms_error_db=1.2,
+        confidence_label="high",
+        error=None,
+    )
+    bad = types.SimpleNamespace(success=False, label="B", error="boom")
+
+    def fake_run_batch_fit(manifest, spec, *, max_filters, filter_budget, on_progress):
+        on_progress(1, 2, "A")
+        on_progress(2, 2, "B")
+        return [ok, bad]
+
+    monkeypatch.setattr("headmatch.batch.run_batch_fit", fake_run_batch_fit)
+    cli.main(["batch-fit", "--manifest", str(tmp_path / "m.json")])
+    out = capsys.readouterr().out
+    assert "Running batch fit from" in out
+    assert "[1/2] A ..." in out
+    assert "Batch complete: 1 succeeded, 1 failed out of 2." in out
+    assert "A: L=1.00 R=1.20" in out
+    assert "B: boom" in out
+
+
+# ── batch-template (lines 758-762) ───────────────────────────────────────────
+
+
+def test_batch_template_writes_file(monkeypatch, capsys, tmp_path):
+    out_path = tmp_path / "batch_manifest.json"
+    monkeypatch.setattr(
+        "headmatch.batch.generate_manifest_template",
+        lambda out, num_entries: Path(out),
+    )
+    cli.main(["batch-template", "--out", str(out_path), "--entries", "2"])
+    out = capsys.readouterr().out
+    assert f"Template written to {out_path}" in out
+    assert "Edit the entries array" in out
+
+
+# ── history (lines 763-774) ──────────────────────────────────────────────────
+
+
+def test_history_no_runs(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("headmatch.history.load_recent_runs", lambda root, limit: [])
+    cli.main(["history", "--root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "No run_summary.json files found" in out
+
+
+def test_history_lists_runs(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        "headmatch.history.load_recent_runs", lambda root, limit: ["e1", "e2"]
+    )
+    monkeypatch.setattr(
+        "headmatch.history.format_run_entry", lambda entry, index: f"#{index} {entry}"
+    )
+    cli.main(["history", "--root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "Recent runs under" in out
+    assert "#1 e1" in out
+    assert "#2 e2" in out
+
+
+# ── compare-runs (lines 775-785) ─────────────────────────────────────────────
+
+
+def test_compare_runs_needs_two(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr("headmatch.history.load_recent_runs", lambda root, limit: ["only"])
+    cli.main(["compare-runs", "--root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "Need at least 2 runs" in out
+
+
+def test_compare_runs_cannot_build(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        "headmatch.history.load_recent_runs", lambda root, limit: ["a", "b"]
+    )
+    monkeypatch.setattr("headmatch.history.build_run_comparison", lambda runs: None)
+    cli.main(["compare-runs", "--root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "Could not build comparison." in out
+
+
+def test_compare_runs_renders_table(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        "headmatch.history.load_recent_runs", lambda root, limit: ["a", "b"]
+    )
+    monkeypatch.setattr(
+        "headmatch.history.build_run_comparison", lambda runs: "COMP"
+    )
+    monkeypatch.setattr(
+        "headmatch.history.format_comparison_table", lambda comparison: "TABLE-OUT"
+    )
+    cli.main(["compare-runs", "--root", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "TABLE-OUT" in out
+
+
+# ── compare-ab (lines 786-798) ───────────────────────────────────────────────
+
+
+def test_compare_ab_exports_presets(monkeypatch, capsys, tmp_path):
+    export = types.SimpleNamespace(
+        output_dir=str(tmp_path / "ab"),
+        preset_a_apo=Path("A_equalizer_apo.txt"),
+        preset_b_apo=Path("B_equalizer_apo.txt"),
+        preset_a_cdsp=Path("A_camilladsp_full.yaml"),
+        preset_b_cdsp=Path("B_camilladsp_full.yaml"),
+        comparison_json=Path("comparison.json"),
+    )
+    monkeypatch.setattr(
+        "headmatch.ab_compare.build_comparison_pair",
+        lambda a, b, *, label_a, label_b: "PAIR",
+    )
+    monkeypatch.setattr(
+        "headmatch.ab_compare.format_comparison_table", lambda pair: "AB-TABLE"
+    )
+    monkeypatch.setattr(
+        "headmatch.ab_compare.export_ab_comparison", lambda pair, out_dir: export
+    )
+    cli.main(
+        [
+            "compare-ab",
+            "--run-a",
+            str(tmp_path / "a"),
+            "--run-b",
+            str(tmp_path / "b"),
+            "--out-dir",
+            str(tmp_path / "ab"),
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "AB-TABLE" in out
+    assert "Presets exported to" in out
+    assert "A_equalizer_apo.txt" in out
+    assert "comparison.json" in out
+
+
+# ── iterate (lines 799-810) ──────────────────────────────────────────────────
+
+
+def test_iterate_dispatches(monkeypatch, capsys, tmp_path):
+    calls = {}
+    monkeypatch.setattr(
+        "headmatch.pipeline.iterative_measure_and_fit",
+        lambda **kw: calls.update(kw),
+    )
+    cli.main(["iterate", "--out-dir", str(tmp_path / "out")])
+    assert calls["output_dir"] == str(tmp_path / "out")
+    out = capsys.readouterr().out
+    assert "Done. Review outputs in" in out
+
+
+# ── ValueError handler (line 812) ────────────────────────────────────────────
+
+
+def test_value_error_from_handler_exits_with_message(monkeypatch, capsys, tmp_path):
+    def boom(*a, **k):
+        raise ValueError("bad input")
+
+    monkeypatch.setattr("headmatch.pipeline.build_clone_curve", boom)
+    with pytest.raises(SystemExit) as exc:
+        cli.main(
+            [
+                "clone-target",
+                "--source-csv",
+                "s.csv",
+                "--target-csv",
+                "t.csv",
+                "--out",
+                str(tmp_path / "out.csv"),
+            ]
+        )
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "Error: clone-target failed: bad input" in err
+
+
+# ── save_config OSError swallowed (lines 817-818) ────────────────────────────
+
+
+def test_save_config_oserror_is_swallowed(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(
+        "headmatch.measure.render_sweep_file", lambda spec, out: None
+    )
+
+    def raise_oserror(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("headmatch.cli.save_config", raise_oserror)
+    # render-sweep is not in the skip set, so save_config runs; OSError is caught.
+    cli.main(["render-sweep", "--out", str(tmp_path / "sweep.wav")])
+    # No exception propagates; render-sweep has no next-steps output.
+    assert "Traceback" not in capsys.readouterr().out

--- a/tests/test_cli_shortcuts.py
+++ b/tests/test_cli_shortcuts.py
@@ -1,0 +1,136 @@
+"""End-to-end tests for the `create-shortcut` / `remove-shortcut` CLI commands
+and their Linux gate.
+
+These commands are registered in build_parser only on Linux (desktop .desktop
+launchers are an XDG concept). The handlers drive headmatch.desktop, which is
+tested directly in test_desktop.py; here we cover the CLI wiring and the gate.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from headmatch import cli
+from headmatch.contracts import FrontendConfig
+
+
+@pytest.fixture(autouse=True)
+def isolate_cli_config(monkeypatch, tmp_path):
+    """Keep cli.main from touching real config state."""
+    monkeypatch.setattr(
+        "headmatch.cli.load_or_create_config",
+        lambda _path=None: (FrontendConfig(), tmp_path / "config.json", False),
+    )
+    monkeypatch.setattr("headmatch.cli.save_config", lambda *_a, **_k: None)
+
+
+@pytest.fixture
+def fake_apps(tmp_path, monkeypatch):
+    """Point the desktop entry dir at a temp dir so nothing writes to ~/."""
+    apps = tmp_path / "applications"
+    monkeypatch.setattr("headmatch.desktop.DESKTOP_DIR", apps)
+    return apps
+
+
+# ── create-shortcut ──────────────────────────────────────────────────────────
+
+
+def test_create_shortcut_cli_writes_desktop_file(fake_apps, monkeypatch, capsys):
+    monkeypatch.setattr("headmatch.desktop.find_gui_binary", lambda: "/usr/bin/headmatch-gui")
+
+    cli.main(["create-shortcut"])
+
+    desktop_file = fake_apps / "headmatch.desktop"
+    assert desktop_file.exists()
+    content = desktop_file.read_text()
+    assert "Exec=/usr/bin/headmatch-gui" in content
+    assert "Name=HeadMatch" in content
+
+    out = capsys.readouterr().out
+    assert "Desktop shortcut created" in out
+    assert "/usr/bin/headmatch-gui" in out
+
+
+def test_create_shortcut_cli_reports_missing_gui_binary(fake_apps, monkeypatch, capsys):
+    monkeypatch.setattr("headmatch.desktop.find_gui_binary", lambda: None)
+
+    cli.main(["create-shortcut"])
+
+    assert not (fake_apps / "headmatch.desktop").exists()
+    out = capsys.readouterr().out
+    assert "Could not find headmatch-gui" in out
+
+
+# ── remove-shortcut ──────────────────────────────────────────────────────────
+
+
+def test_remove_shortcut_cli_removes_existing(fake_apps, capsys):
+    fake_apps.mkdir(parents=True, exist_ok=True)
+    target = fake_apps / "headmatch.desktop"
+    target.write_text("[Desktop Entry]\n")
+
+    cli.main(["remove-shortcut"])
+
+    assert not target.exists()
+    assert "Desktop shortcut removed" in capsys.readouterr().out
+
+
+def test_remove_shortcut_cli_when_absent(fake_apps, capsys):
+    cli.main(["remove-shortcut"])
+
+    assert "No desktop shortcut found" in capsys.readouterr().out
+
+
+# ── Linux gate ───────────────────────────────────────────────────────────────
+
+
+def test_shortcut_commands_unregistered_off_linux(monkeypatch):
+    """On non-Linux platforms the subcommands are not registered, so argparse
+    rejects them with a SystemExit before any handler runs."""
+    monkeypatch.setattr(cli, "_desktop_shortcuts_supported", lambda: False)
+
+    for cmd in ("create-shortcut", "remove-shortcut"):
+        with pytest.raises(SystemExit):
+            cli.main([cmd])
+
+
+def test_shortcut_commands_registered_on_linux(monkeypatch):
+    monkeypatch.setattr(cli, "_desktop_shortcuts_supported", lambda: True)
+    parser = cli.build_parser(FrontendConfig())
+    # The subparsers action holds the registered command choices.
+    choices = parser.parse_args(["remove-shortcut"]).cmd
+    assert choices == "remove-shortcut"
+
+
+def test_desktop_shortcuts_supported_tracks_platform(monkeypatch):
+    monkeypatch.setattr("headmatch.cli.sys.platform", "linux")
+    assert cli._desktop_shortcuts_supported() is True
+    monkeypatch.setattr("headmatch.cli.sys.platform", "darwin")
+    assert cli._desktop_shortcuts_supported() is False
+    monkeypatch.setattr("headmatch.cli.sys.platform", "win32")
+    assert cli._desktop_shortcuts_supported() is False
+
+
+# ── doctor tip is gated too ──────────────────────────────────────────────────
+
+
+def _patch_doctor_report(monkeypatch):
+    monkeypatch.setattr("headmatch.measure.collect_doctor_checks", lambda path, config: [])
+    monkeypatch.setattr(
+        "headmatch.measure.format_doctor_report",
+        lambda checks, config_path: "HeadMatch doctor report",
+    )
+
+
+def test_doctor_tip_suppressed_off_linux(monkeypatch, capsys):
+    _patch_doctor_report(monkeypatch)
+    monkeypatch.setattr(cli, "_desktop_shortcuts_supported", lambda: False)
+    # find_gui_binary would otherwise trigger the tip; ensure the gate wins.
+    monkeypatch.setattr("headmatch.desktop.find_gui_binary", lambda: "/usr/bin/headmatch-gui")
+
+    cli.main(["doctor"])
+
+    out = capsys.readouterr().out
+    assert "create-shortcut" not in out
+    assert "Desktop shortcut" not in out

--- a/tests/test_desktop_coverage.py
+++ b/tests/test_desktop_coverage.py
@@ -1,0 +1,29 @@
+"""Coverage tests for desktop.py missing lines.
+
+Targets: 31 (which finds the binary), 35 (fallback candidate exists).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from headmatch.desktop import find_gui_binary
+
+
+# ── line 31: shutil.which finds the binary ──
+
+def test_find_gui_binary_via_which():
+    with patch("shutil.which", return_value="/usr/local/bin/headmatch-gui"):
+        assert find_gui_binary() == "/usr/local/bin/headmatch-gui"
+
+
+# ── line 35: which misses, but the sibling-of-python candidate exists ──
+
+def test_find_gui_binary_via_executable_fallback(tmp_path, monkeypatch):
+    fake_bin = tmp_path / "headmatch-gui"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_python = tmp_path / "python"
+    monkeypatch.setattr("headmatch.desktop.sys.executable", str(fake_python))
+    with patch("shutil.which", return_value=None):
+        result = find_gui_binary()
+    assert result == str(fake_bin)

--- a/tests/test_e2e_apo_roundtrip.py
+++ b/tests/test_e2e_apo_roundtrip.py
@@ -1,0 +1,165 @@
+"""End-to-end test for the import-apo -> refine-apo inter-command contract.
+
+An Equalizer APO parametric preset that is imported and then refined against a
+synthetic measurement must still produce a valid APO preset that re-parses
+cleanly through the real importer into a non-empty band list.
+
+All assertions use the production APO parser (``parse_apo_parametric`` /
+``load_apo_preset``) rather than hand-rolled regex so they exercise the real
+round-trip contract.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from headmatch import cli
+from headmatch.apo_import import load_apo_preset, parse_apo_parametric
+
+from tests.test_integration_cli import (
+    _patch_cli_config,
+    _read_json,
+    build_synthetic_recording,
+)
+
+
+# Bands we hand-write into the source preset. Frequencies, gains and Qs are
+# chosen so they survive the importer's "%.1f Hz / %.1f dB / %.2f Q" round-trip
+# without rounding surprises.
+_LEFT_SPEC = [
+    # (kind_token, fc_hz, gain_db, q)
+    ("PK", 120.0, -3.0, 1.00),
+    ("PK", 2500.0, 4.5, 1.40),
+    ("PK", 8000.0, -2.5, 2.80),
+]
+_RIGHT_SPEC = [
+    ("PK", 110.0, -2.0, 0.90),
+    ("PK", 3000.0, 5.0, 1.60),
+    ("PK", 9000.0, -3.0, 3.00),
+]
+
+
+def _write_source_preset(path: Path) -> Path:
+    """Write a known stereo parametric APO preset matching the importer format."""
+    lines = ["; e2e source preset"]
+    for label, spec in [("Channel: L", _LEFT_SPEC), ("Channel: R", _RIGHT_SPEC)]:
+        lines.append(label)
+        lines.append("Preamp: 0.0 dB")
+        for i, (kind, fc, gain, q) in enumerate(spec, start=1):
+            lines.append(
+                f"Filter {i}: ON {kind} Fc {fc:.1f} Hz Gain {gain:.1f} dB Q {q:.2f}"
+            )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_source_preset_parses_to_expected_bands(tmp_path: Path):
+    """Sanity: the hand-written preset matches what the real importer expects.
+
+    Contract: the .txt format we author is exactly the format
+    ``parse_apo_parametric`` reads, so the bands round-trip to the freqs/gains
+    we wrote.
+    """
+    preset = _write_source_preset(tmp_path / "source.txt")
+    left, right = load_apo_preset(preset)
+
+    assert len(left) == len(_LEFT_SPEC)
+    assert len(right) == len(_RIGHT_SPEC)
+    for band, (_, fc, gain, q) in zip(left, _LEFT_SPEC):
+        assert band.kind == "peaking"
+        assert band.freq == fc
+        assert band.gain_db == gain
+        assert band.q == q
+    for band, (_, fc, gain, q) in zip(right, _RIGHT_SPEC):
+        assert band.kind == "peaking"
+        assert band.freq == fc
+        assert band.gain_db == gain
+        assert band.q == q
+
+
+def test_import_then_refine_apo_roundtrip(monkeypatch, tmp_path: Path):
+    """import-apo -> refine-apo inter-command contract.
+
+    1. import-apo converts the source preset; the emitted equalizer_apo.txt
+       re-parses to the same gains/freqs we authored (lossless import).
+    2. refine-apo, fed the SAME source preset plus a synthetic measurement,
+       emits its own equalizer_apo.txt that re-parses cleanly through the real
+       importer into a non-empty stereo band list -- the round-trip contract
+       the two commands must jointly uphold.
+    """
+    _patch_cli_config(monkeypatch, tmp_path)
+    preset = _write_source_preset(tmp_path / "source.txt")
+
+    # --- Step 1: import-apo -------------------------------------------------
+    imp_dir = tmp_path / "imported"
+    cli.main(["import-apo", "--preset", str(preset), "--out-dir", str(imp_dir)])
+
+    # Converted artifacts written by the import-apo handler.
+    imported_apo = imp_dir / "equalizer_apo.txt"
+    assert imported_apo.exists()
+    assert (imp_dir / "camilladsp_full.yaml").exists()
+    assert (imp_dir / "camilladsp_filters_only.yaml").exists()
+
+    # Imported bands round-trip back to what we authored, via the real parser.
+    imp_left, imp_right = load_apo_preset(imported_apo)
+    assert len(imp_left) == len(_LEFT_SPEC)
+    assert len(imp_right) == len(_RIGHT_SPEC)
+    for band, (_, fc, gain, q) in zip(imp_left, _LEFT_SPEC):
+        assert band.kind == "peaking"
+        assert band.freq == fc
+        assert band.gain_db == gain
+        assert band.q == q
+    for band, (_, fc, gain, q) in zip(imp_right, _RIGHT_SPEC):
+        assert band.freq == fc
+        assert band.gain_db == gain
+        assert band.q == q
+
+    # --- Step 2: refine-apo against a synthetic measurement -----------------
+    recording, spec = build_synthetic_recording(tmp_path)
+    ref_dir = tmp_path / "refined"
+    cli.main(
+        [
+            "refine-apo",
+            "--preset",
+            str(preset),
+            "--recording",
+            str(recording),
+            "--out-dir",
+            str(ref_dir),
+            "--sample-rate",
+            str(spec.sample_rate),
+            "--duration",
+            str(spec.duration_s),
+            "--pre-silence",
+            str(spec.pre_silence_s),
+            "--post-silence",
+            str(spec.post_silence_s),
+            "--amplitude",
+            str(spec.amplitude),
+        ]
+    )
+
+    # Refine artifacts produced by refine_apo_preset.
+    refined_apo = ref_dir / "equalizer_apo.txt"
+    assert refined_apo.exists()
+    assert (ref_dir / "camilladsp_full.yaml").exists()
+    assert (ref_dir / "fit_overview.svg").exists()
+
+    summary = _read_json(ref_dir / "run_summary.json")
+    report = _read_json(ref_dir / "fit_report.json")
+    assert report["mode"] == "refine"
+    assert report["left_bands"], "refine produced no left bands"
+    assert report["right_bands"], "refine produced no right bands"
+
+    # --- The round-trip contract: refined preset re-parses cleanly ----------
+    ref_left, ref_right = parse_apo_parametric(refined_apo.read_text(encoding="utf-8"))
+    assert ref_left, "refined equalizer_apo.txt re-parsed to an empty left chain"
+    assert ref_right, "refined equalizer_apo.txt re-parsed to an empty right chain"
+
+    # The re-parsed text must agree with the structured report the command
+    # wrote: same number of bands per channel, all valid PEQ types.
+    assert len(ref_left) == len(report["left_bands"])
+    assert len(ref_right) == len(report["right_bands"])
+    for band in ref_left + ref_right:
+        assert band.kind in ("peaking", "lowshelf", "highshelf")
+        assert band.freq > 0
+        assert band.q > 0

--- a/tests/test_e2e_batch.py
+++ b/tests/test_e2e_batch.py
@@ -1,0 +1,128 @@
+"""End-to-end test of the batch-fit workflow via the CLI.
+
+A JSON manifest listing two genuinely different synthetic recordings (one
+HD 650-colored, one HD 800S-colored) is processed in a single `batch-fit`
+run.  The test proves that:
+
+- a consolidated ``batch_summary.json`` is written next to the manifest and
+  lists both entries with success status, and
+- each entry gets its own output folder with the standard EQ exports AND a
+  correcting EQ (predicted error after the fit is lower than before).
+
+It also checks that ``batch-template`` writes a parseable manifest template.
+
+No hardware / network / real home (conftest sandboxes HOME/XDG); everything
+is synthesised from a deterministic log sweep.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from headmatch import cli
+from headmatch.io_utils import write_wav
+
+from tests.test_integration_cli import (
+    _patch_cli_config,
+    _predicted_errors,
+    _read_json,
+    _synthetic_sweep_spec,
+)
+from tests.test_e2e_fitting import (
+    HD650_CSV,
+    HD800S_CSV,
+    _inject_headset_channels,
+)
+
+
+def _write_synthetic_recording(path: Path, spec, csv_path: Path) -> None:
+    """Write a stereo recording colored by a real published headphone curve."""
+    recording, _curve = _inject_headset_channels(spec, csv_path)
+    write_wav(path, recording, spec.sample_rate)
+
+
+def _sweep_args(spec) -> list[str]:
+    return [
+        "--sample-rate", str(spec.sample_rate),
+        "--duration", str(spec.duration_s),
+        "--pre-silence", str(spec.pre_silence_s),
+        "--post-silence", str(spec.post_silence_s),
+        "--amplitude", str(spec.amplitude),
+    ]
+
+
+def test_batch_fit_cli_end_to_end_corrects_every_entry(monkeypatch, tmp_path: Path):
+    spec = _synthetic_sweep_spec()
+    _patch_cli_config(monkeypatch, tmp_path)
+
+    # Two genuinely distinct recordings: HD 650 vs HD 800S coloration.
+    rec_hd650 = tmp_path / "hd650" / "recording.wav"
+    rec_hd800s = tmp_path / "hd800s" / "recording.wav"
+    rec_hd650.parent.mkdir(parents=True, exist_ok=True)
+    rec_hd800s.parent.mkdir(parents=True, exist_ok=True)
+    _write_synthetic_recording(rec_hd650, spec, HD650_CSV)
+    _write_synthetic_recording(rec_hd800s, spec, HD800S_CSV)
+
+    # Manifest with relative paths, resolved against the manifest's parent.
+    # target_csv=null means a flat target.
+    manifest = tmp_path / "batch_manifest.json"
+    entries = [
+        {"recording": "hd650/recording.wav", "out_dir": "hd650/fit", "target_csv": None, "label": "HD650"},
+        {"recording": "hd800s/recording.wav", "out_dir": "hd800s/fit", "target_csv": None, "label": "HD800S"},
+    ]
+    manifest.write_text(json.dumps({"entries": entries}, indent=2), encoding="utf-8")
+
+    cli.main(["batch-fit", "--manifest", str(manifest), *_sweep_args(spec), "--max-filters", "5"])
+
+    # (1) Consolidated summary written next to the manifest.
+    summary_path = tmp_path / "batch_summary.json"
+    assert summary_path.exists(), "batch_summary.json not written next to manifest"
+    summary = _read_json(summary_path)
+    assert summary["total"] == 2
+    assert summary["succeeded"] == 2
+    assert summary["failed"] == 0
+
+    results = summary["results"]
+    assert {r["label"] for r in results} == {"HD650", "HD800S"}
+    for r in results:
+        assert r["success"] is True
+        assert r["error"] is None
+        assert r["predicted_left_rms_error_db"] is not None
+        assert r["predicted_right_rms_error_db"] is not None
+
+    # (2) Each entry's output folder has the standard exports AND a correcting EQ.
+    for label, out_dir in (("HD650", tmp_path / "hd650" / "fit"), ("HD800S", tmp_path / "hd800s" / "fit")):
+        for name in ("equalizer_apo.txt", "equalizer_apo_graphiceq.txt", "measurement_left.csv", "fit_report.json"):
+            assert (out_dir / name).exists(), f"{label}: missing {name}"
+
+        errs = _predicted_errors(out_dir, spec.sample_rate)
+        assert errs["left_after"] < errs["left_before"], (
+            f"{label}: left EQ did not correct ({errs['left_after']:.2f} >= {errs['left_before']:.2f})"
+        )
+        assert errs["right_after"] < errs["right_before"], (
+            f"{label}: right EQ did not correct ({errs['right_after']:.2f} >= {errs['right_before']:.2f})"
+        )
+
+        # The summary's predicted error matches the entry's actual fit report.
+        report = _read_json(out_dir / "fit_report.json")
+        result = next(r for r in results if r["label"] == label)
+        assert abs(result["predicted_left_rms_error_db"] - report["predicted_left_rms_error_db"]) < 1e-6
+        assert abs(result["predicted_right_rms_error_db"] - report["predicted_right_rms_error_db"]) < 1e-6
+
+
+def test_batch_template_cli_writes_parseable_manifest(monkeypatch, tmp_path: Path):
+    _patch_cli_config(monkeypatch, tmp_path)
+    template_path = tmp_path / "template.json"
+
+    cli.main(["batch-template", "--out", str(template_path), "--entries", "2"])
+
+    assert template_path.exists()
+    data = _read_json(template_path)
+    assert "_comment" in data
+    assert isinstance(data["entries"], list)
+    assert len(data["entries"]) == 2
+    for entry in data["entries"]:
+        assert "recording" in entry
+        assert "out_dir" in entry
+        assert "target_csv" in entry
+        assert "label" in entry

--- a/tests/test_e2e_compare.py
+++ b/tests/test_e2e_compare.py
@@ -1,0 +1,190 @@
+"""End-to-end tests for the compare-runs and compare-ab workflows.
+
+These exercise the real CLI: two completed `fit` runs (built from two
+distinct synthesised headphone recordings) are produced under a shared
+root, then:
+
+- ``compare-runs`` must print a side-by-side table that references both
+  run folders and their predicted-error metrics (cross-checked against
+  each run's ``run_summary.json``).
+- ``compare-ab`` must export paired A_/B_ prefixed presets that each
+  re-import cleanly through the real Equalizer APO parser into a
+  non-empty band list (the round-trip contract), plus a sensible
+  ``comparison.json`` verdict artifact.
+
+No hardware, network, or real home directory is used: recordings are
+synthesised from published headphone curves, and the autouse conftest
+fixture sandboxes HOME / XDG_CONFIG_HOME.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from headmatch import cli
+from headmatch.apo_import import load_apo_preset
+
+from tests.test_integration_cli import (
+    _patch_cli_config,
+    _read_json,
+    _synthetic_sweep_spec,
+    flat_target_csv,
+)
+from tests.test_e2e_fitting import (
+    HD650_CSV,
+    HD800S_CSV,
+    _inject_headset_channels,
+)
+from headmatch.io_utils import write_wav
+
+
+def _make_recording(tmp_path: Path, csv_path: Path, name: str) -> Path:
+    """Synthesise a stereo recording coloured by a published headphone curve."""
+    spec = _synthetic_sweep_spec()
+    recording, _ = _inject_headset_channels(spec, csv_path)
+    path = tmp_path / name
+    write_wav(path, recording, spec.sample_rate)
+    return path
+
+
+def _run_fit(monkeypatch, tmp_path: Path, out_dir: Path, recording: Path, max_filters: int) -> None:
+    """Invoke the real `fit` CLI into out_dir, producing a full run."""
+    spec = _synthetic_sweep_spec()
+    _patch_cli_config(monkeypatch, tmp_path)
+    cli.main(
+        [
+            "fit",
+            "--recording", str(recording),
+            "--out-dir", str(out_dir),
+            "--target-csv", str(flat_target_csv()),
+            "--sample-rate", str(spec.sample_rate),
+            "--duration", str(spec.duration_s),
+            "--pre-silence", str(spec.pre_silence_s),
+            "--post-silence", str(spec.post_silence_s),
+            "--amplitude", str(spec.amplitude),
+            "--max-filters", str(max_filters),
+        ]
+    )
+
+
+def _make_two_runs(monkeypatch, tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Produce two distinct completed fit runs under a shared root.
+
+    Returns (root, run_a_dir, run_b_dir). The two runs differ both in
+    their source headphone curve (HD 650 vs HD 800S) and in their filter
+    budget, so their summaries and presets genuinely diverge.
+    """
+    root = tmp_path / "runs"
+    root.mkdir()
+
+    rec_a = _make_recording(tmp_path, HD650_CSV, "rec_a.wav")
+    rec_b = _make_recording(tmp_path, HD800S_CSV, "rec_b.wav")
+
+    run_a = root / "run_a"
+    run_b = root / "run_b"
+    _run_fit(monkeypatch, tmp_path, run_a, rec_a, max_filters=6)
+    _run_fit(monkeypatch, tmp_path, run_b, rec_b, max_filters=4)
+    return root, run_a, run_b
+
+
+def test_compare_runs_tabulates_both_runs(monkeypatch, tmp_path, capsys):
+    root, run_a, run_b = _make_two_runs(monkeypatch, tmp_path)
+
+    summary_a = _read_json(run_a / "run_summary.json")
+    summary_b = _read_json(run_b / "run_summary.json")
+
+    # Sanity: each fit produced its own summary and exports.
+    assert summary_a["kind"] == "fit"
+    assert summary_b["kind"] == "fit"
+    assert (run_a / "equalizer_apo.txt").exists()
+    assert (run_b / "equalizer_apo.txt").exists()
+
+    capsys.readouterr()  # discard fit output
+    cli.main(["compare-runs", "--root", str(root)])
+    out = capsys.readouterr().out
+
+    # The table is a side-by-side comparison referencing both run folders.
+    assert "Side-by-side comparison" in out
+    assert summary_a["out_dir"] in out
+    assert summary_b["out_dir"] in out
+
+    # A predicted-error row is present.
+    assert "Predicted error" in out
+
+    # Cross-check at least one actual metric from each run's summary appears
+    # in the rendered table (history formats RMS to 2 decimals).
+    a_left_rms = f"{summary_a['predicted_error_db']['left_rms']:.2f}"
+    b_left_rms = f"{summary_b['predicted_error_db']['left_rms']:.2f}"
+    assert f"L rms {a_left_rms}" in out
+    assert f"L rms {b_left_rms}" in out
+
+    # Both runs' filter counts are surfaced.
+    assert "Filters (L/R)" in out
+
+
+def test_compare_ab_exports_paired_presets_that_reimport(monkeypatch, tmp_path, capsys):
+    root, run_a, run_b = _make_two_runs(monkeypatch, tmp_path)
+
+    summary_a = _read_json(run_a / "run_summary.json")
+    summary_b = _read_json(run_b / "run_summary.json")
+
+    ab_out = tmp_path / "ab"
+    _patch_cli_config(monkeypatch, tmp_path)
+    capsys.readouterr()  # discard prior output
+    cli.main(
+        [
+            "compare-ab",
+            "--run-a", str(run_a),
+            "--run-b", str(run_b),
+            "--label-a", "A",
+            "--label-b", "B",
+            "--out-dir", str(ab_out),
+        ]
+    )
+    out = capsys.readouterr().out
+
+    # The command prints the A/B comparison table with a verdict.
+    assert "A/B Comparison: A vs B" in out
+    assert "Verdict:" in out
+
+    # Exact A_/B_ prefixed preset filenames (per ab_compare._copy_preset).
+    preset_a = ab_out / "A_equalizer_apo.txt"
+    preset_b = ab_out / "B_equalizer_apo.txt"
+    assert preset_a.exists(), "expected A_equalizer_apo.txt"
+    assert preset_b.exists(), "expected B_equalizer_apo.txt"
+    # CamillaDSP presets are also paired.
+    assert (ab_out / "A_camilladsp_full.yaml").exists()
+    assert (ab_out / "B_camilladsp_full.yaml").exists()
+
+    # Round-trip contract: each exported APO preset re-imports cleanly through
+    # the real parser into a non-empty band list.
+    for preset in (preset_a, preset_b):
+        left_bands, right_bands = load_apo_preset(preset)
+        assert left_bands, f"{preset.name} parsed into zero left bands"
+        assert right_bands, f"{preset.name} parsed into zero right bands"
+        for band in left_bands + right_bands:
+            assert band.kind in ("peaking", "lowshelf", "highshelf")
+            assert band.freq > 0
+            assert band.q > 0
+
+    # Verdict / summary artifact is written and sensible.
+    comparison_json = ab_out / "comparison.json"
+    assert comparison_json.exists(), "expected comparison.json verdict artifact"
+    data = _read_json(comparison_json)
+    assert data["label_a"] == "A"
+    assert data["label_b"] == "B"
+    assert data["run_a_dir"] == str(run_a)
+    assert data["run_b_dir"] == str(run_b)
+
+    # The artifact cross-checks against each run's own run_summary.json.
+    cmp = data["comparison"]
+    assert cmp["target"]["a"] == summary_a["target"]
+    assert cmp["target"]["b"] == summary_b["target"]
+    assert cmp["predicted_error_left_rms"]["a"] == summary_a["predicted_error_db"]["left_rms"]
+    assert cmp["predicted_error_right_rms"]["b"] == summary_b["predicted_error_db"]["right_rms"]
+    assert cmp["filters_left"]["a"] == summary_a["filters"]["left"]
+    assert cmp["filters_right"]["b"] == summary_b["filters"]["right"]
+
+    # Usage instructions reference the exact exported preset names.
+    instructions = "\n".join(data["instructions"])
+    assert "A_equalizer_apo.txt" in instructions
+    assert "B_equalizer_apo.txt" in instructions

--- a/tests/test_e2e_hearing_chain.py
+++ b/tests/test_e2e_hearing_chain.py
@@ -1,0 +1,179 @@
+"""End-to-end test of the hearing-test -> hearing-fit inter-command contract.
+
+This proves that a hearing profile *written* by the ``headmatch hearing-test``
+CLI command is correctly *read* and consumed by the ``headmatch hearing-fit``
+CLI command to produce a compensation EQ. Both commands are driven through the
+real ``cli.main([...])`` entry point in the same test, so the file that
+hearing-fit loads is exactly the one hearing-test persisted (the conftest
+autouse fixture sandboxes HOME/XDG_CONFIG_HOME, so the config-dir profile
+survives between the two cli.main calls).
+
+Chosen seam (and why)
+---------------------
+The interactive runner ``run_cli_hearing_test`` obtains each per-frequency
+threshold from ``hearing_test.ThresholdEngine`` (a Hughson-Westlake staircase
+driven by tone playback + Enter-press responses). Rather than mock playback,
+stdin, timers, AND choreograph a heard/not-heard response sequence that makes
+the *real* engine converge on a chosen level per frequency (brittle and
+frequency-coupled), we monkeypatch the single seam the CLI uses to obtain a
+threshold: ``ThresholdEngine``. Our fake engine reports, for each frequency, a
+threshold equal to ``NORMAL_HEARING_REFERENCE[f] + presbycusis_loss[f]`` and
+converges on the first response. This still exercises the genuine CLI
+profile-WRITE path end to end -- ``run_cli_hearing_test`` orchestration,
+``averaged_frequency_threshold``, ``HearingProfile`` assembly, and
+``save_hearing_profile`` to ``hearing_profile_path()`` -- without real audio,
+stdin, or home. We additionally neutralise tone generation, the response
+window, sleeps, stdin and catch trials so the run is deterministic and fast.
+
+The contract crux: the profile is NEVER written via the API in this test. It is
+produced solely by the hearing-test CLI run, and hearing-fit reads it back via
+its own CLI run (``load_hearing_profile``).
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from headmatch import cli
+from headmatch import hearing_test as ht_mod
+from headmatch.hearing_test import (
+    MAX_COMPENSATION_DB,
+    NORMAL_HEARING_REFERENCE,
+    TEST_FREQUENCIES,
+    hearing_profile_path,
+)
+
+
+# A representative middle-aged (presbycusis) audiogram, mirroring
+# tests/test_e2e_fitting.py: gentle low-frequency loss sloping to a moderate
+# high-frequency loss (dB above the normal reference).
+_PRESBYCUSIS_LOSS_DB = {250: 4, 500: 5, 1000: 8, 2000: 13, 3000: 22, 4000: 32, 6000: 40, 8000: 48}
+
+
+class _PresbycusisEngine:
+    """Stand-in for ht_mod.ThresholdEngine that converges immediately on a
+    presbycusis threshold for its frequency.
+
+    The runner constructs it as ``ThresholdEngine(freq_hz, start_level_dbfs=...)``,
+    plays a tone, calls ``record_response(heard)`` until ``done``, then reads
+    ``threshold`` / ``converged`` / ``floored`` / ``ascending_run_count``.
+    Louder (less negative dBFS) threshold == worse hearing, so high frequencies
+    get the larger loss and therefore the higher (worse) threshold.
+    """
+
+    def __init__(self, freq_hz, start_level_dbfs=-20.0):
+        self.freq_hz = freq_hz
+        loss = _PRESBYCUSIS_LOSS_DB.get(freq_hz, 0.0)
+        self._threshold = NORMAL_HEARING_REFERENCE[freq_hz] + loss
+        self.current_level_dbfs = self._threshold
+        self.threshold = self._threshold
+        self.ascending_run_count = 3
+        self.converged = True
+        self.floored = False
+        self.done = False
+
+    def record_response(self, _heard):
+        # Converge on the first presentation; no real staircase needed.
+        self.done = True
+
+
+class _SilentBackend:
+    """Audio backend stub: counts play_tone calls, emits nothing."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def play_tone(self, *a, **k):
+        self.calls += 1
+
+
+@pytest.fixture
+def patched_hearing_test(monkeypatch):
+    """Make cli.main(["hearing-test", ...]) deterministic and audio/stdin-free
+    while still exercising the genuine profile-write path."""
+    monkeypatch.setattr(ht_mod, "ThresholdEngine", _PresbycusisEngine)
+    # No real synthesis, no real audio device.
+    monkeypatch.setattr(ht_mod, "generate_tone_train", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod, "generate_silence", lambda *a, **k: [0.0])
+    monkeypatch.setattr(
+        "headmatch.audio_backend.get_audio_backend", lambda *a, **k: _SilentBackend()
+    )
+    # No waiting: zero response window, no jitter sleeps, never insert catches.
+    monkeypatch.setattr(ht_mod, "RESPONSE_WINDOW_S", 0.0)
+    monkeypatch.setattr(ht_mod.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(ht_mod, "should_insert_catch", lambda *a, **k: False)
+    # No interactive stdin.
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+
+
+def test_hearing_test_cli_writes_presbycusis_profile(patched_hearing_test):
+    """Step 1: the hearing-test CLI writes a profile reflecting the simulated
+    sloping high-frequency loss."""
+    profile_path = hearing_profile_path()
+    assert not profile_path.exists()
+
+    rc = cli.main(["hearing-test"])
+    assert rc in (0, None)
+
+    # The CLI persisted a profile file at the canonical config-dir location.
+    assert profile_path.exists(), f"hearing-test did not write {profile_path}"
+
+    saved = json.loads(profile_path.read_text(encoding="utf-8"))
+    left = {int(f): t["level_dbfs"] for f, t in saved["left"].items()}
+    # Every tested frequency was determined.
+    assert set(left) == set(TEST_FREQUENCIES)
+    # High-frequency threshold is worse (louder / less negative dBFS) than low.
+    assert left[8000] > left[250], (
+        f"expected sloping HF loss: 8 kHz {left[8000]} should be worse than 250 Hz {left[250]}"
+    )
+    # Monotone-ish slope: 4 kHz worse than 1 kHz too.
+    assert left[4000] > left[1000]
+
+
+def test_hearing_fit_cli_consumes_profile_and_boosts_high_frequencies(
+    patched_hearing_test, tmp_path
+):
+    """Steps 1-3 (the full contract): hearing-test writes the profile, then
+    hearing-fit -- WITHOUT recreating it -- loads that very file and produces a
+    high-frequency-weighted compensation EQ within the compensation cap."""
+    # --- Step 1: hearing-test CLI writes the profile. ---
+    assert cli.main(["hearing-test"]) in (0, None)
+    profile_path = hearing_profile_path()
+    assert profile_path.exists()
+    written_bytes = profile_path.read_bytes()
+
+    # --- Step 2 & 3: hearing-fit CLI reads it back (no API write here). ---
+    out_dir = tmp_path / "hearing_fit_out"
+    rc = cli.main(["hearing-fit", "--out-dir", str(out_dir)])
+    assert rc in (0, None)
+
+    # hearing-fit must not have rewritten the source profile -- it only reads it.
+    assert profile_path.read_bytes() == written_bytes
+
+    # All expected EQ artifacts written by hearing-fit.
+    for name in ("equalizer_apo.txt", "equalizer_apo_graphiceq.txt", "hearing_fit_report.json"):
+        assert (out_dir / name).exists(), f"hearing-fit did not write {name}"
+
+    report = json.loads((out_dir / "hearing_fit_report.json").read_text(encoding="utf-8"))
+    assert report["mode"] == "hearing_only"
+    bands = report["left_bands"]
+    assert bands, "expected compensation bands for presbycusis"
+
+    by_freq = {round(b["freq"]): b["gain_db"] for b in bands}
+    # Compensation boosts high frequencies more than low (sloping loss).
+    assert max(by_freq) >= 6000
+    assert by_freq[max(by_freq)] > by_freq[min(by_freq)], (
+        f"expected HF boost > LF boost, got {by_freq}"
+    )
+    # All gains respect the compensation cap.
+    assert all(b["gain_db"] <= MAX_COMPENSATION_DB + 1e-6 for b in bands)
+
+    # Record the observed high-vs-low boost for the test report.
+    print(
+        f"hearing-fit boost: low {by_freq[min(by_freq)]:.2f} dB @ {min(by_freq)} Hz, "
+        f"high {by_freq[max(by_freq)]:.2f} dB @ {max(by_freq)} Hz"
+    )

--- a/tests/test_e2e_offline_workflow.py
+++ b/tests/test_e2e_offline_workflow.py
@@ -1,0 +1,127 @@
+"""End-to-end test of the offline workflow contract:
+
+    prepare-offline  ->  analyze  ->  fit
+
+`prepare-offline` writes a sweep WAV plus a `measurement_plan.json` describing
+the exact sweep parameters used. The user records the played sweep on external
+gear, and that recording must feed `analyze` (recovering the headphone
+response) and `fit` (producing a correcting EQ) -- all driven by the parameters
+learned from the metadata. This test proves that inter-command contract on
+synthetic data with known ground truth (a real published HD 650 response
+injected onto the prepared sweep), so no hardware/network is needed.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from headmatch import cli
+from headmatch.io_utils import load_fr_csv, write_wav
+from headmatch.signals import SweepSpec
+
+from tests.test_integration_cli import (
+    _patch_cli_config,
+    _predicted_errors,
+    _read_json,
+    _synthetic_sweep_spec,
+    flat_target_csv,
+)
+from tests.test_e2e_fitting import HD650_CSV, _inject_headset_channels
+
+
+def _normalize_at_1k(freqs: np.ndarray, values: np.ndarray) -> np.ndarray:
+    return values - values[int(np.argmin(np.abs(freqs - 1000.0)))]
+
+
+def _sweep_args(spec: SweepSpec) -> list[str]:
+    """CLI sweep flags reconstructed from a SweepSpec (as learned from metadata)."""
+    return [
+        "--sample-rate", str(spec.sample_rate),
+        "--duration", str(spec.duration_s),
+        "--f-start", str(spec.f_start),
+        "--f-end", str(spec.f_end),
+        "--pre-silence", str(spec.pre_silence_s),
+        "--post-silence", str(spec.post_silence_s),
+        "--amplitude", str(spec.amplitude),
+    ]
+
+
+def test_offline_workflow_prepare_analyze_fit_contract(monkeypatch, tmp_path):
+    spec = _synthetic_sweep_spec()
+    _patch_cli_config(monkeypatch, tmp_path)
+
+    # ── 1. prepare-offline: write the sweep package, then inspect what it wrote.
+    prep_dir = tmp_path / "session"
+    cli.main(["prepare-offline", "--out-dir", str(prep_dir), "--notes", "e2e", *_sweep_args(spec)])
+
+    metadata = _read_json(prep_dir / "measurement_plan.json")
+    assert metadata["mode"] == "offline"
+    # The metadata names the sweep WAV it produced, and that file exists.
+    sweep_wav = prep_dir / "sweep.wav"
+    assert sweep_wav.exists()
+    assert metadata["files"]["sweep_wav"] == str(sweep_wav)
+
+    # Contract: the recorded sweep parameters in the metadata match what we passed,
+    # and the recommended capture format matches the sweep sample rate.
+    recorded = metadata["sweep"]
+    assert recorded["sample_rate"] == spec.sample_rate
+    assert recorded["duration_s"] == spec.duration_s
+    assert recorded["f_start"] == spec.f_start
+    assert recorded["f_end"] == spec.f_end
+    assert recorded["pre_silence_s"] == spec.pre_silence_s
+    assert recorded["post_silence_s"] == spec.post_silence_s
+    assert recorded["amplitude"] == spec.amplitude
+    assert metadata["recommended_format"]["sample_rate"] == spec.sample_rate
+
+    # Rebuild the SweepSpec purely from the metadata: downstream commands are
+    # driven by what prepare-offline declared, not by our local `spec`.
+    learned = SweepSpec(**recorded)
+    assert learned == spec
+
+    # ── 2. Synthesise "the user recording the played sweep": the prepared sweep
+    #       colored by a real published HD 650 response, written at the metadata
+    #       sample rate.
+    recording, (inj_f, inj_g) = _inject_headset_channels(learned, HD650_CSV)
+    recording_path = prep_dir / "recording.wav"
+    write_wav(recording_path, recording, learned.sample_rate)
+
+    # ── 3. analyze with the SAME params learned from the metadata.
+    analyze_dir = tmp_path / "analysis"
+    cli.main([
+        "analyze",
+        "--recording", str(recording_path),
+        "--out-dir", str(analyze_dir),
+        *_sweep_args(learned),
+    ])
+
+    assert (analyze_dir / "measurement_left.csv").exists()
+    assert (analyze_dir / "measurement_right.csv").exists()
+
+    # Contract: the analyzed response recovers the injected HD 650 shape
+    # (1 kHz-normalised RMS deviation over ~120-7000 Hz below a few dB).
+    freqs, left = load_fr_csv(analyze_dir / "measurement_left.csv")
+    inj_on_grid = np.interp(np.log10(freqs), np.log10(inj_f), inj_g, left=inj_g[0], right=inj_g[-1])
+    band = (freqs >= 120) & (freqs <= 7000)
+    recovered = _normalize_at_1k(freqs, left)[band]
+    injected = _normalize_at_1k(freqs, inj_on_grid)[band]
+    recovered_rms = float(np.sqrt(np.mean((recovered - injected) ** 2)))
+    assert recovered_rms < 4.0, f"analyze recovered {recovered_rms:.2f} dB RMS off the injected HD650 curve"
+
+    # ── 4. fit the same recording (flat target), again driven by the metadata params.
+    fit_dir = tmp_path / "fit"
+    cli.main([
+        "fit",
+        "--recording", str(recording_path),
+        "--out-dir", str(fit_dir),
+        "--target-csv", str(flat_target_csv()),
+        *_sweep_args(learned),
+        "--max-filters", "5",
+    ])
+
+    # Contract: the fitted EQ reduces predicted error for both channels.
+    errs = _predicted_errors(fit_dir, learned.sample_rate)
+    assert errs["left_after"] < errs["left_before"], errs
+    assert errs["right_after"] < errs["right_before"], errs
+
+    # Contract: standard exports are written.
+    assert (fit_dir / "equalizer_apo.txt").exists()
+    assert (fit_dir / "equalizer_apo_graphiceq.txt").exists()

--- a/tests/test_exporters_coverage.py
+++ b/tests/test_exporters_coverage.py
@@ -1,0 +1,19 @@
+"""Coverage tests for headmatch.exporters edge branches."""
+from __future__ import annotations
+
+import headmatch.exporters as exporters
+
+
+class TestShelfSToQNonPositiveInner:
+    def test_returns_default_q_when_inner_non_positive(self, monkeypatch):
+        """_shelf_s_to_q returns 0.707 when the RBJ inner term is <= 0 (line 38).
+
+        For all valid inputs ``s`` is clamped to [0.1, 1.0], which keeps
+        ``(1/s - 1) >= 0`` and therefore ``inner >= 2`` — the guard is defensive.
+        To exercise it deterministically we shadow the module-level ``min`` so the
+        upper clamp is defeated, letting ``s`` exceed 1.0 (making ``1/s - 1`` < 0).
+        With a large gain ``A`` grows enough that ``inner`` goes non-positive.
+        """
+        monkeypatch.setattr(exporters, "min", lambda *a, **k: 2.0, raising=False)
+        result = exporters._shelf_s_to_q(2.0, 30.0)
+        assert result == 0.707

--- a/tests/test_headphone_db_coverage.py
+++ b/tests/test_headphone_db_coverage.py
@@ -1,0 +1,181 @@
+"""Coverage tests for headphone_db.py missing lines.
+
+Targets: 32-33, 37, 98-99, 103, 133-137, 201, 227, 239-258.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import headmatch.headphone_db as hdb
+from headmatch.headphone_db import (
+    _cache_dir,
+    _fetch_and_cache_index,
+    _get_index,
+    _index_cache_path,
+    _parse_autoeq_csv,
+    fetch_curve_from_url,
+)
+
+
+def _mock_resp(raw: bytes) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = raw
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ── lines 32-33, 37: _cache_dir / _index_cache_path delegate to paths ──
+
+def test_cache_dir_delegates_to_paths(tmp_path):
+    fake = tmp_path / "cache"
+    fake.mkdir()
+    with patch("headmatch.paths.cache_dir", return_value=fake):
+        assert _cache_dir() == fake
+
+
+def test_index_cache_path_uses_cache_dir(tmp_path):
+    fake = tmp_path / "cache"
+    fake.mkdir()
+    with patch("headmatch.paths.cache_dir", return_value=fake):
+        assert _index_cache_path() == fake / "autoeq_index.json"
+
+
+# ── lines 98-99: _fetch_and_cache_index network failure ──
+
+def test_fetch_index_connection_error():
+    from urllib.error import URLError
+
+    with patch("headmatch.headphone_db.urlopen", side_effect=URLError("down")):
+        with pytest.raises(ConnectionError, match="Failed to fetch AutoEQ index"):
+            _fetch_and_cache_index()
+
+
+# ── line 103: _fetch_and_cache_index empty tree raises ValueError ──
+
+def test_fetch_index_empty_tree_raises():
+    resp = _mock_resp(json.dumps({"tree": []}).encode("utf-8"))
+    with patch("headmatch.headphone_db.urlopen", return_value=resp):
+        with pytest.raises(ValueError, match="No headphone entries"):
+            _fetch_and_cache_index()
+
+
+# ── lines 105-112 (success) + 133-137: _get_index cache hit & refresh ──
+
+def test_fetch_index_success_writes_cache(tmp_path):
+    cache_file = tmp_path / "autoeq_index.json"
+    tree = {
+        "tree": [
+            {"path": "results/oratory1990/over-ear/Model X/Model X.csv", "type": "blob"},
+        ]
+    }
+    resp = _mock_resp(json.dumps(tree).encode("utf-8"))
+    with patch("headmatch.headphone_db.urlopen", return_value=resp), patch(
+        "headmatch.headphone_db._index_cache_path", return_value=cache_file
+    ):
+        entries = _fetch_and_cache_index()
+    assert len(entries) == 1
+    assert cache_file.exists()
+    cached = json.loads(cache_file.read_text())
+    assert cached["count"] == 1
+
+
+def test_get_index_returns_cached_when_present():
+    sentinel = [{"name": "X", "source": "s", "form_factor": "f", "csv_path": "results/a/b/X/X.csv"}]
+    with patch("headmatch.headphone_db._load_cached_index", return_value=sentinel):
+        assert _get_index() is sentinel
+
+
+def test_get_index_fetches_when_no_cache():
+    fetched = [{"name": "Y", "source": "s", "form_factor": "f", "csv_path": "results/a/b/Y/Y.csv"}]
+    with patch("headmatch.headphone_db._load_cached_index", return_value=None), patch(
+        "headmatch.headphone_db._fetch_and_cache_index", return_value=fetched
+    ):
+        assert _get_index() == fetched
+
+
+def test_get_index_force_refresh_skips_cache():
+    fetched = [{"name": "Z", "source": "s", "form_factor": "f", "csv_path": "results/a/b/Z/Z.csv"}]
+    with patch("headmatch.headphone_db._load_cached_index") as mock_cache, patch(
+        "headmatch.headphone_db._fetch_and_cache_index", return_value=fetched
+    ):
+        result = _get_index(force_refresh=True)
+    assert result == fetched
+    mock_cache.assert_not_called()
+
+
+# ── line 201: _parse_autoeq_csv skips blank rows ──
+
+def test_parse_csv_skips_blank_rows():
+    text = "\n100,0.5\n\n   \n1000,1.0\n"
+    freqs, values = _parse_autoeq_csv(text)
+    assert len(freqs) == 2
+
+
+# ── fetch_curve_from_url: lines 227, 239-258 ──
+
+def test_fetch_rejects_oversized_response(tmp_path):
+    # Return more than MAX_RESPONSE_BYTES so the size check trips (line 227).
+    big = b"x" * (hdb.MAX_RESPONSE_BYTES + 1)
+    resp = _mock_resp(big)
+    with patch("headmatch.headphone_db.urlopen", return_value=resp):
+        with pytest.raises(ValueError, match="exceeds"):
+            fetch_curve_from_url("https://example.com/big.csv", tmp_path / "out.csv")
+
+
+def test_fetch_connection_error(tmp_path):
+    from urllib.error import URLError
+
+    with patch("headmatch.headphone_db.urlopen", side_effect=URLError("nope")):
+        with pytest.raises(ConnectionError, match="Failed to fetch"):
+            fetch_curve_from_url("https://example.com/x.csv", tmp_path / "out.csv")
+
+
+def test_fetch_too_few_points(tmp_path):
+    # 5 valid points < 10 (line 238).
+    rows = "\n".join(f"{f},0.0" for f in [20, 100, 1000, 5000, 20000])
+    resp = _mock_resp(("frequency,raw\n" + rows + "\n").encode("utf-8"))
+    with patch("headmatch.headphone_db.urlopen", return_value=resp):
+        with pytest.raises(ValueError, match="only .* points"):
+            fetch_curve_from_url("https://example.com/few.csv", tmp_path / "out.csv")
+
+
+def _curve_text(freqs):
+    return "frequency,raw\n" + "\n".join(f"{f},0.0" for f in freqs) + "\n"
+
+
+def test_fetch_max_below_1khz(tmp_path):
+    # 12 points but max < 1000 Hz (lines 240-244).
+    freqs = list(range(20, 20 + 12 * 10, 10))  # 20..130
+    resp = _mock_resp(_curve_text(freqs).encode("utf-8"))
+    with patch("headmatch.headphone_db.urlopen", return_value=resp):
+        with pytest.raises(ValueError, match="at least 1 kHz"):
+            fetch_curve_from_url("https://example.com/low.csv", tmp_path / "out.csv")
+
+
+def test_fetch_min_above_1khz(tmp_path):
+    # 12 points all above 1000 Hz (lines 245-249).
+    freqs = list(range(2000, 2000 + 12 * 100, 100))
+    resp = _mock_resp(_curve_text(freqs).encode("utf-8"))
+    with patch("headmatch.headphone_db.urlopen", return_value=resp):
+        with pytest.raises(ValueError, match="includes frequencies below 1 kHz"):
+            fetch_curve_from_url("https://example.com/high.csv", tmp_path / "out.csv")
+
+
+def test_fetch_writes_standard_format(tmp_path):
+    # Valid full-range curve: writes file (lines 251-258).
+    freqs = [20, 50, 100, 200, 500, 800, 1000, 2000, 5000, 10000, 15000, 20000]
+    resp = _mock_resp(_curve_text(freqs).encode("utf-8"))
+    out = tmp_path / "nested" / "out.csv"
+    with patch("headmatch.headphone_db.urlopen", return_value=resp):
+        result = fetch_curve_from_url("https://example.com/ok.csv", out)
+    assert result == out
+    assert out.exists()
+    content = out.read_text()
+    assert content.startswith("frequency_hz,response_db")
+    assert "20.0" in content

--- a/tests/test_hearing_test_coverage.py
+++ b/tests/test_hearing_test_coverage.py
@@ -1,0 +1,320 @@
+"""Targeted coverage tests for headmatch.hearing_test.
+
+Each test here drives a specific previously-uncovered branch/exception/edge path
+in the threshold engine, the relative-compensation helpers, the PEQ band builder,
+persistence, and the CLI runner. Style follows the sibling hearing tests:
+behaviour-grouped classes, numpy for numerics, fast/deterministic, no real audio.
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from headmatch import hearing_test as ht_mod
+from headmatch.hearing_test import (
+    MAX_COMPENSATION_DB,
+    MAX_PRESENTATIONS,
+    MIN_LEVEL_DBFS,
+    NOISE_FLOOR_DB,
+    NORMAL_RELATIVE_SHAPE_DB,
+    WHO_GRADE_BANDS,
+    FrequencyThreshold,
+    HearingProfile,
+    ThresholdEngine,
+    compute_relative_compensation,
+    eq_bands_from_gain_points,
+    hearing_profile_path,
+    run_cli_hearing_test,
+    who_grade,
+    _ear_deviations,
+    _smooth_and_gate,
+)
+
+
+# ── Safety-cap termination branches (lines 351, 354) ──────────────────────────
+
+class TestSafetyCapTermination:
+    def test_cap_uses_best_estimate_when_ascending_hits_exist(self):
+        """Reach MAX_PRESENTATIONS with at least one completed ascending run so
+        _best_estimate() returns a level (line 351)."""
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        # Drive a degenerate staircase that records an ascending hit but never
+        # satisfies the 2-of-3 rule, so it runs to MAX_PRESENTATIONS with a
+        # non-empty _ascending_hits list -> _best_estimate() returns a level.
+        n = 0
+        while not e.done:
+            if e._in_ascending:
+                heard = (int(round(e.current_level_dbfs)) % 10 == 0) and (n % 2 == 0)
+            else:
+                heard = False  # force misses to climb into ascending runs
+            e.record_response(heard)
+            n += 1
+        assert e._presentations >= MAX_PRESENTATIONS
+        assert not e.converged
+        assert e._ascending_hits  # at least one hit -> best-estimate path
+        assert e.threshold is not None  # line 351
+
+    def test_cap_floor_threshold_when_ever_heard_but_no_runs(self):
+        """Hit the cap having heard tones but never completing an ascending run,
+        so _best_estimate() is None yet _ever_heard is True (line 354)."""
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        # Heard at the very first presentation (sets _ever_heard) then miss
+        # everything afterwards. A miss never produces an ascending *hit*, so
+        # _ascending_hits stays empty -> _best_estimate() is None.
+        e.record_response(True)   # ever_heard = True, step down, not ascending
+        while not e.done:
+            e.record_response(False)  # only misses from here -> no ascending hits
+        assert e._presentations >= MAX_PRESENTATIONS
+        assert not e.converged
+        assert e._ever_heard
+        # Threshold pinned to current level (rounded), not None (line 354).
+        assert e.threshold is not None
+
+    def test_cap_undetermined_when_never_heard(self):
+        """Control: never hearing anything leaves threshold None (line 357)."""
+        e = ThresholdEngine(1000, start_level_dbfs=-30.0)
+        while not e.done:
+            e.record_response(False)
+        assert e._presentations >= MAX_PRESENTATIONS
+        assert e.threshold is None
+
+
+# ── who_grade fallthrough (line 492) ──────────────────────────────────────────
+
+class TestWhoGradeFallthrough:
+    def test_value_at_or_above_last_finite_bound_returns_complete(self):
+        # The final band's bound is +inf, so the in-loop return normally always
+        # fires. Patching the bands to a finite-only table forces the fallthrough
+        # return at the bottom of the function (line 492).
+        finite_bands = tuple(b for b in WHO_GRADE_BANDS if b[0] != float("inf"))
+        import unittest.mock as mock
+        with mock.patch.object(ht_mod, "WHO_GRADE_BANDS", finite_bands):
+            assert ht_mod.who_grade(1e9) == finite_bands[-1][1]
+
+    def test_normal_path_still_works(self):
+        assert who_grade(0.0) == "No impairment"
+        assert who_grade(1e9) == "Complete"
+
+
+# ── compute_relative_compensation single-ear branches (lines 637-640) ─────────
+
+def _side(levels: dict[int, float], spread: float = 0.0) -> dict[int, FrequencyThreshold]:
+    return {f: FrequencyThreshold(f, levels[f], 3, True, spread_db=spread) for f in levels}
+
+
+class TestRelativeCompensationSingleEar:
+    def test_left_only_frequency_pools_into_left(self):
+        """Frequencies determined only in the left ear take the `elif dl` path
+        (lines 637-638)."""
+        # Right ear only has the low/mid frequencies; the entire high band
+        # (6000/8000) is left-only and carries a coherent elevated slope, so the
+        # left-only deviations survive smoothing + the variance gate.
+        right_levels = {f: -60.0 + NORMAL_RELATIVE_SHAPE_DB[f] for f in (1000, 2000, 4000)}
+        left_levels = {f: -60.0 + NORMAL_RELATIVE_SHAPE_DB[f] for f in (1000, 2000, 4000)}
+        left_levels[6000] = -60.0 + NORMAL_RELATIVE_SHAPE_DB[6000] + 18.0
+        left_levels[8000] = -60.0 + NORMAL_RELATIVE_SHAPE_DB[8000] + 20.0
+        profile = HearingProfile(
+            left=_side(left_levels),
+            right=_side(right_levels),
+            tested_at="t",
+            asymmetric_freqs=[],
+        )
+        left_pts, right_pts = compute_relative_compensation(profile)
+        assert 8000 in left_pts and left_pts[8000] > 0
+        assert 6000 not in right_pts and 8000 not in right_pts
+
+    def test_right_only_frequency_pools_into_right(self):
+        """Frequencies determined only in the right ear take the `elif dr` path
+        (lines 639-640)."""
+        left_levels = {f: -60.0 + NORMAL_RELATIVE_SHAPE_DB[f] for f in (1000, 2000, 4000)}
+        right_levels = {f: -60.0 + NORMAL_RELATIVE_SHAPE_DB[f] for f in (1000, 2000, 4000)}
+        right_levels[6000] = -60.0 + NORMAL_RELATIVE_SHAPE_DB[6000] + 18.0
+        right_levels[8000] = -60.0 + NORMAL_RELATIVE_SHAPE_DB[8000] + 20.0
+        profile = HearingProfile(
+            left=_side(left_levels),
+            right=_side(right_levels),
+            tested_at="t",
+            asymmetric_freqs=[],
+        )
+        left_pts, right_pts = compute_relative_compensation(profile)
+        assert 8000 in right_pts and right_pts[8000] > 0
+        assert 6000 not in left_pts and 8000 not in left_pts
+
+
+# ── _ear_deviations 1 kHz-missing reference fallback (lines 670-671) ───────────
+
+class TestEarDeviationsReferenceFallback:
+    def test_falls_back_to_most_sensitive_when_1khz_missing(self):
+        # No 1000 Hz entry -> ref_level falls back to the most sensitive (min)
+        # determined level (lines 670-671).
+        levels = {
+            2000: -55.0,
+            4000: -40.0,
+            8000: -30.0,
+        }
+        out = _ear_deviations(_side(levels))
+        assert out  # non-empty -> reference fallback succeeded
+        # The most sensitive frequency (2000 @ -55) becomes the reference, so its
+        # own deviation is -ref minus shape; relative offsets are anchored to it.
+        assert 2000 in out and 4000 in out and 8000 in out
+
+
+# ── _smooth_and_gate variance gate (line 740) ─────────────────────────────────
+
+class TestSmoothAndGateVarianceGate:
+    def test_deviation_beats_deadband_but_not_its_noise_is_gated(self):
+        # A single edge point whose deviation clears the deadband but does NOT
+        # exceed GATE_SIGMA * its (large) noise must be gated out (line 740).
+        # Two points so the dict is non-empty; both are spectral edges (one-sided),
+        # so neither is smoothed and each keeps its own large noise.
+        dn = {
+            1000: (0.0, NOISE_FLOOR_DB),       # reference-ish, below deadband
+            8000: (8.0, 50.0),                 # dev 8 dB > 6 dB deadband, but << 50 dB noise
+        }
+        pts = _smooth_and_gate(dn, fraction=0.5, deadband_db=6.0, max_gain_db=MAX_COMPENSATION_DB)
+        assert 8000 not in pts  # gated by the variance gate
+
+    def test_deviation_beating_its_noise_is_kept(self):
+        dn = {
+            1000: (0.0, NOISE_FLOOR_DB),
+            8000: (12.0, 2.0),  # clears deadband and easily beats its noise
+        }
+        pts = _smooth_and_gate(dn, fraction=0.5, deadband_db=6.0, max_gain_db=MAX_COMPENSATION_DB)
+        assert 8000 in pts and pts[8000] > 0
+
+
+# ── eq_bands_from_gain_points max_filters trimming (lines 835-836) ────────────
+
+class TestEqBandsMaxFilters:
+    def test_max_filters_keeps_largest_and_resorts_by_freq(self):
+        points = {500: 2.0, 1000: 8.0, 2000: 4.0, 4000: 10.0, 8000: 1.0}
+        bands = eq_bands_from_gain_points(points, max_filters=2)
+        assert len(bands) == 2
+        # Largest-magnitude bands kept (4000 @ 10, 1000 @ 8) then re-sorted by freq.
+        freqs = [b.freq for b in bands]
+        assert freqs == sorted(freqs)
+        assert set(round(f) for f in freqs) == {1000, 4000}
+
+    def test_no_trim_when_under_limit(self):
+        points = {1000: 8.0, 4000: 10.0}
+        bands = eq_bands_from_gain_points(points, max_filters=5)
+        assert len(bands) == 2
+
+
+# ── hearing_profile_path (line 910) ───────────────────────────────────────────
+
+class TestHearingProfilePath:
+    def test_returns_path_under_config_dir(self):
+        p = hearing_profile_path()
+        assert p.name == ht_mod.HEARING_PROFILE_FILENAME
+
+
+# ── CLI runner branches (lines 953-954, 999-1000, 1012-1015) ──────────────────
+
+class _FakeBackend:
+    def __init__(self):
+        self.calls = 0
+
+    def play_tone(self, *a, **k):
+        self.calls += 1
+
+
+class _ConvergingEngine:
+    def __init__(self, freq_hz, start_level_dbfs=-20.0):
+        self.freq_hz = freq_hz
+        self.current_level_dbfs = start_level_dbfs
+        self._n = 0
+        self.done = False
+        self.threshold = -45.0
+        self.ascending_run_count = 2
+        self.converged = True
+        self.floored = False
+
+    def record_response(self, _heard):
+        self._n += 1
+        if self._n >= 2:
+            self.done = True
+
+
+def _patch_fast(monkeypatch):
+    monkeypatch.setattr(ht_mod, "RESPONSE_WINDOW_S", 0.01)
+    monkeypatch.setattr(ht_mod, "generate_tone_train", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod, "generate_silence", lambda *a, **k: [0.0])
+    monkeypatch.setattr(ht_mod.time, "sleep", lambda *_: None)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    # Never insert catch trials by default (keeps presentation count tight/fast).
+    monkeypatch.setattr(ht_mod, "should_insert_catch", lambda *a, **k: False)
+
+
+class TestCliRunnerBranches:
+    def test_read_thread_swallows_stdin_errors(self, monkeypatch):
+        """_ask_heard's reader thread must swallow EOFError/OSError from stdin
+        (lines 953-954). A stdin whose readline raises drives that except clause."""
+        _patch_fast(monkeypatch)
+        monkeypatch.setattr(ht_mod, "ThresholdEngine", _ConvergingEngine)
+
+        class _RaisingStdin:
+            def readline(self):
+                raise OSError("no tty")
+
+        monkeypatch.setattr(sys, "stdin", _RaisingStdin())
+        # A short-but-nonzero window gives the reader thread time to run and raise.
+        monkeypatch.setattr(ht_mod, "RESPONSE_WINDOW_S", 0.05)
+        profile = run_cli_hearing_test(_FakeBackend(), None, on_status=lambda *_: None)
+        assert isinstance(profile, HearingProfile)
+
+    def test_floored_frequency_breaks_and_reports(self, monkeypatch):
+        """A floored engine breaks the repeat loop (lines 999-1000) and produces
+        the floored status message (lines 1012-1013)."""
+        _patch_fast(monkeypatch)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+        class _FlooredEngine:
+            def __init__(self, freq_hz, start_level_dbfs=-20.0):
+                self.current_level_dbfs = start_level_dbfs
+                self._n = 0
+                self.done = False
+                self.threshold = None
+                self.ascending_run_count = 1
+                self.converged = False
+                self.floored = True
+
+            def record_response(self, _heard):
+                self._n += 1
+                if self._n >= 1:
+                    self.done = True
+
+        monkeypatch.setattr(ht_mod, "ThresholdEngine", _FlooredEngine)
+        statuses: list[str] = []
+        profile = run_cli_hearing_test(_FakeBackend(), None, on_status=statuses.append)
+        assert any("floored" in s for s in statuses)
+        assert all(not t.determined for t in profile.left.values())
+
+    def test_undetermined_frequency_reports(self, monkeypatch):
+        """A non-converging, non-floored engine yields the 'undetermined' status
+        (lines 1014-1015)."""
+        _patch_fast(monkeypatch)
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+        class _UndeterminedEngine:
+            def __init__(self, freq_hz, start_level_dbfs=-20.0):
+                self.current_level_dbfs = start_level_dbfs
+                self._n = 0
+                self.done = False
+                self.threshold = None
+                self.ascending_run_count = 3
+                self.converged = False
+                self.floored = False
+
+            def record_response(self, _heard):
+                self._n += 1
+                if self._n >= 1:
+                    self.done = True
+
+        monkeypatch.setattr(ht_mod, "ThresholdEngine", _UndeterminedEngine)
+        statuses: list[str] = []
+        profile = run_cli_hearing_test(_FakeBackend(), None, on_status=statuses.append)
+        assert any("undetermined" in s for s in statuses)
+        assert all(not t.determined for t in profile.left.values())

--- a/tests/test_history_coverage.py
+++ b/tests/test_history_coverage.py
@@ -1,0 +1,120 @@
+"""Coverage tests for history.py missing lines.
+
+Targets: 44, 63, 66-67, 164-176.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from headmatch.contracts import (
+    ConfidenceSummary,
+    FrontendRunSummary,
+    RunErrorSummary,
+    RunFilterCounts,
+)
+from headmatch.history import (
+    RunHistoryEntry,
+    build_run_comparison,
+    format_comparison_table,
+    load_recent_runs,
+)
+
+
+def _summary_dict(out_dir: Path, *, results_guide: str, kind="fit", warnings=None):
+    return {
+        "kind": kind,
+        "out_dir": str(out_dir),
+        "sample_rate": 48000,
+        "frequency_points": 256,
+        "target": "flat",
+        "filters": {"left": 4, "right": 4},
+        "predicted_error_db": {"left_rms": 1.0, "right_rms": 1.1, "left_max": 3.0, "right_max": 3.1},
+        "confidence": {
+            "score": 90,
+            "label": "high",
+            "headline": "Trustworthy.",
+            "interpretation": "Clean.",
+            "reasons": [],
+            "warnings": warnings or [],
+            "metrics": {},
+        },
+        "results_guide": results_guide,
+    }
+
+
+# ── line 44: _iter_summary_files returns () when root missing ──
+
+def test_load_recent_runs_missing_root(tmp_path):
+    entries = load_recent_runs(tmp_path / "nope")
+    assert entries == []
+
+
+# ── line 63: relative results_guide resolved against summary parent ──
+
+def test_load_recent_runs_relative_guide(tmp_path):
+    run = tmp_path / "run"
+    run.mkdir()
+    (run / "README.txt").write_text("guide\n")
+    # results_guide is a bare relative filename, not absolute.
+    (run / "run_summary.json").write_text(
+        json.dumps(_summary_dict(run, results_guide="README.txt"))
+    )
+    entries = load_recent_runs(tmp_path)
+    assert len(entries) == 1
+    assert entries[0].guide_path == (run / "README.txt").resolve()
+    assert entries[0].guide_path.is_absolute()
+
+
+# ── lines 66-67: limit break ──
+
+def test_load_recent_runs_respects_limit(tmp_path):
+    for i in range(4):
+        run = tmp_path / f"run{i}"
+        run.mkdir()
+        (run / "README.txt").write_text("g\n")
+        (run / "run_summary.json").write_text(
+            json.dumps(_summary_dict(run, results_guide=str(run / "README.txt")))
+        )
+    entries = load_recent_runs(tmp_path, limit=2)
+    assert len(entries) == 2
+
+
+# ── lines 164-176: format_comparison_table ──
+
+def _entry(tmp_path: Path, name: str, *, target: str, warnings) -> RunHistoryEntry:
+    out = tmp_path / name
+    summary = FrontendRunSummary(
+        schema_version=1,
+        kind="fit",
+        out_dir=str(out),
+        sample_rate=48000,
+        frequency_points=256,
+        target=target,
+        filters=RunFilterCounts(left=4, right=5),
+        predicted_error_db=RunErrorSummary(left_rms=1.0, right_rms=1.1, left_max=3.0, right_max=3.1),
+        generated_by={},
+        plots={},
+        results_guide="",
+        confidence=ConfidenceSummary(
+            score=88, label="high", headline="ok",
+            interpretation="fine", reasons=(), warnings=tuple(warnings), metrics={},
+        ),
+    )
+    return RunHistoryEntry(
+        summary_path=out / "run_summary.json", summary=summary, guide_path=out / "README.txt"
+    )
+
+
+def test_format_comparison_table(tmp_path):
+    left = _entry(tmp_path, "left", target="custom", warnings=["w1", "w2"])
+    right = _entry(tmp_path, "right", target="flat", warnings=[])
+    comparison = build_run_comparison([left, right])
+    assert comparison is not None
+    table = format_comparison_table(comparison)
+    assert "Side-by-side comparison" in table
+    assert str((tmp_path / "left")) in table
+    assert str((tmp_path / "right")) in table
+    assert "Target" in table
+    assert "A: custom" in table
+    assert "B: flat" in table

--- a/tests/test_io_utils_coverage.py
+++ b/tests/test_io_utils_coverage.py
@@ -1,0 +1,166 @@
+"""Coverage tests for io_utils.py missing lines.
+
+Targets: 90, 95, 102, 117-120, 125-128, 131, 133, 135.
+"""
+from __future__ import annotations
+
+import pytest
+
+from headmatch.io_utils import load_fr_csv
+
+
+# ── line 90: no rows after filtering comments/blanks ──
+
+def test_load_fr_csv_no_rows(tmp_path):
+    path = tmp_path / "empty.csv"
+    path.write_text("# just a comment\n\n   \n", encoding="utf-8")
+    with pytest.raises(ValueError, match="No rows found"):
+        load_fr_csv(path)
+
+
+# ── line 95: header present but no data rows ──
+
+def test_load_fr_csv_header_only(tmp_path):
+    path = tmp_path / "header.csv"
+    path.write_text("frequency_hz,response_db\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="No data rows found"):
+        load_fr_csv(path)
+
+
+# ── line 102: no recognizable frequency column ──
+
+def test_load_fr_csv_no_frequency_column(tmp_path):
+    path = tmp_path / "nofreq.csv"
+    path.write_text("foo,response_db\n1,2\n3,4\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Could not find a frequency column"):
+        load_fr_csv(path)
+
+
+# ── lines 114-116: value column found via hint, not priority list ──
+
+def test_load_fr_csv_value_column_via_hint(tmp_path):
+    # 'left_response' normalizes to contain hint 'response' but isn't in priority list.
+    path = tmp_path / "hint.csv"
+    path.write_text("frequency_hz,left_response\n100,1.0\n1000,2.0\n", encoding="utf-8")
+    freqs, vals = load_fr_csv(path)
+    assert list(vals) == [1.0, 2.0]
+
+
+# ── lines 117-118: fall back to first non-freq column when no hint ──
+
+def test_load_fr_csv_value_column_fallback_first(tmp_path):
+    path = tmp_path / "fallback.csv"
+    path.write_text("frequency_hz,xyz\n100,1.0\n1000,2.0\n", encoding="utf-8")
+    freqs, vals = load_fr_csv(path)
+    assert list(vals) == [1.0, 2.0]
+
+
+# ── lines 119-120: only a frequency column, nothing else ──
+
+def test_load_fr_csv_no_value_column(tmp_path):
+    path = tmp_path / "onlyfreq.csv"
+    path.write_text("frequency_hz\n100\n1000\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Could not find response column"):
+        load_fr_csv(path)
+
+
+# ── lines 125-126: KeyError path ──
+# csv.DictReader always provides every fieldname as a key in each row (missing
+# cells become None), so a KeyError on r[freq_key] / r[value_key] cannot arise
+# from real CSV input. We force it by feeding rows that lack the resolved key,
+# patching csv.DictReader so fieldnames are detected but rows omit the column.
+
+def test_load_fr_csv_key_error(tmp_path, monkeypatch):
+    import csv as _csv
+
+    path = tmp_path / "keyerr.csv"
+    path.write_text("frequency_hz,response_db\n100,1.0\n1000,2.0\n", encoding="utf-8")
+
+    real_dictreader = _csv.DictReader
+
+    class StubReader:
+        def __init__(self, *args, **kwargs):
+            self._inner = real_dictreader(*args, **kwargs)
+            self.fieldnames = self._inner.fieldnames
+
+        def __iter__(self):
+            # Yield rows missing the value column -> KeyError on r[value_key].
+            return iter([{"frequency_hz": "100"}, {"frequency_hz": "1000"}])
+
+    monkeypatch.setattr("headmatch.io_utils.csv.DictReader", StubReader)
+    with pytest.raises(ValueError, match="Missing expected column"):
+        load_fr_csv(path)
+
+
+# ── lines 127-128: ValueError path (non-numeric data) ──
+
+def test_load_fr_csv_non_numeric(tmp_path):
+    path = tmp_path / "nonnum.csv"
+    path.write_text("frequency_hz,response_db\n100,abc\n1000,2.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Could not parse numeric"):
+        load_fr_csv(path)
+
+
+# ── line 131: invalid shape ──
+# freqs and vals are built from the same rows list, so they always share length
+# and are 1-D for real input. We force a mismatch with a patched np.array.
+
+def test_load_fr_csv_invalid_shape(tmp_path, monkeypatch):
+    import numpy as _np
+
+    path = tmp_path / "shape.csv"
+    path.write_text("frequency_hz,response_db\n100,1.0\n1000,2.0\n", encoding="utf-8")
+
+    real_array = _np.array
+    calls = {"n": 0}
+
+    def fake_array(seq, dtype=None):
+        calls["n"] += 1
+        # Return a longer array on the second call (the values array) to break the
+        # len(freqs) == len(vals) invariant.
+        if calls["n"] == 2:
+            return real_array([1.0, 2.0, 3.0], dtype=dtype)
+        return real_array(seq, dtype=dtype)
+
+    monkeypatch.setattr("headmatch.io_utils.np.array", fake_array)
+    with pytest.raises(ValueError, match="Invalid frequency-response data shape"):
+        load_fr_csv(path)
+
+
+# ── ragged/short row: a data row with fewer cells than the header leaves the
+# value cell as None (csv.DictReader restval default), so float(None) must be
+# reported as a ValueError, not propagate an uncaught TypeError. ──
+
+def test_load_fr_csv_short_row(tmp_path):
+    path = tmp_path / "ragged.csv"
+    # second data row is missing the response_db cell
+    path.write_text("frequency_hz,response_db\n100,1.0\n1000\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Could not parse numeric"):
+        load_fr_csv(path)
+
+
+# ── line 133: fewer than two rows ──
+
+def test_load_fr_csv_single_row(tmp_path):
+    path = tmp_path / "one.csv"
+    path.write_text("frequency_hz,response_db\n100,1.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="at least two frequency rows"):
+        load_fr_csv(path)
+
+
+# ── line 135: non-finite values ──
+
+def test_load_fr_csv_non_finite(tmp_path):
+    path = tmp_path / "inf.csv"
+    path.write_text("frequency_hz,response_db\n100,1.0\n1000,inf\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="non-finite"):
+        load_fr_csv(path)
+
+
+# ── line 137: non-positive frequency ──
+
+def test_load_fr_csv_non_positive_freq(tmp_path):
+    path = tmp_path / "neg.csv"
+    path.write_text("frequency_hz,response_db\n0,1.0\n1000,2.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="non-positive frequencies"):
+        load_fr_csv(path)

--- a/tests/test_measure_coverage.py
+++ b/tests/test_measure_coverage.py
@@ -1,0 +1,116 @@
+"""Coverage tests for headmatch.measure — error/edge branches."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from headmatch.contracts import FrontendConfig
+from headmatch.measure import (
+    DoctorCheck,
+    OfflineMeasurementPlan,
+    PipeWireTarget,
+    _saved_target_matches_discovery,
+    collect_doctor_checks,
+    format_doctor_report,
+    prepare_offline_measurement,
+    render_sweep_file,
+    require_executable,
+    run_pipewire_measurement,
+)
+from headmatch.signals import SweepSpec
+
+
+class TestRequireExecutable:
+    def test_missing_raises(self, monkeypatch):
+        monkeypatch.setattr("headmatch.measure.shutil.which", lambda name: None)
+        with pytest.raises(RuntimeError, match="Required executable not found"):
+            require_executable("definitely-not-a-real-binary")
+
+    def test_present_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr("headmatch.measure.shutil.which", lambda name: "/usr/bin/x")
+        require_executable("x")
+
+
+class TestRenderAndPrepareOffline:
+    def test_render_sweep_file(self, tmp_path):
+        spec = SweepSpec(sample_rate=48000, duration_s=0.2,
+                         pre_silence_s=0.05, post_silence_s=0.05)
+        out = render_sweep_file(spec, tmp_path / "sweep.wav")
+        assert out.exists()
+
+    def test_prepare_offline_measurement_writes_files(self, tmp_path):
+        spec = SweepSpec(sample_rate=48000, duration_s=0.2,
+                         pre_silence_s=0.05, post_silence_s=0.05)
+        plan = OfflineMeasurementPlan(
+            sweep_wav=tmp_path / "nested" / "sweep.wav",
+            metadata_json=tmp_path / "meta" / "plan.json",
+            notes="hello",
+        )
+        payload = prepare_offline_measurement(spec, plan)
+        assert plan.sweep_wav.exists()
+        assert plan.metadata_json.exists()
+        assert payload["mode"] == "offline"
+        assert payload["notes"] == "hello"
+        assert payload["sweep"]["sample_rate"] == 48000
+        assert payload["files"]["sweep_wav"] == str(plan.sweep_wav)
+
+
+class TestRunPipewireMeasurement:
+    def test_delegates_to_backend(self, monkeypatch, tmp_path):
+        spec = SweepSpec()
+        sentinel_path = tmp_path / "recording.wav"
+
+        class FakeBackend:
+            def play_and_record(self, spec_, paths_, device_):
+                return sentinel_path
+
+        monkeypatch.setattr(
+            "headmatch.measure.get_audio_backend", lambda: FakeBackend()
+        )
+        result = run_pipewire_measurement(spec, paths="P", device="D")
+        assert result == sentinel_path
+
+
+class TestSavedTargetMatches:
+    def test_empty_saved_returns_false(self):
+        assert _saved_target_matches_discovery("   ", "playback", []) is False
+
+
+class TestCollectDoctorChecksDiscoveryNone:
+    def test_discovery_failure_with_saved_targets(self, monkeypatch, tmp_path):
+        # Backend collect_doctor_checks returns nothing extra; force discovery
+        # to raise RuntimeError so `discovered is None` branches run (172, 191).
+        class FakeBackend:
+            def collect_doctor_checks(self):
+                return []
+
+        monkeypatch.setattr(
+            "headmatch.measure.get_audio_backend", lambda: FakeBackend()
+        )
+
+        def _boom():
+            raise RuntimeError("no audio")
+
+        monkeypatch.setattr("headmatch.measure.list_pipewire_targets", _boom)
+
+        config = FrontendConfig(
+            pipewire_output_target="usb-dac",
+            pipewire_input_target="usb-mic",
+        )
+        checks = collect_doctor_checks(tmp_path / "config.json", config)
+        by_name = {c.name: c for c in checks}
+        assert by_name["saved output target"].ok is True
+        assert by_name["saved output target"].detail == "Configured: usb-dac"
+        assert by_name["saved input target"].ok is True
+        assert by_name["saved input target"].detail == "Configured: usb-mic"
+
+
+class TestFormatDoctorReportNoActions:
+    def test_no_actions_shows_default_next_step(self, tmp_path):
+        text = format_doctor_report(
+            [DoctorCheck(name="config file", ok=True, detail="Using config.json")],
+            config_path=tmp_path / "config.json",
+        )
+        assert "Suggested next step:" in text
+        assert "headmatch list-targets" in text

--- a/tests/test_paths_coverage.py
+++ b/tests/test_paths_coverage.py
@@ -1,0 +1,53 @@
+"""Coverage tests for paths.py missing lines.
+
+Targets: 50-59 (documents_dir on win32 and non-win32).
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def test_documents_dir_linux(tmp_path, monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from headmatch import paths
+
+    importlib.reload(paths)
+    d = paths.documents_dir()
+    assert d == tmp_path / "Documents" / "HeadMatch"
+    assert d.exists()
+
+
+def test_documents_dir_darwin(tmp_path, monkeypatch):
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from headmatch import paths
+
+    importlib.reload(paths)
+    d = paths.documents_dir()
+    assert d == tmp_path / "Documents" / "HeadMatch"
+    assert d.exists()
+
+
+def test_documents_dir_win32_with_userprofile(tmp_path, monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "profile"))
+    from headmatch import paths
+
+    importlib.reload(paths)
+    d = paths.documents_dir()
+    assert d == tmp_path / "profile" / "Documents" / "HeadMatch"
+    assert d.exists()
+
+
+def test_documents_dir_win32_without_userprofile(tmp_path, monkeypatch):
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from headmatch import paths
+
+    importlib.reload(paths)
+    d = paths.documents_dir()
+    assert d == tmp_path / "Documents" / "HeadMatch"
+    assert d.exists()

--- a/tests/test_peq_coverage.py
+++ b/tests/test_peq_coverage.py
@@ -1,0 +1,163 @@
+"""Coverage tests for headmatch.peq defensive/edge branches."""
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+import headmatch.peq as peq
+from headmatch.peq import (
+    FilterBudget,
+    FitObjective,
+    PEQBand,
+    _band_mean,
+    _default_graphic_eq_profile_name,
+    _edge_shelf_candidate,
+    _refine_bands_jointly,
+    _same_sign_fraction,
+    _select_peaking_candidate,
+    biquad_response_db,
+    fit_peq,
+    graphic_eq_profile,
+    solve_band_gains_lsq,
+)
+
+
+class TestShelfQNonPositiveInner:
+    def test_shelf_q_returns_default_when_inner_non_positive(self, monkeypatch):
+        """PEQBand.shelf_q returns 0.707 when the RBJ inner term is <= 0 (line 125).
+
+        ``effective_slope`` is clamped to [0.1, 1.0] via ``min``/``max`` builtins,
+        which keeps the inner term >= 2. We shadow the module-level ``min`` so the
+        clamp is defeated and the slope can exceed 1.0, driving the inner term
+        non-positive together with a large gain.
+        """
+        band = PEQBand("lowshelf", 105.0, 30.0, 0.7, slope=2.0)
+        monkeypatch.setattr(peq, "min", lambda *a, **k: 2.0, raising=False)
+        assert band.shelf_q == 0.707
+
+
+class TestDefaultGraphicEqProfileName:
+    def test_returns_31_band_for_large_budget(self):
+        assert _default_graphic_eq_profile_name(31) == "geq_31_band"
+        assert _default_graphic_eq_profile_name(50) == "geq_31_band"
+
+    def test_returns_10_band_for_small_budget(self):
+        assert _default_graphic_eq_profile_name(10) == "geq_10_band"
+        assert _default_graphic_eq_profile_name(0) == "geq_10_band"
+
+
+class TestGraphicEqProfileLookup:
+    def test_unknown_profile_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unsupported GraphicEQ profile"):
+            graphic_eq_profile("does_not_exist")
+
+
+class TestBiquadResponseUnsupportedKind:
+    def test_unsupported_band_kind_raises(self):
+        band = PEQBand("bogus", 1000.0, 1.0, 1.0)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="Unsupported band type"):
+            biquad_response_db(np.array([1000.0]), 48000, band)
+
+
+class TestSolveBandGainsEmpty:
+    def test_no_bands_returns_empty_list(self):
+        assert solve_band_gains_lsq([1000.0], [1.0], 48000, [], []) == []
+
+
+class TestSameSignFractionEmpty:
+    def test_empty_values_returns_zero(self):
+        assert _same_sign_fraction(np.array([]), 1.0) == 0.0
+
+
+class TestEdgeShelfCandidate:
+    def test_no_edge_samples_returns_none(self):
+        """When no frequencies fall in the edge band, return None (line 316)."""
+        # All frequencies above 140 Hz -> lowshelf edge_mask is all-False.
+        freqs = np.geomspace(200.0, 20000.0, 100)
+        target = np.zeros_like(freqs)
+        assert _edge_shelf_candidate(freqs, target, kind="lowshelf", max_gain_db=12.0) is None
+
+    def test_mixed_sign_edge_returns_none(self):
+        """A large but sign-inconsistent edge mean is rejected (line 323)."""
+        freqs = np.geomspace(20.0, 20000.0, 300)
+        target = np.zeros_like(freqs)
+        mask = freqs <= 140
+        idx = np.where(mask)[0]
+        # Strong positive overall, but ~45% of the edge is negative so the
+        # same-sign fraction drops below 0.7.
+        target[mask] = 5.0
+        target[idx[: int(len(idx) * 0.45)]] = -2.0
+        # Sanity: edge mean is large and clearly different from the compare band.
+        assert abs(_band_mean(freqs, target, 20, 140)) >= 1.25
+        result = _edge_shelf_candidate(freqs, target, kind="lowshelf", max_gain_db=12.0)
+        assert result is None
+
+
+class TestSelectPeakingCandidateGainBelowMin:
+    def test_candidate_below_min_gain_is_skipped(self):
+        """Candidates whose |gain| < min_gain_db are skipped (line 398).
+
+        With an impossibly high min_gain_db every candidate is filtered out and
+        the selector returns None.
+        """
+        freqs = np.geomspace(20.0, 20000.0, 300)
+        target = np.where((freqs > 900) & (freqs < 1100), 3.0, 0.0)
+        objective = FitObjective.from_target(freqs, target, 48000)
+        residual = objective.residual_db([])
+        result = _select_peaking_candidate(
+            objective,
+            residual,
+            [],
+            max_gain_db=8.0,
+            max_q=4.5,
+            min_peak_db=0.0,
+            min_gain_db=100.0,
+            allow_nearby_same_sign=True,
+        )
+        assert result is None
+
+
+class TestRefineBandsNoImprovement:
+    def test_refinement_rejected_keeps_original_bands(self, monkeypatch):
+        """If Nelder-Mead does not beat the 3% threshold, original bands are kept (line 445)."""
+        freqs = np.geomspace(20.0, 20000.0, 300)
+        target = np.where((freqs > 900) & (freqs < 1100), 3.0, 0.0)
+        objective = FitObjective.from_target(freqs, target, 48000)
+        bands = [
+            PEQBand("peaking", 500.0, 2.0, 1.0),
+            PEQBand("peaking", 2000.0, -2.0, 1.0),
+        ]
+
+        class _Result:
+            fun = 1e9  # far worse than initial cost
+            x = np.array([1000.0, 1.0, 1.0, 2000.0, 1.0, 1.0])
+
+        import scipy.optimize as so
+
+        monkeypatch.setattr(so, "minimize", lambda *a, **k: _Result())
+        out = _refine_bands_jointly(objective, bands, max_gain_db=8.0, max_q=4.5)
+        assert out is bands
+
+
+class TestFitPeqUnsupportedFamily:
+    def test_unsupported_family_raises(self):
+        """fit_peq raises for a family that is neither graphic_eq nor peq (line 469)."""
+        budget = dataclasses.replace(FilterBudget(family="peq", max_filters=4), family="weird")
+        freqs = np.geomspace(20.0, 20000.0, 100)
+        with pytest.raises(ValueError, match="Unsupported filter family"):
+            fit_peq(freqs, np.zeros_like(freqs), 48000, budget=budget)  # type: ignore[arg-type]
+
+
+class TestFitPeqExactNBreak:
+    def test_exact_n_breaks_when_no_candidate(self, monkeypatch):
+        """exact_n loop breaks when even the fully relaxed selection yields no
+        candidate (line 525). The fully relaxed selector cannot return None for a
+        non-empty grid, so we mock it to None to drive the defensive break."""
+        freqs = np.geomspace(20.0, 20000.0, 60)
+        target = np.zeros_like(freqs)
+        monkeypatch.setattr(peq, "_select_peaking_candidate", lambda *a, **k: None)
+        budget = FilterBudget(family="peq", max_filters=3, fill_policy="exact_n")
+        bands = fit_peq(freqs, target, 48000, budget=budget)
+        assert bands == []

--- a/tests/test_pipeline_coverage.py
+++ b/tests/test_pipeline_coverage.py
@@ -1,0 +1,228 @@
+"""Coverage tests for pipeline.py thin wrappers / branches and
+pipeline_confidence.py's alignment-peak warning line.
+
+New tests only; existing test files are untouched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from headmatch.analysis import MeasurementResult
+from headmatch.contracts import ConfidenceSummary
+from headmatch.hearing_test import (
+    NORMAL_HEARING_REFERENCE,
+    TEST_FREQUENCIES,
+    FrequencyThreshold,
+    HearingProfile,
+)
+from headmatch.peq import FilterBudget
+from headmatch import pipeline
+from headmatch.pipeline import (
+    ResolvedTargetCurves,
+    _hearing_run_summary,
+    _metrics,
+    _resolve_target_curves,
+    _summarize_trustworthiness,
+    _write_fit_artifacts,
+    build_clone_curve,
+)
+from headmatch.pipeline_confidence import summarize_trustworthiness
+from headmatch.targets import TargetCurve
+
+
+def _clean_diagnostics(**overrides) -> dict:
+    diag = {
+        'alignment_reference_score': 0.99,
+        'alignment_peak_ratio': 0.99,
+        'channel_mismatch_rms_db': 0.1,
+        'left_roughness_db': 0.1,
+        'right_roughness_db': 0.1,
+        'capture_rms_dbfs': -20.0,
+    }
+    diag.update(overrides)
+    return diag
+
+
+def _result(diagnostics: dict | None = None) -> MeasurementResult:
+    freqs = np.array([20.0, 1000.0, 20000.0])
+    return MeasurementResult(
+        freqs_hz=freqs,
+        left_db=np.array([1.0, 0.0, -1.0]),
+        right_db=np.array([2.0, 0.0, -2.0]),
+        left_raw_db=np.array([1.0, 0.0, -1.0]),
+        right_raw_db=np.array([2.0, 0.0, -2.0]),
+        diagnostics=diagnostics if diagnostics is not None else _clean_diagnostics(),
+    )
+
+
+def _clean_report() -> dict:
+    return {
+        'predicted_left_rms_error_db': 0.1,
+        'predicted_right_rms_error_db': 0.1,
+        'predicted_left_max_error_db': 0.2,
+        'predicted_right_max_error_db': 0.2,
+    }
+
+
+class TestResolvedTargetCurvesProperties:
+    def test_name_and_semantics_delegate_to_base(self):
+        result = _result()
+        target = TargetCurve(result.freqs_hz, np.zeros_like(result.freqs_hz), 'mytarget', semantics='relative')
+        resolved = _resolve_target_curves(result, target)
+        assert isinstance(resolved, ResolvedTargetCurves)
+        # lines 63 and 67
+        assert resolved.name == 'mytarget'
+        assert resolved.semantics == 'relative'
+
+
+class TestThinWrappers:
+    def test_summarize_trustworthiness_wrapper_matches_direct_call(self):
+        result = _result()
+        report = _clean_report()
+        # line 88
+        wrapped = _summarize_trustworthiness(result, report)
+        direct = summarize_trustworthiness(result, report)
+        assert wrapped.to_dict() == direct.to_dict()
+
+    def test_write_fit_artifacts_wrapper_delegates(self, monkeypatch):
+        captured = {}
+
+        def fake_write(out_dir, **kwargs):
+            captured['out_dir'] = out_dir
+            captured.update(kwargs)
+            return {'ok': True}
+
+        monkeypatch.setattr('headmatch.pipeline.write_fit_artifacts', fake_write)
+        # line 94
+        out = _write_fit_artifacts(
+            Path('somewhere'),
+            kind='fit',
+            result='r',
+            target='t',
+            left_bands=[],
+            right_bands=[],
+            report={},
+            sample_rate=48000,
+            write_target_curve_csv=True,
+            filter_budget=FilterBudget(max_filters=4),
+        )
+        assert out == {'ok': True}
+        assert captured['kind'] == 'fit'
+        assert captured['sample_rate'] == 48000
+
+    def test_build_clone_curve_wrapper_delegates(self, monkeypatch):
+        sentinel = object()
+
+        def fake_clone(source, target, out):
+            assert (source, target, out) == ('s', 't', 'o')
+            return sentinel
+
+        monkeypatch.setattr('headmatch.pipeline.clone_target_from_source_target', fake_clone)
+        # line 187
+        assert build_clone_curve('s', 't', 'o') is sentinel
+
+
+class TestMetricsBandFallback:
+    def test_metrics_falls_back_to_full_range_when_no_audible_points(self):
+        # All frequencies fall outside the 80-12000 Hz band -> mask empty,
+        # so the fallback full mask is used (line 109).
+        freqs = np.array([20.0, 40.0, 60.0])
+        measured = np.array([1.0, 2.0, 3.0])
+        target = np.array([0.0, 0.0, 0.0])
+        rms, max_abs = _metrics(freqs, measured, target)
+        expected_rms = float(np.sqrt(np.mean(measured ** 2)))
+        assert rms == pytest.approx(expected_rms)
+        assert max_abs == pytest.approx(3.0)
+
+
+class TestConfidenceAlignmentPeakWarning:
+    def test_low_alignment_peak_ratio_emits_warning(self):
+        # alignment_peak_ratio below ALIGNMENT_PEAK_WARNING_THRESHOLD (0.85)
+        # triggers the warning on line 82 of pipeline_confidence.
+        diag = _clean_diagnostics(alignment_peak_ratio=0.50)
+        result = _result(diag)
+        summary = summarize_trustworthiness(result, _clean_report())
+        assert any('alignment peak' in w for w in summary.warnings)
+
+
+def _profile_with(left_thresholds, right_thresholds) -> HearingProfile:
+    return HearingProfile(
+        left=left_thresholds,
+        right=right_thresholds,
+        tested_at='2026-01-01T00:00:00+00:00',
+        asymmetric_freqs=[],
+    )
+
+
+def _threshold(freq, *, determined=True, floored=False) -> FrequencyThreshold:
+    return FrequencyThreshold(
+        freq_hz=freq,
+        level_dbfs=NORMAL_HEARING_REFERENCE[freq],
+        ascending_runs=3,
+        determined=determined,
+        floored=floored,
+    )
+
+
+class TestHearingRunSummaryConfidenceBranches:
+    """Exercise the floored / medium / few-converged branches (lines 417, 420-423)."""
+
+    def _confidence(self, profile):
+        report = {
+            'predicted_left_rms_error_db': 0.1,
+            'predicted_right_rms_error_db': 0.1,
+            'predicted_left_max_error_db': 0.2,
+            'predicted_right_max_error_db': 0.2,
+            'target': 'flat',
+            'eq_clipping': None,
+        }
+        summary = _hearing_run_summary(
+            profile, Path('out'), [], [], report, 48000, FilterBudget(max_filters=4)
+        )
+        return summary.to_dict()['confidence']
+
+    def test_floored_frequencies_score_low(self):
+        # At least one floored threshold -> line 417 (label "low", score 30).
+        side = {f: _threshold(f, determined=True) for f in TEST_FREQUENCIES}
+        first = TEST_FREQUENCIES[0]
+        side[first] = _threshold(first, determined=True, floored=True)
+        profile = _profile_with(dict(side), dict(side))
+        confidence = self._confidence(profile)
+        assert confidence['label'] == 'low'
+        assert confidence['score'] == 30
+        assert 'floored' in confidence['headline'].lower()
+
+    def test_all_determined_scores_high(self):
+        # determined == total -> line 419 (label "high").
+        side = {f: _threshold(f, determined=True) for f in TEST_FREQUENCIES}
+        profile = _profile_with(dict(side), dict(side))
+        confidence = self._confidence(profile)
+        assert confidence['label'] == 'high'
+        assert confidence['score'] == 80
+
+    def test_most_determined_scores_medium(self):
+        # >= 60% but < 100% determined, none floored -> lines 420-421 (medium, 60).
+        freqs = list(TEST_FREQUENCIES)
+        n = len(freqs)
+        # Make exactly enough determined to clear the 60% bar but not all.
+        n_determined = max(int(np.ceil(0.6 * n)), 1)
+        n_determined = min(n_determined, n - 1)  # ensure strictly below total
+        side = {}
+        for i, f in enumerate(freqs):
+            side[f] = _threshold(f, determined=(i < n_determined))
+        profile = _profile_with(dict(side), dict(side))
+        confidence = self._confidence(profile)
+        assert confidence['label'] == 'medium'
+        assert confidence['score'] == 60
+
+    def test_few_determined_scores_low(self):
+        # < 60% determined, none floored -> lines 422-423 (low, 40).
+        side = {f: _threshold(f, determined=False) for f in TEST_FREQUENCIES}
+        profile = _profile_with(dict(side), dict(side))
+        confidence = self._confidence(profile)
+        assert confidence['label'] == 'low'
+        assert confidence['score'] == 40
+        assert 'uncertain' in confidence['headline'].lower()

--- a/tests/test_plots_coverage.py
+++ b/tests/test_plots_coverage.py
@@ -1,0 +1,33 @@
+"""Coverage tests for plots.py missing lines 22 and 62."""
+from __future__ import annotations
+
+import numpy as np
+
+from headmatch.plots import _grid_lines, _log_x_positions
+
+
+# ── line 22: degenerate log range (log_max ≈ log_min) → centered positions ──
+
+def test_log_x_positions_degenerate_range():
+    freqs = np.array([1000.0, 1000.0, 1000.0])
+    width = 800.0
+    out = _log_x_positions(freqs, width)
+    # All collapse to the horizontal centre of the plot.
+    assert np.allclose(out, width * 0.5)
+    assert out.shape == freqs.shape
+
+
+# ── line 62: grid frequencies outside the data range are skipped ──
+
+def test_grid_lines_skips_out_of_range_frequencies():
+    # Narrow band 100..200 Hz: the 20/50 Hz ticks fall below freqs[0] and the
+    # 500..20000 Hz ticks fall above freqs[-1], so only 100 and 200 draw lines.
+    freqs = np.array([100.0, 200.0])
+    lines = _grid_lines(freqs, plot_x=10.0, plot_y=10.0, plot_w=400.0, plot_h=200.0)
+    text = "\n".join(lines)
+    # In-range vertical-grid labels present...
+    assert ">100<" in text
+    assert ">200<" in text
+    # ...out-of-range ticks skipped (no 5k / 20k vertical labels rendered).
+    assert ">5k<" not in text
+    assert ">20k<" not in text

--- a/tests/test_settings_coverage.py
+++ b/tests/test_settings_coverage.py
@@ -1,0 +1,86 @@
+"""Coverage tests for settings.py missing lines.
+
+Targets: 48, 51-52, 54, 74-75, 97.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from headmatch.contracts import FrontendConfig
+from headmatch.settings import (
+    load_config,
+    load_or_create_config,
+    update_config_from_args,
+)
+
+
+# ── line 48: load_config returns default when file is missing ──
+
+def test_load_config_missing_returns_default(tmp_path):
+    config = load_config(tmp_path / "does_not_exist.json")
+    assert isinstance(config, FrontendConfig)
+
+
+# ── lines 51-52: invalid JSON raises ValueError ──
+
+def test_load_config_invalid_json(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(ValueError, match="Invalid JSON in config file"):
+        load_config(path)
+
+
+# ── line 54: JSON that is not an object ──
+
+def test_load_config_non_object_json(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        load_config(path)
+
+
+# ── lines 74-75: load_or_create_config swallows OSError on save ──
+
+def test_load_or_create_config_save_oserror(tmp_path, monkeypatch):
+    target = tmp_path / "config.json"
+
+    def boom(config, path):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("headmatch.settings.save_config", boom)
+    config, path, created = load_or_create_config(target)
+    assert isinstance(config, FrontendConfig)
+    assert path == target
+    assert created is False
+
+
+def test_load_or_create_config_creates_when_missing(tmp_path):
+    target = tmp_path / "new" / "config.json"
+    config, path, created = load_or_create_config(target)
+    assert created is True
+    assert target.exists()
+
+
+def test_load_or_create_config_existing(tmp_path):
+    target = tmp_path / "config.json"
+    target.write_text(json.dumps({"sample_rate": 44100}), encoding="utf-8")
+    config, path, created = load_or_create_config(target)
+    assert created is False
+    assert config.sample_rate == 44100
+
+
+# ── line 97: update_config_from_args iterate branch ──
+
+def test_update_config_from_args_iterate_branch():
+    args = SimpleNamespace(cmd="iterate", iterations=7)
+    config = update_config_from_args(args, existing=FrontendConfig())
+    assert config.iterate_iterations == 7
+
+
+def test_update_config_from_args_start_branch():
+    args = SimpleNamespace(cmd="start", iterations=4)
+    config = update_config_from_args(args, existing=FrontendConfig())
+    assert config.start_iterations == 4

--- a/tests/test_target_editor_coverage.py
+++ b/tests/test_target_editor_coverage.py
@@ -1,0 +1,45 @@
+"""Coverage tests for target_editor.py edge branches."""
+from __future__ import annotations
+
+import numpy as np
+
+from headmatch.io_utils import save_fr_csv
+from headmatch.target_editor import ControlPoint, TargetEditor
+
+
+def test_remove_point_pops_when_above_minimum():
+    # remove_point actually pops the index when > 2 points remain (line 46).
+    editor = TargetEditor(points=[
+        ControlPoint(20.0, 0.0),
+        ControlPoint(1000.0, 1.0),
+        ControlPoint(20000.0, 2.0),
+    ])
+    editor.remove_point(1)
+    assert [p.freq_hz for p in editor.points] == [20.0, 20000.0]
+
+
+def test_evaluate_with_single_point_returns_zeros():
+    # evaluate returns zeros when fewer than 2 control points (line 65).
+    editor = TargetEditor(points=[ControlPoint(1000.0, 5.0)])
+    freqs = np.array([100.0, 1000.0, 10000.0])
+    out_freqs, values = editor.evaluate(freqs)
+    assert np.array_equal(out_freqs, freqs)
+    assert np.array_equal(values, np.zeros_like(freqs))
+
+
+def test_from_csv_prunes_excess_peaks_by_prominence(tmp_path):
+    # A dense, strongly-oscillating curve produces more peaks/troughs than
+    # max_points, exercising the prominence-pruning branch (lines 105-113).
+    n = 200
+    freqs = np.geomspace(20, 20000, n)
+    # Alternating high/low values -> a peak or trough at almost every interior
+    # index, so the peak/trough set far exceeds a small max_points budget.
+    values = np.where(np.arange(n) % 2 == 0, 1.0, -1.0).astype(float)
+    path = str(tmp_path / 'oscillating.csv')
+    save_fr_csv(path, freqs, values)
+
+    editor = TargetEditor.from_csv(path, max_points=6)
+    assert len(editor.points) <= 6
+    # Endpoints are always retained.
+    assert editor.points[0].freq_hz == float(freqs[0])
+    assert editor.points[-1].freq_hz == float(freqs[-1])

--- a/tests/test_targets_coverage.py
+++ b/tests/test_targets_coverage.py
@@ -1,0 +1,54 @@
+"""Coverage tests for targets.py error/edge branches."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from headmatch.targets import (
+    clone_target_from_source_target,
+    load_curve,
+    normalize_at_1khz,
+)
+
+
+class TestNormalizeAt1kHzGuards:
+    def test_shape_mismatch_raises(self):
+        # line 29
+        freqs = np.array([20.0, 1000.0, 20000.0])
+        values = np.array([0.0, 0.0])
+        with pytest.raises(ValueError, match='same shape'):
+            normalize_at_1khz(freqs, values)
+
+    def test_too_few_points_raises(self):
+        # line 31
+        freqs = np.array([1000.0])
+        values = np.array([0.0])
+        with pytest.raises(ValueError, match='at least two'):
+            normalize_at_1khz(freqs, values)
+
+
+class TestReadTargetMetadataBlankLines:
+    def test_blank_lines_before_header_are_skipped(self, tmp_path):
+        # The blank-line `continue` in _read_target_metadata is line 46.
+        csv = tmp_path / 'curve.csv'
+        csv.write_text(
+            '\n'
+            '# headmatch_target_semantics=relative\n'
+            '\n'
+            'frequency_hz,target_db\n'
+            '20,0\n'
+            '1000,0\n'
+            '20000,0\n',
+            encoding='utf-8',
+        )
+        curve = load_curve(csv)
+        assert curve.semantics == 'relative'
+
+
+class TestCloneTargetGuards:
+    def test_identical_source_and_target_raises(self, tmp_path):
+        # line 91
+        csv = tmp_path / 'same.csv'
+        csv.write_text('frequency_hz,target_db\n20,0\n1000,0\n20000,0\n', encoding='utf-8')
+        with pytest.raises(ValueError, match='must be different files'):
+            clone_target_from_source_target(csv, csv, tmp_path / 'out.csv')


### PR DESCRIPTION
## Summary

Brings every core compute/logic module to **100% line coverage**, adds end-to-end tests for the critical inter-command paths, fixes a latent input-parsing crash, and completes a half-wired CLI feature.

- **Coverage:** 82% → **86%** overall; **100%** on all core modules (math/DSP, EQ transform, pipeline/targets, hearing_test, IO/persistence, CLI, plots). The only modules left below 100% are the deliberately out-of-scope GUI and hardware-backend surfaces.
- **Tests:** 833 → **1005** (+172), across new `tests/test_*_coverage.py`, `tests/test_e2e_*.py`, and `tests/test_cli_shortcuts.py`.
- **Production changes are minimal and quality-only:** one bug fix and one feature-wiring fix.

## Bug fix — `load_fr_csv` ragged-row crash
A short/ragged CSV row left a value cell as `None`, so `float(None)` raised an **uncaught `TypeError`**. `load_fr_csv` now catches `TypeError` alongside `ValueError` and reports a clean parse error like every other malformed-input case. Covered by a regression test.

## Feature fix — `create-shortcut` / `remove-shortcut`
The `doctor` command advertised `headmatch create-shortcut`, but the subcommands were never registered in `build_parser`, so running them failed with an argparse *invalid choice* error (the handlers and `desktop.py` already existed). Both subcommands — and the `doctor` tip — are now registered behind a `_desktop_shortcuts_supported()` **Linux gate**, since `.desktop` launchers are a Linux/XDG concept. Removed the now-reachable `# pragma: no cover` markers.

## End-to-end tests for inter-command contracts
Where one command writes a file another reads — exactly where line coverage gives false confidence:

- `import-apo → refine-apo` — presets re-parse cleanly
- `prepare-offline → analyze → fit` — metadata drives downstream; recovers the injected curve and corrects it
- `hearing-test → hearing-fit` — profile written by one CLI call is consumed by the next
- `batch-fit` — a multi-entry manifest corrects every recording
- `compare-runs` / `compare-ab` — paired A/B presets export and re-import

Each asserts correctness (round-trip, error reduction, metric cross-checks), not just file existence.

## Notes
- Scope was intentionally limited to core compute/logic + CLI + plots; GUI shell/views, TUI, and hardware backends are excluded.
- A handful of genuinely-unreachable defensive lines (`__main__` guard, a post-`parser.exit` `raise`) remain `# pragma: no cover`.

## Test plan
- [x] `pytest` — **1005 passed, 0 failures**, stable across repeated and randomized-order runs
- [x] `pytest --cov=headmatch` — 100% on all in-scope modules
- [x] Manual: `headmatch --help` lists the new subcommands; `headmatch remove-shortcut` behaves correctly